### PR TITLE
trillium-rustls: Make client support optional

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -11,18 +11,19 @@ keywords = ["trillium", "framework", "async"]
 categories = ["web-programming::http-server", "web-programming"]
 
 [features]
-default = ["native-roots"]
-native-roots = ["dep:rustls-native-certs"]
+default = ["client", "native-roots"]
+client = ["dep:log", "dep:rustls-webpki", "dep:webpki-roots"]
+native-roots = ["client", "dep:rustls-native-certs"]
 
 [dependencies]
 async-rustls = "0.4.0"
-log = "0.4.19"
+log = { version = "0.4.19", optional = true }
 rustls = "0.21.0"
 rustls-native-certs = { version = "0.6.2", optional = true }
 rustls-pemfile = "1.0.2"
-rustls-webpki = "0.100.1"
+rustls-webpki = { version = "0.100.1", optional = true }
 trillium-server-common = { path = "../server-common", version = "^0.4.0" }
-webpki-roots = "0.23"
+webpki-roots = { version = "0.23", optional = true }
 
 [dev-dependencies]
 env_logger = "0.10.0"

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -14,7 +14,9 @@ This crate provides rustls trait implementations for trillium
 client ([`RustlsConnector`]) and server ([`RustlsAcceptor`]).
 */
 
+#[cfg(feature = "client")]
 mod client;
+#[cfg(feature = "client")]
 pub use client::RustlsConfig;
 
 mod server;

--- a/rustls/tests/against_trillium.rs
+++ b/rustls/tests/against_trillium.rs
@@ -2,7 +2,9 @@ use std::{env::var, error::Error, fs::read, future::Future};
 use test_harness::test;
 use trillium_client::Client;
 use trillium_native_tls::{NativeTlsAcceptor, NativeTlsConfig};
-use trillium_rustls::{RustlsAcceptor, RustlsConfig};
+use trillium_rustls::RustlsAcceptor;
+#[cfg(feature = "client")]
+use trillium_rustls::RustlsConfig;
 use trillium_server_common::Url;
 use trillium_testing::{block_on, client_config, config};
 
@@ -64,6 +66,7 @@ where
     });
 }
 
+#[cfg(feature = "client")]
 pub fn rustls_client() -> Client {
     Client::new(RustlsConfig {
         rustls_config: Default::default(),
@@ -78,12 +81,14 @@ pub fn native_tls_client() -> Client {
     })
 }
 
+#[cfg(feature = "client")]
 #[test(harness = with_native_tls_server)]
 async fn rustls_client_native_tls_server(url: Url) -> Result<(), Box<dyn Error>> {
     let _ = rustls_client().get(url).await?.success()?;
     Ok(())
 }
 
+#[cfg(feature = "client")]
 #[test(harness = with_rustls_server)]
 async fn rustls_client_rustls_server(url: Url) -> Result<(), Box<dyn Error>> {
     let _ = rustls_client().get(url).await?.success()?;


### PR DESCRIPTION
Client support compiles in several crates not needed for server support.
Make client support optional to allow removing these dependencies.

Built atop https://github.com/trillium-rs/trillium/pull/373 to avoid conflicts.
