### PR TITLE
cookies and sessions minor feature: use CookieJar and Session from state for testing purposes

### DIFF
--- a/cookies/src/cookies_handler.rs
+++ b/cookies/src/cookies_handler.rs
@@ -22,8 +22,8 @@ impl CookiesHandler {
 
 #[async_trait]
 impl Handler for CookiesHandler {
-    async fn run(&self, conn: Conn) -> Conn {
-        let mut jar = CookieJar::new();
+    async fn run(&self, mut conn: Conn) -> Conn {
+        let mut jar: CookieJar = conn.take_state().unwrap_or_default();
 
         if let Some(cookies) = conn.headers().get_values(KnownHeaderName::Cookie) {
             for cookie in cookies.iter().filter_map(HeaderValue::as_str) {

--- a/cookies/src/cookies_handler.rs
+++ b/cookies/src/cookies_handler.rs
@@ -46,9 +46,10 @@ impl Handler for CookiesHandler {
                     .map(|cookie| cookie.encoded().to_string())
                     .collect::<HeaderValues>(),
             );
+            conn.with_state(jar)
+        } else {
+            conn
         }
-
-        conn
     }
 }
 

--- a/sessions/src/session_handler.rs
+++ b/sessions/src/session_handler.rs
@@ -291,6 +291,7 @@ impl<Store: SessionStore> Handler for SessionHandler<Store> {
 
     async fn before_send(&self, mut conn: Conn) -> Conn {
         if let Some(session) = conn.take_state::<Session>() {
+            let session_to_keep = session.clone();
             let secure = conn.is_secure();
             if session.is_destroyed() {
                 self.store.destroy_session(session).await.ok();
@@ -302,9 +303,10 @@ impl<Store: SessionStore> Handler for SessionHandler<Store> {
                         .add(self.build_cookie(secure, cookie_value));
                 }
             }
+            conn.with_state(session_to_keep)
+        } else {
+            conn
         }
-
-        conn
     }
 }
 


### PR DESCRIPTION
If the conn has a CookieJar or Session previously set on it, we use that. With this change, trillium_testing::TestConn can explicitly provide a Session or CookieJar prior to the application running