### PR TITLE
http bugfix: address theoretical memory leak in after_send caused by std::mem::forget

### DIFF
--- a/http/src/conn.rs
+++ b/http/src/conn.rs
@@ -186,11 +186,7 @@ where
         }
 
         bufwriter.flush().await?;
-
-        let mut after_send = std::mem::take(&mut self.after_send);
-        after_send.call(true.into());
-        std::mem::forget(after_send);
-
+        self.after_send.call(true.into());
         self.finish().await
     }
 


### PR DESCRIPTION
I have been unable to observe this actually leaking memory under any instrumentation, but the documentation for std::mem::forget indicates that it could/should leak.

As of this PR there is zero usage of std::mem::forget in trillium.