### PR TITLE
add optional support for OPTIONS handling

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -48,9 +48,8 @@ the list of supported http methods at the given route. If the OPTIONS
 request is sent for `*`, it responds with the full set of http methods
 supported by this router.
 
-**Note:** This does not currently recurse into nested routers. Please
-open an issue if this is of concern for your application. It is
-intended to be a best-effort response to the OPTIONS method
+**Note:** This behavior is superceded by an explicit OPTIONS handler
+or an `any` handler.
 
 To disable the default OPTIONS behavior, use
 [`Router::without_options_handling`] or

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -41,6 +41,20 @@ crate! It should be possible to nest different types of routers (and
 different versions of router crates) within each other as long as they
 all depend on the same version of the `trillium` crate.
 
+## Options handling
+
+By default, the trillium router will reply to an OPTIONS request with
+the list of supported http methods at the given route. If the OPTIONS
+request is sent for `*`, it responds with the full set of http methods
+supported by this router.
+
+**Note:** This does not currently recurse into nested routers. Please
+open an issue if this is of concern for your application. It is
+intended to be a best-effort response to the OPTIONS method
+
+To disable the default OPTIONS behavior, use
+[`Router::without_options_handling`] or
+[`RouterRef::set_options_handling`]
 */
 
 mod router;

--- a/router/src/router.rs
+++ b/router/src/router.rs
@@ -213,7 +213,7 @@ impl Handler for Router {
 
         if method == Method::Options && self.handle_options {
             let methods_set = if path == "*" {
-                self.method_map.keys().map(|m| *m).collect::<BTreeSet<_>>()
+                self.method_map.keys().copied().collect::<BTreeSet<_>>()
             } else {
                 self.method_map
                     .iter()

--- a/router/src/router_ref.rs
+++ b/router/src/router_ref.rs
@@ -92,4 +92,16 @@ impl<'r> RouterRef<'r> {
     pub(crate) fn new(router: &'r mut Router) -> Self {
         Self(router)
     }
+
+    /**
+    enable or disable the router's behavior of responding to OPTIONS
+    requests with the supported methods at given path.
+
+    default: enabled
+
+    see crate-level docs for further explanation of the default behavior.
+     */
+    pub fn set_options_handling(&mut self, options_enabled: bool) {
+        self.0.set_options_handling(options_enabled);
+    }
 }

--- a/router/tests/options.rs
+++ b/router/tests/options.rs
@@ -52,6 +52,16 @@ fn options_any() {
 
 #[test]
 fn when_options_are_disabled() {
-    let router = Router::new().without_options_handling().any("*", "ok");
-    assert_not_handled!(TestConn::build("options", "/", ()));
+    let router = Router::new().without_options_handling().get("*", "ok");
+    assert_not_handled!(TestConn::build("options", "/", ()).on(&router));
+}
+
+#[test]
+fn nested_router() {
+    let router = Router::new().any(
+        "/nested/*",
+        Router::new().get("/here", "ok").post("*", "ok"),
+    );
+    assert_headers!(TestConn::build("options", "/nested/here", ()).on(&router), "allow" => "GET, POST");
+    assert_headers!(TestConn::build("options", "*", ()).on(&router), "allow" => "DELETE, GET, PATCH, POST, PUT");
 }

--- a/router/tests/options.rs
+++ b/router/tests/options.rs
@@ -1,0 +1,57 @@
+use trillium_router::*;
+use trillium_testing::{prelude::*, TestConn};
+
+#[test]
+fn options_star_with_a_star_handler() {
+    let router = Router::new()
+        .get("*", "ok")
+        .post("/some/specific/route", "ok");
+    let mut conn = TestConn::build("options", "*", ()).on(&router);
+    assert_status!(&conn, 200);
+    assert_headers!(&mut conn, "allow" => "GET, POST");
+}
+
+#[test]
+fn options_specific_route_with_several_matching_methods() {
+    let router = Router::new()
+        .get("*", "ok")
+        .post("/some/specific/route", "ok")
+        .delete("/some/specific/:anything", "ok");
+
+    let mut conn = TestConn::build("options", "/some/specific/route", ()).on(&router);
+    assert_status!(&conn, 200);
+    assert_headers!(&mut conn, "allow" => "DELETE, GET, POST");
+
+    let mut conn = TestConn::build("options", "/some/specific/other", ()).on(&router);
+    assert_status!(&conn, 200);
+    assert_headers!(&mut conn, "allow" => "DELETE, GET");
+
+    let mut conn = TestConn::build("options", "/only-get", ()).on(&router);
+    assert_status!(&conn, 200);
+    assert_headers!(&mut conn, "allow" => "GET");
+}
+
+#[test]
+fn options_specific_route_with_no_matching_routes() {
+    let router = Router::new()
+        .post("/some/specific/route", "ok")
+        .delete("/some/specific/:anything", "ok");
+
+    let mut conn = TestConn::build("options", "/other", ()).on(&router);
+    assert_status!(&conn, 200);
+    assert_headers!(&mut conn, "allow" => "");
+}
+
+#[test]
+fn options_any() {
+    let router = Router::new().any("/some-route", "ok");
+    let mut conn = TestConn::build("options", "*", ()).on(&router);
+    assert_status!(&conn, 200);
+    assert_headers!(&mut conn, "allow" => "DELETE, GET, PATCH, POST, PUT");
+}
+
+#[test]
+fn when_options_are_disabled() {
+    let router = Router::new().without_options_handling().any("*", "ok");
+    assert_not_handled!(TestConn::build("options", "/", ()));
+}


### PR DESCRIPTION
closes #62 

## Options handling
By default, the trillium router will reply to an OPTIONS request with
the list of supported http methods at the given route. If the OPTIONS
request is sent for `*`, it responds with the full set of http methods
supported by this router.


**Note:** This behavior is superceded by an explicit OPTIONS handler
or an `any` handler.

To disable the default OPTIONS behavior, use
`Router::without_options_handling` or
`RouterRef::set_options_handling`