### PR TITLE
fix failing docs build for testing & static

### DIFF
--- a/caching-headers/Cargo.toml
+++ b/caching-headers/Cargo.toml
@@ -17,6 +17,6 @@ trillium = { path = "../trillium", version = "^0.2.0" }
 
 [dev-dependencies]
 trillium-smol = { path = "../smol" }
-trillium-static = { path = "../static" }
+trillium-static = { path = "../static", features = ["smol"] }
 
 [features]

--- a/static/Cargo.toml
+++ b/static/Cargo.toml
@@ -10,6 +10,9 @@ readme = "../README.md"
 keywords = ["trillium", "framework", "async"]
 categories = ["web-programming::http-server", "web-programming"]
 
+[package.metadata.docs.rs]
+features = ["smol"]
+
 [features]
 async-std = ["async_std_crate"]
 default = []

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -10,6 +10,9 @@ readme = "../README.md"
 keywords = ["trillium", "framework", "testing"]
 categories = ["web-programming::http-server", "web-programming"]
 
+[package.metadata.docs.rs]
+features = ["smol"]
+
 [features]
 tokio = ["trillium-tokio"]
 smol = ["trillium-smol"]

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -42,21 +42,21 @@ assert_response!(
 ```toml
 [dev-dependencies]
 # ...
-trillium-testing = { version = "0.2", , features = ["tokio"] }
+trillium-testing = { version = "0.2", features = ["tokio"] }
 ```
 
 ### Async-std:
 ```toml
 [dev-dependencies]
 # ...
-trillium-testing = { version = "0.2", , features = ["async-std"] }
+trillium-testing = { version = "0.2", features = ["async-std"] }
 ```
 
 ### Smol:
 ```toml
 [dev-dependencies]
 # ...
-trillium-testing = { version = "0.2", , features = ["smol"] }
+trillium-testing = { version = "0.2", features = ["smol"] }
 ```
 
 


### PR DESCRIPTION
Enable smol as runtime for docs.rs builds, issue #202 

I took the liberty to also:
- Fix minor documentation error in testing
- Enable smol feature for static in caching headers

Should I update crate versions as well?