### PR TITLE
trillium bugfix: initialize the handler returned from `trillium::init`

### DIFF
--- a/trillium/src/init.rs
+++ b/trillium/src/init.rs
@@ -137,7 +137,11 @@ impl<T: Handler> Handler for Init<T> {
 
     async fn init(&mut self, info: &mut Info) {
         self.0 = match mem::replace(&mut self.0, Inner::Initializing) {
-            Inner::New(init) => Inner::Initialized(init(info.clone()).await),
+            Inner::New(init) => {
+                let mut initialized = init(info.clone()).await;
+                initialized.init(info).await;
+                Inner::Initialized(initialized)
+            }
             other => other,
         }
     }


### PR DESCRIPTION
Previous to this pr, the `init` hook was not recursively called on handlers returned from `trillium::init`/`trillium::Init::new`. For example, a logger returned from `init` would not emit an initial hello message.