### PR TITLE
trillium patch feature: add trillium::init

### DIFF
--- a/trillium/src/init.rs
+++ b/trillium/src/init.rs
@@ -164,3 +164,13 @@ impl<T: Handler> Handler for Init<T> {
         }
     }
 }
+
+/// alias for [`Init::new`]
+pub fn init<T, F, Fut>(init: F) -> Init<T>
+where
+    F: Fn(Info) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = T> + Send + 'static,
+    T: Handler,
+{
+    Init::new(init)
+}

--- a/trillium/src/lib.rs
+++ b/trillium/src/lib.rs
@@ -61,4 +61,4 @@ mod info;
 pub use info::Info;
 
 mod init;
-pub use init::Init;
+pub use init::{init, Init};


### PR DESCRIPTION
as an alias for `trillium::Init::new`, for consistency with `trillium::state` as an alias for `trililum::State::new`