### PR TITLE
add an after_send callback on trillium_http::Conn

### DIFF
--- a/http/src/synthetic.rs
+++ b/http/src/synthetic.rs
@@ -6,6 +6,7 @@ use http_types::{
 use std::{
     pin::Pin,
     task::{Context, Poll},
+    time::Instant,
 };
 
 use crate::{received_body::ReceivedBodyState, Conn, Stopper};
@@ -136,6 +137,8 @@ impl Conn<Synthetic> {
             request_body_state: ReceivedBodyState::Start,
             secure: false,
             stopper: Stopper::new(),
+            after_send: None,
+            start_time: Instant::now(),
         }
     }
 


### PR DESCRIPTION
motivation:
- having full end-to-end timing in Logger
- providing a hook for applications to spawn async tasks outside of the http conn cycle (#49)
- other telemetry (https://twitter.com/algo_luca/status/1404194564123078662)

This would be trillium-http v0.1.3 and trillium-logger v0.1.2