### PR TITLE
add conn.querystring to both trillium-http and trillium

### DIFF
--- a/http/src/conn.rs
+++ b/http/src/conn.rs
@@ -182,6 +182,25 @@ where
         self.path.split('?').next().unwrap()
     }
 
+    /**
+    retrieves the query component of the path
+    ```
+    # use trillium_http::{Conn, http_types::Method};
+    let mut conn = Conn::new_synthetic(Method::Get, "/some/path?and&a=query", ());
+    assert_eq!(conn.querystring(), "and&a=query");
+
+    let mut conn = Conn::new_synthetic(Method::Get, "/some/path", ());
+    assert_eq!(conn.querystring(), "");
+
+    ```
+    */
+    pub fn querystring(&self) -> &str {
+        match self.path.split_once('?') {
+            Some((_, query)) => query,
+            None => "",
+        }
+    }
+
     // pub fn url(&self) -> Result<Url> {
     //     let path = self.path();
     //     let host = self.host().unwrap_or_else(|| String::from("_"));

--- a/trillium/src/conn.rs
+++ b/trillium/src/conn.rs
@@ -354,14 +354,32 @@ impl Conn {
         self
     }
 
-    /// returns the path for this request. note that this may not
-    /// represent the entire http request path if running nested
-    /// routers.
+    /**
+    returns the path for this request. note that this may not
+    represent the entire http request path if running nested
+    routers.
+    */
     pub fn path(&self) -> &str {
         self.path
             .last()
             .map(|p| &**p)
             .unwrap_or_else(|| self.inner.path())
+    }
+
+    /**
+    returns query part of the request path
+
+    ```
+    use trillium_testing::prelude::*;
+    let conn = get("/a/b?c&d=e").on(&());
+    assert_eq!(conn.querystring(), "c&d=e");
+
+    let conn = get("/a/b").on(&());
+    assert_eq!(conn.querystring(), "");
+    ```
+    */
+    pub fn querystring(&self) -> &str {
+        self.inner.querystring()
     }
 
     /**


### PR DESCRIPTION
partially addresses #6. Maybe it would be best if querystrong was implemented as a distinct crate, as some people may want to use serde_qs

semver: patch, straightforward addition. trillium 0.1.3 and trillium-http 0.1.3