### PR TITLE
add support for async initializers to State

### DIFF
--- a/trillium/src/handler.rs
+++ b/trillium/src/handler.rs
@@ -377,7 +377,10 @@ macro_rules! impl_handler_tuple {
                 #[allow(non_snake_case)]
                 async fn init(&mut self) {
                     let ($(ref mut $name,)*) = *self;
-                    $(($name).init().await;)*
+                    $(
+                        log::trace!("initializing {}", ($name).name());
+                        ($name).init().await;
+                    )*
                 }
 
                 #[allow(non_snake_case)]


### PR DESCRIPTION
Stability: If we continue to have new features for State, it will be removed from the `trillium` crate and moved into `trillium_state` so that there is less opportunity for churn on the central crate.