### PR TITLE
Pass a new `Info` struct to init and add an `Init` handler

### DIFF
--- a/async-std/src/server.rs
+++ b/async-std/src/server.rs
@@ -49,8 +49,11 @@ impl Server for AsyncStdServer {
         }
 
         let listener = config.build_listener::<TcpListener>();
+
+        let mut info = listener.local_addr().unwrap().into();
+        handler.init(&mut info).await;
+
         let mut incoming = config.stopper().stop_stream(listener.incoming());
-        handler.init().await;
         let handler = Arc::new(handler);
 
         while let Some(Ok(stream)) = incoming.next().await {

--- a/aws-lambda/src/lib.rs
+++ b/aws-lambda/src/lib.rs
@@ -79,7 +79,9 @@ async fn handler_fn(
 
 This function will poll pending until the server shuts down.
 */
-pub async fn run_async(handler: impl Handler) {
+pub async fn run_async(mut handler: impl Handler) {
+    let mut info = "aws lambda".into();
+    handler.init(&mut info).await;
     lamedh_runtime::run(HandlerWrapper(Arc::new(handler)))
         .await
         .unwrap()

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -18,7 +18,7 @@ interface will likely change quite a bit before stabilizing
 use colored::*;
 use size::{Base, Size, Style};
 use std::time::Instant;
-use trillium::{async_trait, http_types::StatusCode, Conn, Handler};
+use trillium::{async_trait, http_types::StatusCode, Conn, Handler, Info};
 
 #[derive(Debug)]
 struct Start(Instant);
@@ -46,6 +46,10 @@ impl Logger {
 
 #[async_trait]
 impl Handler for Logger {
+    async fn init(&mut self, info: &mut Info) {
+        log::info!("listening on {}", info);
+    }
+
     async fn run(&self, conn: Conn) -> Conn {
         conn.with_state(Start::now())
     }

--- a/server-common/src/config_ext.rs
+++ b/server-common/src/config_ext.rs
@@ -206,7 +206,6 @@ where
         #[cfg(not(unix))]
         let listener = TcpListener::bind((self.host(), self.port())).unwrap();
 
-        log::info!("listening on {:?}", listener.local_addr().unwrap());
         listener.set_nonblocking(true).unwrap();
         listener.try_into().unwrap()
     }

--- a/smol/src/server.rs
+++ b/smol/src/server.rs
@@ -48,7 +48,8 @@ impl Server for Smol {
 
         let listener = config.build_listener::<TcpListener>();
         let mut incoming = config.stopper().stop_stream(listener.incoming());
-        handler.init().await;
+        let mut info = listener.local_addr().unwrap().into();
+        handler.init(&mut info).await;
         let handler = Arc::new(handler);
 
         while let Some(Ok(stream)) = incoming.next().await {

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -53,10 +53,16 @@ pub mod prelude {
     */
     pub use crate::{
         assert_body, assert_body_contains, assert_headers, assert_not_handled, assert_ok,
-        assert_response, assert_status, methods::*, Method, StatusCode,
+        assert_response, assert_status, init, methods::*, Method, StatusCode,
     };
 
     pub use trillium::Conn;
+}
+
+/// initialize a handler
+pub fn init(handler: &mut impl trillium::Handler) {
+    let mut info = "testing".into();
+    block_on(handler.init(&mut info))
 }
 
 // these exports are used by macros

--- a/tokio/src/server.rs
+++ b/tokio/src/server.rs
@@ -54,7 +54,9 @@ impl Server for TokioServer {
         }
 
         let listener = config.build_listener::<TcpListener>();
-        handler.init().await;
+
+        let mut info = listener.local_addr().unwrap().into();
+        handler.init(&mut info).await;
         let handler = Arc::new(handler);
 
         let mut stream = config

--- a/trillium/src/info.rs
+++ b/trillium/src/info.rs
@@ -1,0 +1,52 @@
+use std::{fmt::Display, net::SocketAddr};
+
+/**
+This struct represents information about the currently connected
+server.
+
+It is passed to [`Handler::init`].
+*/
+
+#[derive(Debug, Clone)]
+pub struct Info {
+    description: String,
+    tcp_socket_addr: Option<SocketAddr>,
+}
+
+impl Display for Info {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.description())
+    }
+}
+
+impl Info {
+    /// Returns a user-displayable string description of the
+    /// server. Do not rely on the format of this string
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    /// Returns the local_addr of a bound tcp listener, if such a
+    /// thing exists for this server
+    pub fn tcp_socket_addr(&self) -> Option<&SocketAddr> {
+        self.tcp_socket_addr.as_ref()
+    }
+}
+
+impl From<&'static str> for Info {
+    fn from(description: &'static str) -> Self {
+        Self {
+            description: String::from(description),
+            tcp_socket_addr: None,
+        }
+    }
+}
+
+impl From<SocketAddr> for Info {
+    fn from(socket_addr: SocketAddr) -> Self {
+        Self {
+            description: socket_addr.to_string(),
+            tcp_socket_addr: Some(socket_addr),
+        }
+    }
+}

--- a/trillium/src/init.rs
+++ b/trillium/src/init.rs
@@ -1,0 +1,170 @@
+use crate::{async_trait, Conn, Handler, Info, Upgrade};
+use std::{
+    borrow::Cow,
+    fmt::{self, Debug, Formatter},
+    future::Future,
+    mem,
+    ops::Deref,
+    pin::Pin,
+};
+
+/**
+
+Provides support for asynchronous initialization of a handler after
+the server is started.
+
+```
+use trillium::{Conn, State, Init};
+
+#[derive(Debug, Clone)]
+struct MyDatabaseConnection(String);
+impl MyDatabaseConnection {
+    async fn connect(uri: String) -> std::io::Result<Self> {
+        Ok(Self(uri))
+    }
+    async fn query(&mut self, query: &str) -> String {
+        format!("you queried `{}` against {}", query, &self.0)
+    }
+}
+
+let mut handler = (
+    Init::new(|_| async {
+        let url = std::env::var("DATABASE_URL").unwrap();
+        let db = MyDatabaseConnection::connect(url).await.unwrap();
+        State::new(db)
+    }),
+    |mut conn: Conn| async move {
+        let db = conn.state_mut::<MyDatabaseConnection>().unwrap();
+        let response = db.query("select * from users limit 1").await;
+        conn.ok(response)
+    }
+);
+
+std::env::set_var("DATABASE_URL", "db://db");
+
+use trillium_testing::prelude::*;
+
+init(&mut handler);
+assert_ok!(
+    get("/").on(&handler),
+    "you queried `select * from users limit 1` against db://db"
+);
+
+```
+
+Because () is the noop handler, this can also be used to perform one-time set up:
+```
+use trillium::{Init, Conn};
+
+let mut handler = (
+    Init::new(|info| async move { log::info!("{}", info); }),
+    |conn: Conn| async move { conn.ok("ok!") }
+);
+
+use trillium_testing::prelude::*;
+init(&mut handler);
+assert_ok!(get("/").on(&handler), "ok!");
+```
+*/
+pub struct Init<T>(Inner<T>);
+
+enum Inner<T> {
+    New(
+        Box<
+            dyn Fn(Info) -> Pin<Box<dyn Future<Output = T> + Send + 'static>>
+                + Send
+                + Sync
+                + 'static,
+        >,
+    ),
+    Initializing,
+    Initialized(T),
+}
+
+impl<T: Handler> Deref for Inner<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Inner::Initialized(t) => t,
+            _ => {
+                panic!("attempted to dereference uninitialized handler {:?}", &self);
+            }
+        }
+    }
+}
+
+impl<T: Handler> Debug for Inner<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Initialized(ref t) => f.debug_tuple("Initialized").field(&t.name()).finish(),
+
+            Self::New(_) => f
+                .debug_tuple("New")
+                .field(&std::any::type_name::<T>())
+                .finish(),
+
+            Self::Initializing => f
+                .debug_tuple("Initializing")
+                .field(&std::any::type_name::<T>())
+                .finish(),
+        }
+    }
+}
+
+impl<T: Handler> Debug for Init<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Init").field(&self.0).finish()
+    }
+}
+
+impl<T: Handler> Init<T> {
+    /**
+    Constructs a new Init handler with an async function that
+    returns the handler post-initialization. The async function
+    receives [`Info`] for the current server.
+    */
+    pub fn new<F, Fut>(init: F) -> Self
+    where
+        F: Fn(Info) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = T> + Send + 'static,
+    {
+        Self(Inner::New(Box::new(move |info| Box::pin(init(info)))))
+    }
+}
+
+#[async_trait]
+impl<T: Handler> Handler for Init<T> {
+    async fn run(&self, conn: Conn) -> Conn {
+        self.0.run(conn).await
+    }
+
+    async fn init(&mut self, info: &mut Info) {
+        self.0 = match mem::replace(&mut self.0, Inner::Initializing) {
+            Inner::New(init) => Inner::Initialized(init(info.clone()).await),
+            other => other,
+        }
+    }
+
+    async fn before_send(&self, conn: Conn) -> Conn {
+        self.0.before_send(conn).await
+    }
+
+    fn has_upgrade(&self, upgrade: &Upgrade) -> bool {
+        self.0.has_upgrade(upgrade)
+    }
+
+    async fn upgrade(&self, upgrade: Upgrade) {
+        self.0.upgrade(upgrade).await
+    }
+
+    fn name(&self) -> Cow<'static, str> {
+        match &self.0 {
+            Inner::New(_) => format!("uninitialized {}", std::any::type_name::<T>()).into(),
+            Inner::Initializing => {
+                format!("currently initializing {}", std::any::type_name::<T>()).into()
+            }
+            Inner::Initialized(t) => t.name(),
+        }
+    }
+}

--- a/trillium/src/lib.rs
+++ b/trillium/src/lib.rs
@@ -50,3 +50,9 @@ pub type Upgrade = trillium_http::Upgrade<trillium_http::transport::BoxedTranspo
 mod macros;
 
 pub use log;
+
+mod info;
+pub use info::Info;
+
+mod init;
+pub use init::Init;


### PR DESCRIPTION
Provides support for asynchronous initialization of a handler after
the server is started.

```rust
use trillium::{Conn, State, Init};

#[derive(Debug, Clone)]
struct MyDatabaseConnection(String);
impl MyDatabaseConnection {
    async fn connect(uri: String) -> std::io::Result<Self> {
        Ok(Self(uri))
    }
    async fn query(&mut self, query: &str) -> String {
        format!("you queried `{}` against {}", query, &self.0)
    }
}

let mut handler = (
    Init::new(|_| async {
        let url = std::env::var("DATABASE_URL").unwrap();
        let db = MyDatabaseConnection::connect(url).await.unwrap();
        State::new(db)
    }),
    |mut conn: Conn| async move {
        let db = conn.state_mut::<MyDatabaseConnection>().unwrap();
        let response = db.query("select * from users limit 1").await;
        conn.ok(response)
    }
);

std::env::set_var("DATABASE_URL", "db://db");

use trillium_testing::prelude::*;

init(&mut handler);
assert_ok!(
    get("/").on(&handler),
    "you queried `select * from users limit 1` against db://db"
);

```

Because () is the noop handler, this can also be used to perform one-time set up:
```rust
use trillium::{Init, Conn};

let mut handler = (
    Init::new(|info| async move { log::info!("{}", info); }),
    |conn: Conn| async move { conn.ok("ok!") }
);

use trillium_testing::prelude::*;
init(&mut handler);
assert_ok!(get("/").on(&handler), "ok!");
```

This PR also adds `&mut Info` to the Handler::init hook. Although there is nothing mutable to do with the Info currently, the intent is that at some point this could be used for handlers to communicate with "downstream" handlers by appending some data to the info, and by taking a mutable reference now, we won't have to change the api later.