### PR TITLE
Fix rustdoc syntax to avoid interpretation as HTML

### DIFF
--- a/server-common/src/acceptor.rs
+++ b/server-common/src/acceptor.rs
@@ -29,7 +29,7 @@ pub trait Acceptor<Input>: Clone + Send + Sync + 'static
 where
     Input: Transport,
 {
-    /// The stream type. For example, TlsStream<Input>
+    /// The stream type. For example, `TlsStream<Input>`
     type Output: Transport;
 
     /// An error type that [`Acceptor::accept`] may return


### PR DESCRIPTION
`TlsStream<Input>` without the backquotes lets markdown interpret
`<Input>` as HTML, which looks like this:

![image](https://github.com/trillium-rs/trillium/assets/162737/ab67a275-13dc-45cd-b95c-02e465919dfc)


