### PR TITLE
Upgrade `size` dependency to 0.4

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -19,7 +19,7 @@ futures-lite = "1.12.0"
 httparse = "1.5.1"
 log = "0.4.14"
 memmem = "0.1.1"
-size = "0.3.0"
+size = "0.4.0"
 trillium-tls-common = { path = "../tls-common", version = "^0.1.0" }
 url = "2.2.2"
 mime = "0.3.16"

--- a/client/src/conn.rs
+++ b/client/src/conn.rs
@@ -896,8 +896,10 @@ impl<C: Connector> AsRef<C::Transport> for Conn<'_, C> {
 }
 
 fn bytes(bytes: u64) -> String {
-    use size::{Base, Size, Style};
-    Size::to_string(&Size::Bytes(bytes), Base::Base10, Style::Smart)
+    use size::{Base, Size};
+    Size::from_bytes(bytes).format()
+        .with_base(Base::Base10)
+        .to_string()
 }
 
 impl<C: Connector> Drop for Conn<'_, C> {

--- a/client/src/conn.rs
+++ b/client/src/conn.rs
@@ -897,7 +897,8 @@ impl<C: Connector> AsRef<C::Transport> for Conn<'_, C> {
 
 fn bytes(bytes: u64) -> String {
     use size::{Base, Size};
-    Size::from_bytes(bytes).format()
+    Size::from_bytes(bytes)
+        .format()
         .with_base(Base::Base10)
         .to_string()
 }

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -15,7 +15,7 @@ atty = "0.2.14"
 chrono = "0.4.19"
 colored = "2.0.0"
 log = "0.4.14"
-size = "0.3.0"
+size = "0.4.0"
 trillium = { path = "../trillium", version = "^0.2.0" }
 
 [dev-dependencies]

--- a/logger/src/formatters.rs
+++ b/logger/src/formatters.rs
@@ -191,8 +191,13 @@ is no response body. see [`bytes`] for the raw number of bytes
 */
 pub fn body_len_human(conn: &Conn, _color: bool) -> Cow<'static, str> {
     conn.response_len()
-        .map(|l| Size::from_bytes(l).format()
-            .with_base(Base::Base10).to_string().into())
+        .map(|l| {
+            Size::from_bytes(l)
+                .format()
+                .with_base(Base::Base10)
+                .to_string()
+                .into()
+        })
         .unwrap_or_else(|| Cow::from("-"))
 }
 

--- a/logger/src/formatters.rs
+++ b/logger/src/formatters.rs
@@ -1,7 +1,7 @@
 use crate::LogFormatter;
 use chrono::Local;
 use colored::{ColoredString, Colorize};
-use size::{Base, Size, Style};
+use size::{Base, Size};
 use std::{borrow::Cow, fmt::Display, sync::Arc, time::Instant};
 use trillium::{Conn, Method, Status, Version};
 
@@ -191,7 +191,8 @@ is no response body. see [`bytes`] for the raw number of bytes
 */
 pub fn body_len_human(conn: &Conn, _color: bool) -> Cow<'static, str> {
     conn.response_len()
-        .map(|l| Size::to_string(&Size::Bytes(l), Base::Base10, Style::Smart).into())
+        .map(|l| Size::from_bytes(l).format()
+            .with_base(Base::Base10).to_string().into())
         .unwrap_or_else(|| Cow::from("-"))
 }
 

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["web-programming::http-server", "web-programming"]
 [dependencies]
 full-duplex-async-copy = "0.1.0"
 log = "0.4.14"
-size = "0.3.0"
+size = "0.4.0"
 trillium = { path = "../trillium", version = "^0.2.0"}
 trillium-client = { path = "../client", version = "^0.2.0"}
 trillium-http = { path = "../http", version = "^0.2.0" }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -17,7 +17,7 @@ http reverse proxy trillium handler
 */
 
 use full_duplex_async_copy::full_duplex_copy;
-use size::{Base, Size, Style};
+use size::{Base, Size};
 use std::convert::TryInto;
 use trillium::{
     async_trait, conn_try, Conn, Handler, KnownHeaderName,
@@ -260,5 +260,7 @@ impl<C: Connector> Handler for Proxy<C> {
 }
 
 fn bytes(bytes: u64) -> String {
-    Size::to_string(&Size::Bytes(bytes), Base::Base10, Style::Smart)
+    Size::from_bytes(bytes).format()
+        .with_base(Base::Base10)
+        .to_string()
 }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -260,7 +260,8 @@ impl<C: Connector> Handler for Proxy<C> {
 }
 
 fn bytes(bytes: u64) -> String {
-    Size::from_bytes(bytes).format()
+    Size::from_bytes(bytes)
+        .format()
         .with_base(Base::Base10)
         .to_string()
 }


### PR DESCRIPTION
To prevent future breakage, the `size` crate now uses the builder pattern for
formatting sizes as strings instead of taking hard-coded parameters for the
various knobs and settings.

This lets you also only set the settings you wish to override (Base2 to Base10).

(I'm not expecting any more breaking changes and apologize for the churn!)