### PR TITLE
tera: Attempt to obtain mutable reference.

### DIFF
--- a/tera/src/tera_handler.rs
+++ b/tera/src/tera_handler.rs
@@ -75,6 +75,12 @@ impl TeraHandler {
     pub(crate) fn tera(&self) -> &Tera {
         &*self.0
     }
+
+    /// Attempts to obtain a mutable reference to the Tera instance
+    /// See [`Arc::get_mut`] for more information.
+    pub fn tera_mut(&mut self) -> Option<&mut Tera> {
+        Arc::get_mut(&mut self.0)
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
I've come into a situation where I need to call [`Tera::full_reload`](https://docs.rs/tera/latest/tera/struct.Tera.html#method.full_reload) so I can reload templates in a development environment (versus respawning this application). I'm not sure if allowing for a `From<Arc<Tera>> for TeraHandler` would have helped here (because then I can control the instance of Tera being used (to a degree).

I know I opened this up as a PR versus going into discussions—mainly because it seemed simple enough. However, I can't get this imported into my project locally so I wasn't able to fully test this.