### PR TITLE
Use ToString for `with_host`

### DIFF
--- a/server-common/src/config.rs
+++ b/server-common/src/config.rs
@@ -100,8 +100,8 @@ where
     /// Configures the server to listen on this host or ip
     /// address. The default is the HOST environment variable or
     /// "localhost"
-    pub fn with_host(mut self, host: &str) -> Self {
-        self.host = Some(host.into());
+    pub fn with_host(mut self, host: impl ToString) -> Self {
+        self.host = Some(host.to_string());
         self
     }
 


### PR DESCRIPTION
I tend to use `SocketAddr` to define the listening address for Web applications. [`SocketAddr::ip`](https://doc.rust-lang.org/std/net/enum.SocketAddr.html#method.ip) gives back a type [that implements `ToString`](https://doc.rust-lang.org/std/net/enum.IpAddr.html#impl-ToString). This would make it _a bit_ easier to pass in any sort of value.