### PR TITLE
trillium-rustls: Make native root support optional

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -10,11 +10,15 @@ readme = "../README.md"
 keywords = ["trillium", "framework", "async"]
 categories = ["web-programming::http-server", "web-programming"]
 
+[features]
+default = ["native-roots"]
+native-roots = ["dep:rustls-native-certs"]
+
 [dependencies]
 async-rustls = "0.4.0"
 log = "0.4.19"
 rustls = "0.21.0"
-rustls-native-certs = "0.6.2"
+rustls-native-certs = { version = "0.6.2", optional = true }
 rustls-pemfile = "1.0.2"
 rustls-webpki = "0.100.1"
 trillium-server-common = { path = "../server-common", version = "^0.4.0" }


### PR DESCRIPTION
This avoids the extra dependencies on openssl-probe and the probe for
native certificates on a server that will never have them installed.

I made native-roots a default feature for compatibility, but in a future
breaking-change version, you might consider making it non-default.
