### PR TITLE
Fix the dependency specification in the core concepts documentation

### DIFF
--- a/docs/src/overview/core_concepts.md
+++ b/docs/src/overview/core_concepts.md
@@ -24,5 +24,5 @@ run with only the following dependencies:
 ```toml
 [dependencies]
 trillium = "0.1"
-trillium_smol = "0.1"
+trillium-smol = "0.1"
 ```


### PR DESCRIPTION
Fixes a typo in the core concepts docs, so the dependencies can be copy-pasted from the docs again.