### PR TITLE
bugfix: after send waited for next keepalive req

### DIFF
--- a/http/src/conn.rs
+++ b/http/src/conn.rs
@@ -163,10 +163,9 @@ where
         }
 
         let mut after_send = std::mem::take(&mut self.after_send);
-        let result = self.finish().await;
-        after_send.call(result.is_ok().into());
+        after_send.call(true.into());
         std::mem::forget(after_send);
-
+        let result = self.finish().await;
         result
     }
 


### PR DESCRIPTION
This closes #67
The bue was due to the `after_send` callback waiting for the beginning of the _next_ http cycle if the tcp connection was held open for keepalive