### PR TITLE
Trillium http/response headers mut

### DIFF
--- a/http/examples/http.rs
+++ b/http/examples/http.rs
@@ -8,7 +8,8 @@ async fn handler(mut conn: Conn<TcpStream>) -> Conn<TcpStream> {
         log::info!("< {}", String::from_utf8(chunk).unwrap());
     }
     conn.set_response_body("Hello world");
-    conn.response_headers().insert("Content-type", "text/plain");
+    conn.response_headers_mut()
+        .insert("Content-type", "text/plain");
     conn.set_status(200);
     conn
 }

--- a/http/examples/tokio-http.rs
+++ b/http/examples/tokio-http.rs
@@ -9,7 +9,8 @@ async fn handler(mut conn: Conn<Compat<TcpStream>>) -> Conn<Compat<TcpStream>> {
         log::info!("< {}", String::from_utf8(chunk).unwrap());
     }
     conn.set_response_body("Hello world");
-    conn.response_headers().insert("Content-type", "text/plain");
+    conn.response_headers_mut()
+        .insert("Content-type", "text/plain");
     conn.set_status(200);
     conn
 }

--- a/http/src/conn.rs
+++ b/http/src/conn.rs
@@ -190,17 +190,24 @@ where
         &mut self.state
     }
 
-    /// returns an immutable reference to the request headers. it is
-    /// not currently possible to mutate request headers for a conn
-    /// that has been read from a transport. For synthetic conns, use
-    /// [Conn<Synthetic>::request_headers_mut](Conn<trillium_http::Synthetic>::request_headers_mut)
+    /// returns a reference to the request headers
     pub fn request_headers(&self) -> &Headers {
         &self.request_headers
     }
 
     /// returns a mutable reference to the response [headers](Headers)
-    pub fn response_headers(&mut self) -> &mut Headers {
+    pub fn request_headers_mut(&mut self) -> &mut Headers {
+        &mut self.request_headers
+    }
+
+    /// returns a mutable reference to the response [headers](Headers)
+    pub fn response_headers_mut(&mut self) -> &mut Headers {
         &mut self.response_headers
+    }
+
+    /// returns a reference to the response [headers](Headers)
+    pub fn response_headers(&self) -> &Headers {
+        &self.response_headers
     }
 
     /** sets the http status code from any `TryInto<StatusCode>`.
@@ -383,7 +390,7 @@ where
     # use trillium_http::{Conn, http_types::{Method, Body}};
     let mut conn = Conn::new_synthetic(Method::Get, "/", ());
     assert_eq!(conn.response_encoding(), encoding_rs::WINDOWS_1252); // the default
-    conn.response_headers().insert("content-type", "text/plain;charset=utf-16");
+    conn.response_headers_mut().insert("content-type", "text/plain;charset=utf-16");
     assert_eq!(conn.response_encoding(), encoding_rs::UTF_16LE);
     ```
     */

--- a/http/src/synthetic.rs
+++ b/http/src/synthetic.rs
@@ -144,23 +144,6 @@ impl Conn<Synthetic> {
     }
 
     /**
-    A Conn<Synthetic> provides the ability to mutate request headers
-    with `request_headers_mut`. This is only provided on synthetic
-    requests for now, since it doesn't generally make sense to mutate
-    headers for a request that is read from an io transport.
-
-    ```rust
-    # use trillium_http::{http_types::Method, Conn};
-    let mut conn = Conn::new_synthetic(Method::Get, "/", "hello");
-    conn.request_headers_mut().insert("content-type", "application/json");
-    assert_eq!(conn.request_headers()["content-type"], "application/json");
-    ```
-    */
-    pub fn request_headers_mut(&mut self) -> &mut Headers {
-        &mut self.request_headers
-    }
-
-    /**
     Replaces the synthetic body. This is intended for testing use.
      */
     pub fn replace_body(&mut self, body: impl Into<Synthetic>) {

--- a/testing/src/assertions.rs
+++ b/testing/src/assertions.rs
@@ -212,7 +212,7 @@ macro_rules! assert_response {
     ($conn:expr, $status:expr, $body:expr, $($header_name:literal => $header_value:expr),*) => {
         let mut conn = $conn;
         $crate::assert_response!(&mut conn, $status, $body);
-        $crate::assert_headers!(&mut conn, $($header_name => $header_value),*);
+        $crate::assert_headers!(&conn, $($header_name => $header_value),*);
     };
 
 }
@@ -245,8 +245,8 @@ macro_rules! assert_headers {
     };
 
     ($conn:expr, $($header_name:literal => $header_value:expr),*) => {
-        let mut conn = $conn;
-        let headers = conn.inner_mut().response_headers();
+        let conn = $conn;
+        let headers = conn.inner().response_headers();
         $(
             assert_eq!(
                 headers.get($header_name).map(|h| h.as_str()),

--- a/trillium/src/conn.rs
+++ b/trillium/src/conn.rs
@@ -333,7 +333,7 @@ impl Conn {
     ///
     /// stability note: this may become `response_headers` at some point
     pub fn headers_mut(&mut self) -> &mut Headers {
-        self.inner.response_headers()
+        self.inner.response_headers_mut()
     }
 
     /**


### PR DESCRIPTION
this is a breaking change so it's going into the trillium/0.2.0 line