### PR TITLE
http patch: only buffer the top of the response

### DIFF
--- a/http/src/bufwriter.rs
+++ b/http/src/bufwriter.rs
@@ -53,11 +53,6 @@ impl<W: AsyncWrite + Unpin> BufWriter<W> {
             }
         }
 
-        if *written > 0 {
-            buf.drain(..*written);
-        }
-        *written = 0;
-
         Poll::Ready(ret)
     }
 }


### PR DESCRIPTION
when we hit the buffer's capacity, transparently write to the inner AsyncWrite

this retains the substantial performance benefit of #397 for short responses but eliminates the slight performance regression introduced by that pr for longer bodies