### PR TITLE
Logger: use time crate instead of chrono

### DIFF
--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -12,14 +12,17 @@ categories = ["web-programming::http-server", "web-programming"]
 
 [dependencies]
 atty = "0.2.14"
-chrono = "0.4.24"
 colored = "2.0.0"
 log = "0.4.17"
 size = "0.4.1"
+time = { version = "0.3.20", features = ["local-offset", "formatting", "macros"] }
 trillium = { path = "../trillium", version = "^0.2.0" }
 
 [dev-dependencies]
+access_log_parser = "0.8.0"
 trillium-smol = { path = "../smol" }
+trillium-testing = { path = "../testing" }
+trillium-http = { path = "../http", features = ["http-compat"] }
 
 [package.metadata.cargo-udeps.ignore]
 development = ["trillium-testing"]

--- a/logger/src/formatters.rs
+++ b/logger/src/formatters.rs
@@ -224,7 +224,7 @@ mod timestamp_mod {
     // apache time format is 10/Oct/2000:13:55:36 -0700
     impl Display for Now {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            let now = OffsetDateTime::now_local().unwrap()
+            let now = OffsetDateTime::now_local().unwrap_or_else(|_| OffsetDateTime::now_utc())
                 .format(format_description!(version = 2, "[day]/[month repr:short]/[year repr:full]:[hour repr:24]:[minute]:[second] [offset_hour sign:mandatory][offset_minute]")).unwrap();
             f.write_str(&now)
         }

--- a/logger/tests/apache.rs
+++ b/logger/tests/apache.rs
@@ -34,7 +34,7 @@ fn test_apache_combined() {
     let Ok(LogEntry::CombinedLog(log)) = parse(LogType::CombinedLog, &s) else { panic!() };
     let RequestResult::Valid(request) = log.request else { panic!() };
     assert_eq!(log.ip, ip);
-    assert!(OffsetDateTime::now_local().unwrap().unix_timestamp() - log.timestamp.timestamp() < 2);
+    assert!(OffsetDateTime::now_utc().unix_timestamp() - log.timestamp.timestamp() < 2);
     assert_eq!(request.uri(), "/some/path?query");
     assert_eq!(request.method(), "GET");
     assert_eq!(log.status_code, Status::ImATeapot);
@@ -66,7 +66,7 @@ fn test_apache_common() {
     let s = s.lock().unwrap();
     let Ok(LogEntry::CommonLog(log)) = parse(LogType::CommonLog, &s) else { panic!() };
     let RequestResult::Valid(request) = log.request else { panic!() };
-    assert!(OffsetDateTime::now_local().unwrap().unix_timestamp() - log.timestamp.timestamp() < 2);
+    assert!(OffsetDateTime::now_utc().unix_timestamp() - log.timestamp.timestamp() < 2);
     assert_eq!(log.ip, ip);
     assert_eq!(request.uri(), "/some/path?query");
     assert_eq!(request.method(), "GET");

--- a/logger/tests/apache.rs
+++ b/logger/tests/apache.rs
@@ -1,0 +1,77 @@
+use access_log_parser::{parse, LogEntry, LogType, RequestResult};
+use std::sync::{Arc, Mutex};
+use time::OffsetDateTime;
+use trillium::{
+    KnownHeaderName::{Referer, UserAgent},
+    Status, Version,
+};
+use trillium_logger::{apache_combined, apache_common, logger, ColorMode};
+use trillium_testing::prelude::*;
+
+async fn teapot(conn: trillium::Conn) -> trillium::Conn {
+    conn.with_status(Status::ImATeapot).with_body("ok")
+}
+
+#[test]
+fn test_apache_combined() {
+    let s = Arc::new(Mutex::new(String::new()));
+    let logger = logger()
+        .with_formatter(apache_combined("request-id", "user"))
+        .with_target({
+            let s = s.clone();
+            move |line: String| s.lock().unwrap().push_str(&line)
+        })
+        .with_color_mode(ColorMode::Off);
+
+    let ip = "1.2.3.4".parse().unwrap();
+    let handler = (logger, teapot);
+    get("/some/path?query")
+        .with_peer_ip(ip)
+        .with_request_header(Referer, "http://example.com")
+        .with_request_header(UserAgent, "secret agent")
+        .on(&handler);
+    let s = s.lock().unwrap();
+    let Ok(LogEntry::CombinedLog(log)) = parse(LogType::CombinedLog, &s) else { panic!() };
+    let RequestResult::Valid(request) = log.request else { panic!() };
+    assert_eq!(log.ip, ip);
+    assert!(OffsetDateTime::now_local().unwrap().unix_timestamp() - log.timestamp.timestamp() < 2);
+    assert_eq!(request.uri(), "/some/path?query");
+    assert_eq!(request.method(), "GET");
+    assert_eq!(log.status_code, Status::ImATeapot);
+    assert_eq!(request.version(), Version::Http1_1);
+    assert_eq!(log.identd_user, Some("request-id"));
+    assert_eq!(log.user, Some("user"));
+    assert_eq!(log.referrer, Some("http://example.com".parse().unwrap()));
+    assert_eq!(log.user_agent, Some("secret agent"));
+}
+
+#[test]
+fn test_apache_common() {
+    let s = Arc::new(Mutex::new(String::new()));
+    let logger = logger()
+        .with_formatter(apache_common("request-id", "user"))
+        .with_target({
+            let s = s.clone();
+            move |line: String| s.lock().unwrap().push_str(&line)
+        })
+        .with_color_mode(ColorMode::Off);
+
+    let ip = "1.2.3.4".parse().unwrap();
+    let handler = (logger, teapot);
+    get("/some/path?query")
+        .with_peer_ip(ip)
+        .with_request_header(Referer, "http://example.com")
+        .with_request_header(UserAgent, "secret agent")
+        .on(&handler);
+    let s = s.lock().unwrap();
+    let Ok(LogEntry::CommonLog(log)) = parse(LogType::CommonLog, &s) else { panic!() };
+    let RequestResult::Valid(request) = log.request else { panic!() };
+    assert!(OffsetDateTime::now_local().unwrap().unix_timestamp() - log.timestamp.timestamp() < 2);
+    assert_eq!(log.ip, ip);
+    assert_eq!(request.uri(), "/some/path?query");
+    assert_eq!(request.method(), "GET");
+    assert_eq!(log.status_code, Status::ImATeapot);
+    assert_eq!(request.version(), Version::Http1_1);
+    assert_eq!(log.identd_user, Some("request-id"));
+    assert_eq!(log.user, Some("user"));
+}


### PR DESCRIPTION
also deprecate formatters::header in preference to request_header, add response_header, make both headers take `impl Into<HeaderName<'static>>`