### PR TITLE
Modify `trillium_server_common::Acceptor` to return an `Option`

### DIFF
--- a/async-std/Cargo.toml
+++ b/async-std/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4.19"
 trillium = { path = "../trillium", version = "^0.2.0" }
 trillium-http = { path = "../http", version = "^0.3.0" }
 trillium-macros = { version = "0.0.4", path = "../macros" }
-trillium-server-common = { path = "../server-common", version = "^0.4.0" }
+trillium-server-common = { path = "../server-common", version = "^0.5.0" }
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = "0.3.17"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -20,7 +20,7 @@ httparse = "1.8.0"
 log = "0.4.19"
 memmem = "0.1.1"
 size = "0.4.1"
-trillium-server-common = { version = "0.4.0", path = "../server-common" }
+trillium-server-common = { version = "0.5.0", path = "../server-common" }
 url = "2.4.0"
 mime = "0.3.17"
 serde_json = { version = "1.0.104", optional = true }

--- a/native-tls/Cargo.toml
+++ b/native-tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-native-tls"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Jacob Rothstein <hi@jbr.me>"]
 edition = "2021"
 description = "native-tls adapter for trillium.rs"
@@ -13,7 +13,7 @@ categories = ["web-programming::http-server", "web-programming"]
 [dependencies]
 async-native-tls = "0.5.0"
 native-tls = "0.2.11"
-trillium-server-common = { path = "../server-common", version = "^0.4.0" }
+trillium-server-common = { path = "../server-common", version = "^0.5.0" }
 
 [dev-dependencies]
 env_logger = "0.10.0"

--- a/native-tls/src/server.rs
+++ b/native-tls/src/server.rs
@@ -70,7 +70,11 @@ where
 {
     type Output = NativeTlsTransport<Input>;
     type Error = Error;
-    async fn accept(&self, input: Input) -> Result<Self::Output, Self::Error> {
-        self.0.accept(input).await.map(NativeTlsTransport::from)
+    async fn accept(&self, input: Input) -> Result<Option<Self::Output>, Self::Error> {
+        self.0
+            .accept(input)
+            .await
+            .map(NativeTlsTransport::from)
+            .map(Some)
     }
 }

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-rustls"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Jacob Rothstein <hi@jbr.me>"]
 edition = "2021"
 description = "rustls adapter for trillium.rs"
@@ -17,7 +17,7 @@ rustls = "0.21.0"
 rustls-native-certs = "0.6.2"
 rustls-pemfile = "1.0.2"
 rustls-webpki = "0.100.1"
-trillium-server-common = { path = "../server-common", version = "^0.4.0" }
+trillium-server-common = { path = "../server-common", version = "^0.5.0" }
 webpki-roots = "0.23"
 
 [dev-dependencies]

--- a/rustls/src/server.rs
+++ b/rustls/src/server.rs
@@ -97,7 +97,11 @@ where
 {
     type Output = RustlsTransport<Input>;
     type Error = io::Error;
-    async fn accept(&self, input: Input) -> Result<Self::Output, Self::Error> {
-        self.0.accept(input).await.map(RustlsTransport::from)
+    async fn accept(&self, input: Input) -> Result<Option<Self::Output>, Self::Error> {
+        self.0
+            .accept(input)
+            .await
+            .map(RustlsTransport::from)
+            .map(Some)
     }
 }

--- a/server-common/Cargo.toml
+++ b/server-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-server-common"
-version = "0.4.4"
+version = "0.5.0"
 authors = ["Jacob Rothstein <hi@jbr.me>"]
 edition = "2021"
 description = "server utilities for trillium.rs"

--- a/server-common/src/acceptor.rs
+++ b/server-common/src/acceptor.rs
@@ -18,8 +18,8 @@ where
 {
     type Output = my_tls_impl::TlsStream<Input>;
     type Error = my_tls_impl::Error;
-    async fn accept(&self, input: Input) -> Result<Self::Output, Self::Error> {
-        self.accept(input).await
+    async fn accept(&self, input: Input) -> Result<Option<Self::Output>, Self::Error> {
+        self.accept(input).await.map(Some)
     }
 }
 ```
@@ -40,10 +40,10 @@ where
 
     Async trait signature:
     ```rust,ignore
-    async fn accept(&self, input: Input) -> Result<Self::Output, Self::Error>;
+    async fn accept(&self, input: Input) -> Result<Option<Self::Output>, Self::Error>;
     ```
     */
-    async fn accept(&self, input: Input) -> Result<Self::Output, Self::Error>;
+    async fn accept(&self, input: Input) -> Result<Option<Self::Output>, Self::Error>;
 }
 
 #[async_trait]
@@ -53,7 +53,7 @@ where
 {
     type Output = Input;
     type Error = Infallible;
-    async fn accept(&self, input: Input) -> Result<Self::Output, Self::Error> {
-        Ok(input)
+    async fn accept(&self, input: Input) -> Result<Option<Self::Output>, Self::Error> {
+        Ok(Some(input))
     }
 }

--- a/server-common/src/config_ext.rs
+++ b/server-common/src/config_ext.rs
@@ -160,7 +160,8 @@ where
         let peer_ip = stream.peer_addr().ok().flatten().map(|addr| addr.ip());
 
         let stream = match self.acceptor.accept(stream).await {
-            Ok(stream) => stream,
+            Ok(Some(stream)) => stream,
+            Ok(None) => return,
             Err(e) => {
                 log::error!("acceptor error: {:?}", e);
                 return;

--- a/smol/Cargo.toml
+++ b/smol/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4.19"
 trillium = { path = "../trillium", version = "^0.2.0" }
 trillium-http = { path = "../http", version = "^0.3.0" }
 trillium-macros = { version = "0.0.4", path = "../macros" }
-trillium-server-common = { path = "../server-common", version = "^0.4.0" }
+trillium-server-common = { path = "../server-common", version = "^0.5.0" }
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = "0.3.17"

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -25,7 +25,7 @@ futures-lite = "1.13.0"
 portpicker = "0.1.1"
 trillium = { path = "../trillium", version = "^0.2.0" }
 trillium-http = { path = "../http", version = "^0.3.0" }
-trillium-server-common = { path = "../server-common", version = "^0.4.0" }
+trillium-server-common = { path = "../server-common", version = "^0.5.0" }
 cfg-if = "1.0.0"
 url = "2.4.0"
 async-channel = "1.9.0"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -17,7 +17,7 @@ tokio-stream = { version = "0.1.14", features = ["net"] }
 trillium = { path = "../trillium", version = "^0.2.0" }
 trillium-http = { path = "../http", version = "^0.3.0" }
 trillium-macros = { version = "0.0.4", path = "../macros" }
-trillium-server-common = { path = "../server-common", version = "^0.4.0" }
+trillium-server-common = { path = "../server-common", version = "^0.5.0" }
 
 [dependencies.tokio]
 version = "1.29.1"


### PR DESCRIPTION
This allows an `Acceptor` to handle some connections entirely internally
and not produce a stream to handle requests from.
