### PR TITLE
add support for max_connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock
 .envrc
 aws-lambda-example/lambda.zip
 aws-lambda-example/bootstrap
+temp

--- a/async-std/Cargo.toml
+++ b/async-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-async-std"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Jacob Rothstein <hi@jbr.me>"]
 edition = "2018"
 description = "async-std runtime adapter for trillium.rs"

--- a/forwarding/src/lib.rs
+++ b/forwarding/src/lib.rs
@@ -67,8 +67,8 @@ impl TrustProxy {
         match self {
             TrustProxy::Always => true,
             TrustProxy::Never => false,
-            TrustProxy::Cidr(cidrs) => cidrs.iter().any(|c| c.contains(&ip)),
-            TrustProxy::Function(trust_predicate) => trust_predicate(&ip),
+            TrustProxy::Cidr(cidrs) => cidrs.iter().any(|c| c.contains(ip)),
+            TrustProxy::Function(trust_predicate) => trust_predicate(ip),
         }
     }
 }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-http"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2018"
 authors = ["Jacob Rothstein <hi@jbr.me>"]
 description = "the http implementation for the trillium toolkit"

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -111,3 +111,10 @@ mod util;
 /// Types to represent the bidirectional data stream over which the
 /// HTTP protocol is communicated
 pub mod transport;
+
+/// A pre-rendered http response to send when the server is at capacity.
+pub const SERVICE_UNAVAILABLE: &[u8] = b"HTTP/1.1 503 Service Unavailable\r
+Connection: close\r
+Content-Length: 0\r
+Retry-After: 60\r
+\r\n";

--- a/logger/examples/logger.rs
+++ b/logger/examples/logger.rs
@@ -6,7 +6,7 @@ struct User(&'static str);
 
 impl User {
     pub fn name(&self) -> &'static str {
-        &self.0
+        self.0
     }
 }
 

--- a/server-common/Cargo.toml
+++ b/server-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-server-common"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Jacob Rothstein <hi@jbr.me>"]
 edition = "2018"
 description = "server utilities for trillium.rs"
@@ -19,6 +19,9 @@ pin-project-lite = "0.2.7"
 trillium = { path = "../trillium", version = "^0.1.0" }
 trillium-http = { path = "../http", version = "^0.1.0" }
 trillium-tls-common = { path = "../tls-common/", version = "^0.1.0" }
+
+[target.'cfg(unix)'.dependencies]
+rlimit = "0.6.2"
 
 [dev-dependencies]
 trillium-smol = { path = "../smol" }

--- a/server-common/src/server.rs
+++ b/server-common/src/server.rs
@@ -16,11 +16,17 @@ pub trait Server: Sized {
     type Transport: Transport;
 
     /**
-    Determine the remote ip/port for the Transport.
-    */
-    fn peer_ip(_transport: &Self::Transport) -> Option<IpAddr> {
+    Determine the remote ip/port for the Transport, if applicable.
+     */
+    #[allow(unused_variables)]
+    fn peer_ip(transport: &Self::Transport) -> Option<IpAddr> {
         None
     }
+    /**
+    Set tcp_nodelay on the transport, if applicable.
+     */
+    #[allow(unused_variables)]
+    fn set_nodelay(transport: &mut Self::Transport, nodelay: bool) {}
 
     /**
     entrypoint to run a handler with a given config. if this function

--- a/smol/Cargo.toml
+++ b/smol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-smol"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Jacob Rothstein <hi@jbr.me>"]
 edition = "2018"
 description = "smol runtime adapter for trillium.rs"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-tokio"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Jacob Rothstein <hi@jbr.me>"]
 edition = "2018"
 description = "tokio runtime adapter for trillium.rs"


### PR DESCRIPTION
send a static 503 response when we are over capacity but under the ulimit. additionally, this pr addresses an issue where we'd previously shut down if the ulimit was reached. now we just log an error and keep trucking

this pr entails patch releases to trillium-http, trillium-server-common, and all of the runtime adapters