### PR TITLE
handle absence content-length AND transfer-encoding

### DIFF
--- a/http/src/conn.rs
+++ b/http/src/conn.rs
@@ -691,10 +691,8 @@ where
             .map(|cl| cl.len())
         {
             Ok(Some(cl))
-        } else if self.method == Method::Get {
-            Ok(Some(0))
         } else {
-            Err(Error::HeaderMissing("content-length or transfer-encoding"))
+            Ok(Some(0))
         }
     }
 


### PR DESCRIPTION
this was a misread of the spec — it is valid to have neither c-l or t-e