### PR TITLE
add feature flags to support testing non-async-global-executor apps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,19 +41,19 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --all --examples --features async-std
+        args: --workspace --all --examples --features async-std
 
     - name: Tokio tests
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --all --examples --features tokio
+        args: --workspace --all --examples --features tokio
 
     - name: Smol tests
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --all --examples --features smol
+        args: --workspace --all --examples --features smol
 
   check_fmt_and_docs:
     name: Lints and Docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,9 +37,12 @@ jobs:
 
     - name: Tests
       uses: actions-rs/cargo@v1
+      strategy:
+        matrix:
+          runtime: [tokio, async-std, smol]
       with:
         command: test
-        args: --all --examples
+        args: --all --examples --features ${{ matrix.runtime }}
 
   check_fmt_and_docs:
     name: Lints and Docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest] # [macOS-latest, ubuntu-latest, windows-latest]
-        rust: [stable] # [nightly, stable]
-
+        os: [ubuntu-latest, macOS-latest] # [macOS-latest, ubuntu-latest, windows-latest]
+        rust: [nightly, stable]
+        runtime: [tokio, async-std, smol]
     steps:
     - uses: actions/checkout@master
     - name: Install ${{ matrix.rust }}
@@ -37,9 +37,6 @@ jobs:
 
     - name: Tests
       uses: actions-rs/cargo@v1
-      strategy:
-        matrix:
-          runtime: [tokio, async-std, smol]
       with:
         command: test
         args: --all --examples --features ${{ matrix.runtime }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest] # [macOS-latest, ubuntu-latest, windows-latest]
         rust: [nightly, stable]
-        runtime: [tokio, async-std, smol]
     steps:
     - uses: actions/checkout@master
     - name: Install ${{ matrix.rust }}
@@ -35,11 +34,23 @@ jobs:
           target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
-    - name: Tests
+    - name: Async-std tests
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --all --examples --features ${{ matrix.runtime }}
+        args: --all --examples --features async-std
+
+    - name: Tokio tests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --all --examples --features tokio
+
+    - name: Smol tests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --all --examples --features smol
 
   check_fmt_and_docs:
     name: Lints and Docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,15 +24,18 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
         override: true
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+    # - uses: actions/cache@v2
+    #   with:
+    #     path: |
+    #       ~/.cargo/bin/
+    #       ~/.cargo/registry/index/
+    #       ~/.cargo/registry/cache/
+    #       ~/.cargo/git/db/
+    #       target/
+    #     key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+
+    - name: Rust Cache
+      uses: Swatinem/rust-cache@v1.3.0
 
     - name: Async-std tests
       uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,19 +41,19 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --workspace --all --examples --features async-std
+        args: --workspace --features async-std --no-fail-fast
 
     - name: Tokio tests
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --workspace --all --examples --features tokio
+        args: --workspace --features tokio --no-fail-fast
 
     - name: Smol tests
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --workspace --all --examples --features smol
+        args: --workspace --features smol --no-fail-fast
 
   check_fmt_and_docs:
     name: Lints and Docs

--- a/async-std/Cargo.toml
+++ b/async-std/Cargo.toml
@@ -22,5 +22,15 @@ signal-hook = "0.3.9"
 signal-hook-async-std = "0.2.1"
 
 [dev-dependencies]
-async-std = { version = "1.9.0", features = ["attributes"], package = "async-std" }
 env_logger = "0.8.4"
+
+[dev-dependencies.async-std]
+version = "1.9.0"
+features = ["attributes"]
+package = "async-std"
+
+[dev-dependencies.trillium-testing]
+version = "0.1.1"
+default-features = false
+features = ["async-std"]
+path = "../testing"

--- a/async-std/Cargo.toml
+++ b/async-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-async-std"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Jacob Rothstein <hi@jbr.me>"]
 edition = "2018"
 description = "async-std runtime adapter for trillium.rs"

--- a/async-std/examples/async-std.rs
+++ b/async-std/examples/async-std.rs
@@ -1,9 +1,27 @@
-#[async_std::main]
-pub async fn main() {
+use trillium_async_std::async_std::task;
+
+pub fn app() -> impl trillium::Handler {
+    |conn: trillium::Conn| async move {
+        let response = task::spawn(async {
+            task::sleep(std::time::Duration::from_millis(10)).await;
+            "successfully spawned a task"
+        })
+        .await;
+
+        conn.ok(response)
+    }
+}
+pub fn main() {
     env_logger::init();
-    trillium_async_std::run_async("hello world").await;
+    trillium_async_std::run(app());
 }
 
-pub fn or_if_main_is_not_async() {
-    trillium_async_std::run("hello world");
+#[cfg(test)]
+mod tests {
+    use trillium_testing::prelude::*;
+    #[test]
+    fn test() {
+        let app = super::app();
+        assert_ok!(get("/").on(&app), "successfully spawned a task");
+    }
 }

--- a/async-std/examples/async-std.rs
+++ b/async-std/examples/async-std.rs
@@ -15,13 +15,3 @@ pub fn main() {
     env_logger::init();
     trillium_async_std::run(app());
 }
-
-#[cfg(test)]
-mod tests {
-    use trillium_testing::prelude::*;
-    #[test]
-    fn test() {
-        let app = super::app();
-        assert_ok!(get("/").on(&app), "successfully spawned a task");
-    }
-}

--- a/async-std/src/lib.rs
+++ b/async-std/src/lib.rs
@@ -41,6 +41,8 @@ pub use client::{ClientConfig, TcpConnector};
 mod server;
 use server::Config;
 
+pub use async_std;
+
 /**
 # Runs a trillium handler in a sync context with default config
 

--- a/http/src/received_body.rs
+++ b/http/src/received_body.rs
@@ -30,7 +30,7 @@ transport, which it may either borrow from a [`Conn`](crate::Conn) or
 own.
 
 ```rust
-# futures_lite::future::block_on(async {
+# trillium_testing::block_on(async {
 # use trillium_http::{http_types::Method, Conn};
 let mut conn = Conn::new_synthetic(Method::Get, "/", "hello");
 let body = conn.request_body().await;
@@ -79,7 +79,7 @@ where
     transfer-encoding chunked, this will be None.
 
     ```rust
-    # futures_lite::future::block_on(async {
+    # trillium_testing::block_on(async {
     # use trillium_http::{http_types::Method, Conn};
     let mut conn = Conn::new_synthetic(Method::Get, "/", "hello");
     let body = conn.request_body().await;
@@ -549,7 +549,7 @@ mod chunk_decode {
             UTF_8,
         );
 
-        let output = async_io::block_on(read_with_buffers_of_size(&mut rb, poll_size))?;
+        let output = trillium_testing::block_on(read_with_buffers_of_size(&mut rb, poll_size))?;
         Ok((output, rb))
     }
 

--- a/server-common/src/clone_counter.rs
+++ b/server-common/src/clone_counter.rs
@@ -15,7 +15,7 @@ pub struct CloneCounterInner {
 # an atomic counter that increments on clone & decrements on drop
 
 ```rust
-# futures_lite::future::block_on(async {
+# trillium_testing::block_on(async {
 # use trillium_server_common::CloneCounter;
 use futures_lite::future::poll_once;
 let counter = CloneCounter::new();

--- a/smol/Cargo.toml
+++ b/smol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-smol"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Jacob Rothstein <hi@jbr.me>"]
 edition = "2018"
 description = "smol runtime adapter for trillium.rs"

--- a/smol/Cargo.toml
+++ b/smol/Cargo.toml
@@ -28,3 +28,7 @@ signal-hook-async-std = "0.2.1"
 env_logger = "0.8.4"
 trillium-client = { path = "../client" }
 trillium-testing = { path = "../testing" }
+
+[[example]]
+name = "smol"
+test = true

--- a/smol/examples/smol.rs
+++ b/smol/examples/smol.rs
@@ -1,4 +1,26 @@
+use trillium_smol::{async_global_executor, async_io::Timer};
+pub fn app() -> impl trillium::Handler {
+    |conn: trillium::Conn| async move {
+        let response = async_global_executor::spawn(async {
+            Timer::after(std::time::Duration::from_millis(10)).await;
+            "successfully spawned a task"
+        })
+        .await;
+
+        conn.ok(response)
+    }
+}
 pub fn main() {
     env_logger::init();
-    trillium_smol::run(|conn: trillium::Conn| async move { conn.ok("hello") });
+    trillium_smol::run(app());
+}
+
+#[cfg(test)]
+mod tests {
+    use trillium_testing::prelude::*;
+    #[test]
+    fn test() {
+        let app = super::app();
+        assert_ok!(get("/").on(&app), "successfully spawned a task");
+    }
 }

--- a/smol/src/lib.rs
+++ b/smol/src/lib.rs
@@ -68,6 +68,9 @@ pub use client::{ClientConfig, TcpConnector};
 mod server;
 use server::Config;
 
+pub use async_global_executor;
+pub use async_io;
+
 /**
 # Runs a trillium handler in a sync context with default config
 

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -10,16 +10,35 @@ readme = "../README.md"
 keywords = ["trillium", "framework", "testing"]
 categories = ["web-programming::http-server", "web-programming"]
 
+[features]
+tokio = ["trillium-tokio"]
+smol = ["trillium-smol"]
+async-std = ["trillium-async-std"]
+default = ["smol"]
+
 [dependencies]
 async-dup = "1.2.2"
-async-global-executor = "2.0.2"
-async-io = "1.6.0"
 futures-lite = "1.12.0"
 portpicker = "0.1.1"
 trillium = { path = "../trillium", version = "^0.1.0" }
 trillium-http = { path = "../http", version = "^0.1.0" }
 trillium-server-common = { path = "../server-common", version = "^0.1.0" }
-trillium-smol = { path = "../smol", version = "^0.1.0" }
+cfg-if = "1.0.0"
+
+[dependencies.trillium-smol]
+path = "../smol"
+version = "^0.1.0"
+optional = true
+
+[dependencies.trillium-tokio]
+path = "../tokio"
+version = "^0.1.0"
+optional = true
+
+[dependencies.trillium-async-std]
+path = "../async-std"
+version = "^0.1.0"
+optional = true
 
 [dev-dependencies]
 trillium-logger = { path = "../logger" }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-testing"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Jacob Rothstein <hi@jbr.me>"]
 edition = "2018"
 description = "testing library for trillium applications"

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -42,3 +42,4 @@ optional = true
 
 [dev-dependencies]
 trillium-logger = { path = "../logger" }
+trillium-smol = { path = "../smol" }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["web-programming::http-server", "web-programming"]
 tokio = ["trillium-tokio"]
 smol = ["trillium-smol"]
 async-std = ["trillium-async-std"]
-default = ["smol"]
+default = []
 
 [dependencies]
 async-dup = "1.2.2"

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -43,3 +43,7 @@ optional = true
 [dev-dependencies]
 trillium-logger = { path = "../logger" }
 trillium-smol = { path = "../smol" }
+
+[[example]]
+name = "testing"
+test = true

--- a/testing/src/assertions.rs
+++ b/testing/src/assertions.rs
@@ -116,7 +116,8 @@ assert_body!(get("/").on(&"beach body"), "winter body");
 #[macro_export]
 macro_rules! assert_body {
     ($conn:expr, $body:expr) => {{
-        let body = $conn.take_body_string().unwrap_or_default();
+        let body = $crate::futures_lite::future::block_on($conn.take_response_body_string())
+            .unwrap_or_default();
         assert_eq!(body.trim_end(), $body.trim_end());
     }};
 }
@@ -150,7 +151,8 @@ assert_body_contains!(get("/").on(&"just a haystack"), "needle");
 #[macro_export]
 macro_rules! assert_body_contains {
     ($conn:expr, $pattern:expr) => {{
-        let body = $conn.take_body_string().expect("body should exist");
+        let body = $crate::futures_lite::future::block_on($conn.take_response_body_string())
+            .unwrap_or_default();
         assert!(
             body.contains($pattern),
             "\nexpected \n`{}`\n to contain `{}`\n but it did not",

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -34,6 +34,41 @@ assert_response!(
 
 ```
 
+## Features
+
+The default runtime for trillium_testing is smol. To test a
+trillium_tokio or trillium_async_std application:
+
+## Tokio:
+
+```toml
+[dev-dependencies.trillium-testing]
+version = "0.1"
+default-features = false
+features = ["tokio"]
+
+# or:
+
+[dev-dependencies]
+# ...
+trillium_testing = { version = "0.1", default-features = false, features = ["tokio"] }
+```
+
+## Async-std:
+```toml
+[dev-dependencies.trillium-testing]
+version = "0.1"
+default-features = false
+features = ["async-std"]
+
+# or:
+
+[dev-dependencies]
+# ...
+trillium_testing = { version = "0.1", default-features = false, features = ["async-std"] }
+```
+
+
 */
 
 mod assertions;

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -106,13 +106,13 @@ pub use futures_lite::{AsyncRead, AsyncReadExt, AsyncWrite};
 pub use trillium_http::http_types::{Method, StatusCode, Url};
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "smol")] {
-        pub use trillium_smol::async_global_executor::block_on;
+    if #[cfg(feature = "tokio")] {
+        pub use trillium_tokio::block_on;
     } else if #[cfg(feature = "async-std")] {
         pub use trillium_async_std::async_std::task::block_on;
-    } else if #[cfg(feature = "tokio")] {
-        pub use trillium_tokio::block_on;
+    } else if #[cfg(feature = "smol")] {
+        pub use trillium_smol::async_global_executor::block_on;
     } else {
-        compiler_error!("must enable smol, async-std, or tokio feature for now");
+        compile_error!("must enable smol, async-std, or tokio feature");
     }
 }

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -36,36 +36,27 @@ assert_response!(
 
 ## Features
 
-The default runtime for trillium_testing is smol. To test a
-trillium_tokio or trillium_async_std application:
+**You must enable a runtime feature for trillium testing**
 
 ### Tokio:
-
 ```toml
-[dev-dependencies.trillium-testing]
-version = "0.1"
-default-features = false
-features = ["tokio"]
-
-# or:
-
 [dev-dependencies]
 # ...
-trillium_testing = { version = "0.1", default-features = false, features = ["tokio"] }
+trillium_testing = { version = "0.2", , features = ["tokio"] }
 ```
 
 ### Async-std:
 ```toml
-[dev-dependencies.trillium-testing]
-version = "0.1"
-default-features = false
-features = ["async-std"]
-
-# or:
-
 [dev-dependencies]
 # ...
-trillium_testing = { version = "0.1", default-features = false, features = ["async-std"] }
+trillium_testing = { version = "0.2", , features = ["async-std"] }
+```
+
+### Smol:
+```toml
+[dev-dependencies]
+# ...
+trillium_testing = { version = "0.2", , features = ["smol"] }
 ```
 
 
@@ -114,5 +105,6 @@ cfg_if::cfg_if! {
         pub use trillium_smol::async_global_executor::block_on;
     } else {
         compile_error!("must enable smol, async-std, or tokio feature");
+        pub fn block_on<Fut: std::future::Future<Output = T>, T>(_: Fut) -> T { unreachable!()}
     }
 }

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -93,6 +93,7 @@ pub fn init(handler: &mut impl trillium::Handler) {
 }
 
 // these exports are used by macros
+pub use futures_lite;
 pub use futures_lite::{AsyncRead, AsyncReadExt, AsyncWrite};
 pub use trillium_http::http_types::{Method, StatusCode, Url};
 

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -67,5 +67,17 @@ pub fn init(handler: &mut impl trillium::Handler) {
 }
 
 // these exports are used by macros
-pub use futures_lite::{future::block_on, AsyncRead, AsyncReadExt, AsyncWrite};
+pub use futures_lite::{AsyncRead, AsyncReadExt, AsyncWrite};
 pub use trillium_http::http_types::{Method, StatusCode, Url};
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "smol")] {
+        pub use trillium_smol::async_global_executor::block_on;
+    } else if #[cfg(feature = "async-std")] {
+        pub use trillium_async_std::async_std::task::block_on;
+    } else if #[cfg(feature = "tokio")] {
+        pub use trillium_tokio::block_on;
+    } else {
+        compiler_error!("must enable smol, async-std, or tokio feature for now");
+    }
+}

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -39,7 +39,7 @@ assert_response!(
 The default runtime for trillium_testing is smol. To test a
 trillium_tokio or trillium_async_std application:
 
-## Tokio:
+### Tokio:
 
 ```toml
 [dev-dependencies.trillium-testing]
@@ -54,7 +54,7 @@ features = ["tokio"]
 trillium_testing = { version = "0.1", default-features = false, features = ["tokio"] }
 ```
 
-## Async-std:
+### Async-std:
 ```toml
 [dev-dependencies.trillium-testing]
 version = "0.1"

--- a/testing/src/test_conn.rs
+++ b/testing/src/test_conn.rs
@@ -175,12 +175,14 @@ impl TestConn {
     used internally to [`assert_body`] which is the preferred
     interface
     */
-    pub fn take_body_string(&mut self) -> Option<String> {
-        self.take_response_body().map(|mut body| {
+    pub async fn take_response_body_string(&mut self) -> Option<String> {
+        if let Some(mut body) = self.take_response_body() {
             let mut s = String::new();
-            futures_lite::future::block_on(body.read_to_string(&mut s)).expect("read");
-            s
-        })
+            body.read_to_string(&mut s).await.expect("read");
+            Some(s)
+        } else {
+            None
+        }
     }
 
     // pub fn take_body_bytes(&mut self) -> Option<Vec<u8>> {

--- a/testing/src/with_server.rs
+++ b/testing/src/with_server.rs
@@ -1,45 +1,132 @@
-use crate::Url;
-use async_io::Timer;
+use crate::{block_on, Url};
 use std::{future::Future, time::Duration};
 use trillium::Handler;
+use trillium_server_common::Stopper;
 
-/**
-Starts an trillium handler using the smol server bound to a random
-available port on localhost, run the async tests provided as the
-second argument, and then shut down the server. useful for full
-integration tests that actually exercise the tcp layer.
+cfg_if::cfg_if! {
+    if #[cfg(feature = "smol")] {
+        use trillium_smol::{async_io::Timer, async_global_executor::spawn};
 
-See
-[`trillium_client::Conn`](https://docs.trillium.rs/trillium_client/struct.conn)
-for usage examples.
+        /**
+        Starts a trillium handler bound to a random available port on
+        localhost, run the async tests provided as the second
+        argument, and then shut down the server. useful for full
+        integration tests that actually exercise the tcp layer.
 
-stability note: this doesn't really feel like it fits in the testing
-crate, as it would not work well with a tokio-specific handler. it may
-go away entirely at some point, or be moved to the trillium_smol crate
-*/
-pub fn with_server<H, Fun, Fut>(handler: H, tests: Fun)
-where
-    H: Handler,
-    Fun: Fn(Url) -> Fut,
-    Fut: Future<Output = Result<(), Box<dyn std::error::Error>>>,
-{
-    async_global_executor::block_on(async move {
-        let port = portpicker::pick_unused_port().expect("could not pick a port");
-        let url = format!("http://localhost:{}", port).parse().unwrap();
-        let stopper = trillium_smol::Stopper::new();
+        See
+        [`trillium_client::Conn`](https://docs.trillium.rs/trillium_client/struct.conn)
+        for usage examples.
 
-        let server_future = async_global_executor::spawn(
-            trillium_smol::config()
-                .with_host("localhost")
-                .with_port(port)
-                .with_stopper(stopper.clone())
-                .run_async(handler),
-        );
+        stability note: this doesn't really feel like it fits in the testing
+        crate, as it would not work well with a tokio-specific handler. it may
+        go away entirely at some point, or be moved to the trillium_smol crate
+         */
+        pub fn with_server<H, Fun, Fut>(handler: H, tests: Fun)
+        where
+            H: Handler,
+            Fun: Fn(Url) -> Fut,
+            Fut: Future<Output = Result<(), Box<dyn std::error::Error>>>,
+        {
+            block_on(async move {
+                let port = portpicker::pick_unused_port().expect("could not pick a port");
+                let url = format!("http://localhost:{}", port).parse().unwrap();
+                let stopper = Stopper::new();
 
-        Timer::after(Duration::from_millis(500)).await;
-        let result = tests(url).await;
-        stopper.stop();
-        server_future.await;
-        result.unwrap()
-    })
+                let server_future = spawn(
+                    trillium_smol::config()
+                        .with_host("localhost")
+                        .with_port(port)
+                        .with_stopper(stopper.clone())
+                        .run_async(handler),
+                );
+
+                Timer::after(Duration::from_millis(500)).await;
+                let result = tests(url).await;
+                stopper.stop();
+                server_future.await;
+                result.unwrap()
+            })
+        }
+    } else if #[cfg(feature = "async-std")] {
+        use trillium_async_std::async_std::task::{sleep, spawn};
+
+        /**
+        Starts a trillium handler bound to a random available port on
+        localhost, run the async tests provided as the second
+        argument, and then shut down the server. useful for full
+        integration tests that actually exercise the tcp layer.
+
+        See
+        [`trillium_client::Conn`](https://docs.trillium.rs/trillium_client/struct.conn)
+        for usage examples.
+         */
+        pub fn with_server<H, Fun, Fut>(handler: H, tests: Fun)
+        where
+            H: Handler,
+            Fun: Fn(Url) -> Fut,
+            Fut: Future<Output = Result<(), Box<dyn std::error::Error>>>,
+        {
+            block_on(async move {
+                let port = portpicker::pick_unused_port().expect("could not pick a port");
+                let url = format!("http://localhost:{}", port).parse().unwrap();
+                let stopper = Stopper::new();
+
+                let server_future = spawn(
+                    trillium_async_std::config()
+                        .with_host("localhost")
+                        .with_port(port)
+                        .with_stopper(stopper.clone())
+                        .run_async(handler),
+                );
+
+                sleep(Duration::from_millis(500)).await;
+                let result = tests(url).await;
+                stopper.stop();
+                server_future.await;
+                result.unwrap()
+            })
+        }
+
+    } else if #[cfg(feature = "tokio")] {
+        use trillium_tokio::tokio::{time::sleep, task::spawn};
+
+        /**
+        Starts a trillium handler bound to a random available port on
+        localhost, run the async tests provided as the second
+        argument, and then shut down the server. useful for full
+        integration tests that actually exercise the tcp layer.
+
+        See
+        [`trillium_client::Conn`](https://docs.trillium.rs/trillium_client/struct.conn)
+        for usage examples.
+         */
+        pub fn with_server<H, Fun, Fut>(handler: H, tests: Fun)
+        where
+            H: Handler,
+            Fun: Fn(Url) -> Fut,
+            Fut: Future<Output = Result<(), Box<dyn std::error::Error>>>,
+        {
+            block_on(async move {
+                let port = portpicker::pick_unused_port().expect("could not pick a port");
+                let url = format!("http://localhost:{}", port).parse().unwrap();
+                let stopper = Stopper::new();
+
+                let server_future = spawn(
+                    trillium_tokio::config()
+                        .with_host("localhost")
+                        .with_port(port)
+                        .with_stopper(stopper.clone())
+                        .run_async(handler),
+                );
+
+                sleep(Duration::from_millis(500)).await;
+                let result = tests(url).await;
+                stopper.stop();
+                drop(server_future.await);
+                result.unwrap()
+            })
+        }
+    } else {
+        compiler_error!("must enable smol, async-std, or tokio feature");
+    }
 }

--- a/testing/src/with_server.rs
+++ b/testing/src/with_server.rs
@@ -127,6 +127,6 @@ cfg_if::cfg_if! {
             })
         }
     } else {
-        compiler_error!("must enable smol, async-std, or tokio feature");
+        compile_error!("must enable smol, async-std, or tokio feature");
     }
 }

--- a/testing/src/with_server.rs
+++ b/testing/src/with_server.rs
@@ -127,6 +127,16 @@ cfg_if::cfg_if! {
             })
         }
     } else {
+        pub fn with_server<H, Fun, Fut>(_handler: H, _tests: Fun)
+        where
+            H: Handler,
+            Fun: Fn(Url) -> Fut,
+            Fut: Future<Output = Result<(), Box<dyn std::error::Error>>>,
+        {
+            block_on(async {});
+            let duration = Duration::ZERO;
+            let stopper = Stopper::new();
+        }
         compile_error!("must enable smol, async-std, or tokio feature");
     }
 }

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -13,11 +13,15 @@ categories = ["web-programming::http-server", "web-programming"]
 [dependencies]
 async-compat = "0.2.1"
 log = "0.4.14"
-tokio = { version = "1.8.1", features = ["rt", "net", "rt-multi-thread"], package = "tokio" }
 tokio-stream = { version = "0.1.7", features = ["net"] }
 trillium = { path = "../trillium", version = "^0.1.0" }
 trillium-http = { path = "../http", version = "^0.1.0" }
 trillium-server-common = { path = "../server-common", version = "^0.1.0" }
+
+[dependencies.tokio]
+version = "1.8.1"
+features = ["rt", "net", "rt-multi-thread", "time"]
+package = "tokio"
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = "0.3.9"
@@ -26,3 +30,9 @@ signal-hook-tokio = { version = "0.3.0", features = ["futures-v0_3"] }
 [dev-dependencies]
 tokio = { version = "1.8.1", features = ["full"], package = "tokio" }
 env_logger = "0.8.4"
+
+[dev-dependencies.trillium-testing]
+version = "0.1.1"
+default-features = false
+features = ["tokio"]
+path = "../testing"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -33,6 +33,4 @@ env_logger = "0.8.4"
 
 [dev-dependencies.trillium-testing]
 version = "0.1.1"
-default-features = false
-features = ["tokio"]
 path = "../testing"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-tokio"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Jacob Rothstein <hi@jbr.me>"]
 edition = "2018"
 description = "tokio runtime adapter for trillium.rs"

--- a/tokio/examples/tokio.rs
+++ b/tokio/examples/tokio.rs
@@ -1,4 +1,25 @@
+pub fn app() -> impl trillium::Handler {
+    |conn: trillium::Conn| async move {
+        let response = tokio::task::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            "successfully spawned a task"
+        })
+        .await
+        .unwrap();
+        conn.ok(response)
+    }
+}
 pub fn main() {
     env_logger::init();
-    trillium_tokio::run(|conn: trillium::Conn| async move { conn.ok("ok!") });
+    trillium_tokio::run(app());
+}
+
+#[cfg(test)]
+mod tests {
+    use trillium_testing::prelude::*;
+    #[test]
+    fn test() {
+        let app = super::app();
+        assert_ok!(get("/").on(&app), "successfully spawned a task");
+    }
 }

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -31,6 +31,8 @@ async fn main() {
 ```
 */
 
+use std::future::Future;
+
 use trillium::Handler;
 pub use trillium_server_common::Stopper;
 
@@ -39,6 +41,8 @@ pub use client::{ClientConfig, TcpConnector};
 
 mod server;
 use server::Config;
+pub use tokio;
+pub use tokio_stream;
 
 /**
 # Runs a trillium handler in a sync context with default config
@@ -104,4 +108,11 @@ See [`trillium_server_common::Config`] for more details
 */
 pub fn config() -> Config<()> {
     Config::new()
+}
+
+/**
+reexport tokio runtime block_on
+*/
+pub fn block_on<Fut: Future<Output = T>, T>(future: Fut) -> T {
+    tokio::runtime::Runtime::new().unwrap().block_on(future)
 }

--- a/tokio/src/server.rs
+++ b/tokio/src/server.rs
@@ -1,9 +1,6 @@
 use async_compat::Compat;
 use std::{net::IpAddr, sync::Arc};
-use tokio::{
-    net::{TcpListener, TcpStream},
-    runtime::Runtime,
-};
+use tokio::net::{TcpListener, TcpStream};
 use tokio_stream::{wrappers::TcpListenerStream, StreamExt};
 use trillium::{async_trait, Handler, Info};
 use trillium_server_common::{Acceptor, ConfigExt, Server, Stopper};
@@ -51,9 +48,7 @@ impl Server for TokioServer {
     }
 
     fn run<A: Acceptor<Self::Transport>, H: Handler>(config: Config<A>, handler: H) {
-        Runtime::new()
-            .unwrap()
-            .block_on(async move { Self::run_async(config, handler).await });
+        crate::block_on(async move { Self::run_async(config, handler).await });
     }
 
     async fn run_async<A: Acceptor<Self::Transport>, H: Handler>(

--- a/tokio/tests/tests.rs
+++ b/tokio/tests/tests.rs
@@ -1,4 +1,6 @@
-pub fn app() -> impl trillium::Handler {
+use trillium_testing::prelude::*;
+
+fn app() -> impl trillium::Handler {
     |conn: trillium::Conn| async move {
         let response = tokio::task::spawn(async {
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
@@ -9,7 +11,10 @@ pub fn app() -> impl trillium::Handler {
         conn.ok(response)
     }
 }
-pub fn main() {
-    env_logger::init();
-    trillium_tokio::run(app());
+
+#[cfg(feature = "tokio")]
+#[test]
+fn smoke() {
+    let app = app();
+    assert_ok!(get("/").on(&app), "successfully spawned a task");
 }

--- a/tokio/tests/tests.rs
+++ b/tokio/tests/tests.rs
@@ -1,20 +1,20 @@
-use trillium_testing::prelude::*;
-
-fn app() -> impl trillium::Handler {
-    |conn: trillium::Conn| async move {
-        let response = tokio::task::spawn(async {
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-            "successfully spawned a task"
-        })
-        .await
-        .unwrap();
-        conn.ok(response)
-    }
-}
-
 #[cfg(feature = "tokio")]
 #[test]
 fn smoke() {
+    use trillium_testing::prelude::*;
+
+    fn app() -> impl trillium::Handler {
+        |conn: trillium::Conn| async move {
+            let response = tokio::task::spawn(async {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                "successfully spawned a task"
+            })
+            .await
+            .unwrap();
+            conn.ok(response)
+        }
+    }
+
     let app = app();
     assert_ok!(get("/").on(&app), "successfully spawned a task");
 }

--- a/trillium/src/conn.rs
+++ b/trillium/src/conn.rs
@@ -261,10 +261,10 @@ impl Conn {
     retains all data and holds the singular transport, but the
     ReceivedBody provides an interface to read body content
     ```
-    # trillium_testing::block_on(async {
     use trillium_testing::prelude::*;
     let mut conn = get("/").with_request_body("request body").on(&());
 
+    # trillium_testing::block_on(async {
     let request_body = conn.request_body().await;
     assert_eq!(request_body.content_length(), Some(12));
     assert_eq!(request_body.read_string().await.unwrap(), "request body");
@@ -278,10 +278,10 @@ impl Conn {
     /**
     Convenience function to read the content of a request body as a String.
     ```
-    # trillium_testing::block_on(async {
     use trillium_testing::prelude::*;
     let mut conn = get("/").with_request_body("request body").on(&());
 
+    # trillium_testing::block_on(async {
     assert_eq!(conn.request_body_string().await.unwrap(), "request body");
     # });
     ```


### PR DESCRIPTION
closes #73 

## Features

The default runtime for trillium_testing is smol. To test a
trillium_tokio or trillium_async_std application:

### Tokio:

```toml
[dev-dependencies.trillium-testing]
version = "0.1"
default-features = false
features = ["tokio"]

# or:

[dev-dependencies]
# ...
trillium_testing = { version = "0.1", default-features = false, features = ["tokio"] }
```

### Async-std:
```toml
[dev-dependencies.trillium-testing]
version = "0.1"
default-features = false
features = ["async-std"]

# or:

[dev-dependencies]
# ...
trillium_testing = { version = "0.1", default-features = false, features = ["async-std"] }
```

## Versions
This PR entails trillium-tokio@0.1.3, trillium-async-std@0.1.3, trillium-smol@0.1.3 and trillium-testing@0.1.2