### PR TITLE
changes to http-types, mostly avoiding implicit string clones

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,5 @@ members = [
 exclude = ["controllers", "basic-auth"]
 
 [patch.crates-io.trillium-http-types]
-git = "https://github.com/trillim-rs/trillium-http-types"
+git = "https://github.com/trillium-rs/trillium-http-types"
 branch = "trillium"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,6 @@ members = [
   "websockets",
 ]
 exclude = ["controllers", "basic-auth"]
+
+[patch.crates-io]
+trillium-http-types = { git = "https://github.com/jbr/http-types", branch = "trillium" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,6 @@ members = [
 ]
 exclude = ["controllers", "basic-auth"]
 
-[patch.crates-io]
-trillium-http-types = { git = "https://github.com/jbr/http-types", branch = "trillium" }
+[patch.crates-io.trillium-http-types]
+git = "https://github.com/trillim-rs/trillium-http-types"
+branch = "trillium"

--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -53,7 +53,7 @@ pub trait AskamaConnExt {
 impl AskamaConnExt for trillium::Conn {
     fn render(self, template: impl Template) -> Self {
         let text = template.render().unwrap();
-        let mut body = Body::from_string(text);
+        let mut body = Body::from(text);
         if let Some(extension) = template.extension() {
             if let Some(mime) = mime_db::lookup(extension) {
                 body.set_mime(mime);

--- a/aws-lambda-example/Cargo.toml
+++ b/aws-lambda-example/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 trillium-aws-lambda = { path = "../aws-lambda" }
 lamedh_runtime = "0.3.0"
-serde_json = "1.0.64"
+serde_json = "1.0.66"
 env_logger = "0.9.0"
 trillium = { path = "../trillium" }
 trillium-router = { path = "../router" }

--- a/aws-lambda/Cargo.toml
+++ b/aws-lambda/Cargo.toml
@@ -17,13 +17,16 @@ lamedh_runtime = "0.3.0"
 log = "0.4.14"
 serde = "1.0.126"
 serde_derive = "1.0.126"
-serde_json = "1.0.64"
-tokio = { version = "1.8.2", features = ["rt", "net", "rt-multi-thread"], package = "tokio" }
+serde_json = "1.0.66"
 trillium = { path = "../trillium", version = "^0.1.0" }
 trillium-http = { path = "../http", version = "^0.1.0" }
 
+[dependencies.tokio]
+version = "1.9.0"
+features = ["rt", "net", "rt-multi-thread"]
+package = "tokio"
+
 [dependencies.http-types]
 version = "0.0.4"
-default-features = false
 features = ["serde"]
 package = "trillium-http-types"

--- a/aws-lambda/Cargo.toml
+++ b/aws-lambda/Cargo.toml
@@ -23,7 +23,7 @@ trillium = { path = "../trillium", version = "^0.1.0" }
 trillium-http = { path = "../http", version = "^0.1.0" }
 
 [dependencies.http-types]
-version = "0.0.3"
+version = "0.0.4"
 default-features = false
 features = ["serde"]
 package = "trillium-http-types"

--- a/aws-lambda/src/request.rs
+++ b/aws-lambda/src/request.rs
@@ -40,7 +40,7 @@ impl AlbRequest {
         let body = standardize_body(body, is_base64_encoded);
         let mut conn = HttpConn::new_synthetic(http_method, path, body);
         for (key, value) in headers {
-            conn.request_headers_mut().append(&*key, &*value);
+            conn.request_headers_mut().append(key, value);
         }
         conn
     }
@@ -81,10 +81,8 @@ impl AlbMultiHeadersRequest {
         } = self;
         let body = standardize_body(body, is_base64_encoded);
         let mut conn = HttpConn::new_synthetic(http_method, path, body);
-        for (key, values) in multi_value_headers {
-            for value in values {
-                conn.request_headers_mut().append(&*key, value);
-            }
+        for (name, values) in multi_value_headers {
+            conn.request_headers_mut().append(name, values);
         }
         conn
     }

--- a/client/src/conn.rs
+++ b/client/src/conn.rs
@@ -706,8 +706,10 @@ impl<C: Connector> Conn<'_, C> {
 
         self.status = httparse_res.code.map(|code| code.try_into().unwrap());
         for header in httparse_res.headers {
-            self.response_headers
-                .insert(header.name, std::str::from_utf8(header.value)?);
+            self.response_headers.append(
+                String::from(header.name),
+                String::from(std::str::from_utf8(header.value)?),
+            );
         }
 
         self.validate_response_headers()?;

--- a/conn-id/src/lib.rs
+++ b/conn-id/src/lib.rs
@@ -218,7 +218,8 @@ impl Handler for ConnId {
             .unwrap_or_else(|| self.generate_id());
 
         if let Some(response_header) = self.response_header {
-            conn.headers_mut().insert(response_header, &*id);
+            conn.headers_mut()
+                .insert(response_header, String::from(&*id));
         }
 
         conn.with_state(id)

--- a/handlebars/Cargo.toml
+++ b/handlebars/Cargo.toml
@@ -15,7 +15,7 @@ glob = "0.3.0"
 handlebars = { version = "4.1.0", features = ["dir_source"] }
 log = "0.4.14"
 serde = { version = "1.0.126", features = ["derive"] }
-serde_json = "1.0.64"
+serde_json = "1.0.66"
 trillium = { path = "../trillium", version = "^0.1.0" }
 
 [dev-dependencies]

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -16,11 +16,11 @@ unstable = []
 [dependencies]
 encoding_rs = "0.8.28"
 futures-lite = "1.12.0"
-http-types = { version = "0.0.4", default-features = false, package = "trillium-http-types" }
+http-types = { version = "0.0.4", package = "trillium-http-types" }
 httparse = "1.4.1"
 log = "0.4.14"
 memmem = "0.1.1"
-pin-project = "1.0.7"
+pin-project = "1.0.8"
 stopper = "0.2.0"
 thiserror = "1.0.26"
 
@@ -35,6 +35,6 @@ trillium-smol = { path = "../smol" }
 trillium-testing = { path = "../testing" }
 
 [dev-dependencies.tokio]
-version = "1.8.2"
+version = "1.9.0"
 features = ["rt", "net", "rt-multi-thread", "macros"]
 package = "tokio"

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -16,7 +16,7 @@ unstable = []
 [dependencies]
 encoding_rs = "0.8.28"
 futures-lite = "1.12.0"
-http-types = { version = "0.0.3", default-features = false, package = "trillium-http-types" }
+http-types = { version = "0.0.4", default-features = false, package = "trillium-http-types" }
 httparse = "1.4.1"
 log = "0.4.14"
 memmem = "0.1.1"

--- a/http/src/conn.rs
+++ b/http/src/conn.rs
@@ -274,7 +274,7 @@ where
 
     /// set the host for this conn
     pub fn set_host(&mut self, host: &str) {
-        self.request_headers.insert("host", host);
+        self.request_headers.insert("host", String::from(host));
     }
 
     // pub fn url(&self) -> Result<Url> {
@@ -494,8 +494,9 @@ where
         };
 
         let mut request_headers = Headers::new();
-        for header in httparse_req.headers.iter() {
-            request_headers.insert(header.name, std::str::from_utf8(header.value)?);
+        for header in httparse_req.headers {
+            let utf8 = std::str::from_utf8(header.value)?;
+            request_headers.append(String::from(header.name), String::from(utf8));
         }
 
         Self::validate_headers(&request_headers)?;

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -186,7 +186,7 @@ impl<C: Connector> Handler for Proxy<C> {
                 if name != "host" {
                     client_conn
                         .request_headers()
-                        .insert(name.as_str(), value.as_str());
+                        .insert(name.clone(), value.clone());
                 }
             }
         }
@@ -220,7 +220,7 @@ impl<C: Connector> Handler for Proxy<C> {
             Some(SwitchingProtocols) => {
                 for (name, value) in client_conn.response_headers() {
                     for value in value {
-                        conn.headers_mut().append(name.as_str(), value.as_str());
+                        conn.headers_mut().append(name.clone(), value.clone());
                     }
                 }
 
@@ -236,7 +236,7 @@ impl<C: Connector> Handler for Proxy<C> {
             Some(status) => {
                 for (name, value) in client_conn.response_headers() {
                     for value in value {
-                        conn.headers_mut().append(name.as_str(), value.as_str());
+                        conn.headers_mut().append(name.clone(), value.clone());
                     }
                 }
 

--- a/sessions/src/lib.rs
+++ b/sessions/src/lib.rs
@@ -103,7 +103,7 @@ let set_cookie_header = conn.headers_mut().get("set-cookie").unwrap().as_str();
 let cookie = Cookie::parse_encoded(set_cookie_header).unwrap();
 
 let make_request = || get("/")
-    .with_request_header(("cookie", &*format!("{}={}", cookie.name(), cookie.value())))
+    .with_request_header(("cookie", format!("{}={}", cookie.name(), cookie.value())))
     .on(&handler);
 
 assert_ok!(make_request(), "count: 1");

--- a/static/Cargo.toml
+++ b/static/Cargo.toml
@@ -23,7 +23,7 @@ cfg-if = "1.0.0"
 futures-lite = "1.12.0"
 log = "0.4.14"
 mime-db = "1.4.0"
-relative-path = "1.4.0"
+relative-path = "1.5.0"
 trillium = { path = "../trillium", version = "^0.1.0" }
 
 [dependencies.async_std_crate]
@@ -35,7 +35,7 @@ version = "1.9.0"
 features = ["fs"]
 optional = true
 package = "tokio"
-version = "1.8.2"
+version = "1.9.0"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/tera/src/tera_conn_ext.rs
+++ b/tera/src/tera_conn_ext.rs
@@ -61,7 +61,7 @@ impl TeraConnExt for Conn {
         let context = self.context();
         match self.tera().render(template_name, context) {
             Ok(string) => {
-                let mut body = Body::from_string(string);
+                let mut body = Body::from(string);
 
                 if let Some(extension) = PathBuf::from(template_name).extension() {
                     if let Some(mime) = mime_db::lookup(extension.to_string_lossy()) {

--- a/tls-common/Cargo.toml
+++ b/tls-common/Cargo.toml
@@ -12,5 +12,5 @@ categories = ["web-programming::http-server", "web-programming"]
 
 [dependencies]
 futures-lite = "1.12.0"
-async-trait = "0.1.50"
+async-trait = "0.1.51"
 url = "2.2.2"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -19,7 +19,7 @@ trillium-http = { path = "../http", version = "^0.1.0" }
 trillium-server-common = { path = "../server-common", version = "^0.2.0" }
 
 [dependencies.tokio]
-version = "1.8.2"
+version = "1.9.0"
 features = ["rt", "net", "rt-multi-thread", "time"]
 package = "tokio"
 
@@ -29,5 +29,5 @@ signal-hook-tokio = { version = "0.3.0", features = ["futures-v0_3"] }
 
 [dev-dependencies]
 env_logger = "0.9.0"
-tokio = { version = "1.8.2", features = ["full"], package = "tokio" }
+tokio = { version = "1.9.0", features = ["full"], package = "tokio" }
 trillium-testing = { path = "../testing" }

--- a/trillium/Cargo.toml
+++ b/trillium/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["trillium", "framework", "async"]
 categories = ["web-programming::http-server", "web-programming"]
 
 [dependencies]
-async-trait = "0.1.50"
+async-trait = "0.1.51"
 futures-lite = "1.12.0"
 log = "0.4.14"
 trillium-http = { path = "../http", version = "^0.1.5" }

--- a/trillium/examples/simple.rs
+++ b/trillium/examples/simple.rs
@@ -1,0 +1,3 @@
+fn main() {
+    trillium_smol::run("hello")
+}

--- a/trillium/src/handler.rs
+++ b/trillium/src/handler.rs
@@ -291,7 +291,7 @@ where
 #[async_trait]
 impl Handler for String {
     async fn run(&self, conn: Conn) -> Conn {
-        conn.ok(&self[..])
+        conn.ok(self.clone())
     }
 }
 

--- a/websockets/Cargo.toml
+++ b/websockets/Cargo.toml
@@ -17,11 +17,11 @@ json = ["serde_json"]
 async-dup = "1.2.2"
 async-tungstenite = "0.14.0"
 base64 = "0.13.0"
-futures-util = "0.3.15"
+futures-util = "0.3.16"
 log = "0.4.14"
-pin-project = "1.0.7"
+pin-project = "1.0.8"
 serde = "1.0.126"
-serde_json = { version = "1.0.64", optional = true }
+serde_json = { version = "1.0.66", optional = true }
 sha-1 = "0.9.7"
 stopper = "0.2.0"
 trillium = { path = "../trillium", version = "^0.1.0" }


### PR DESCRIPTION
draft until trillium-http-types 0.0.4 is published and patch.crates-io is removed