### PR TITLE
move tunable numeric literals into a HttpConfig struct

### DIFF
--- a/http/src/synthetic.rs
+++ b/http/src/synthetic.rs
@@ -1,10 +1,13 @@
 use crate::{
-    conn::AfterSend, received_body::ReceivedBodyState, transport::Transport, Conn, Headers,
-    KnownHeaderName, Method, StateSet, Stopper, Version,
+    conn::{AfterSend, HttpConfig},
+    received_body::ReceivedBodyState,
+    transport::Transport,
+    Conn, Headers, KnownHeaderName, Method, StateSet, Stopper, Version,
 };
 use futures_lite::io::{AsyncRead, AsyncWrite, Result};
 use std::{
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
     time::Instant,
 };
@@ -140,6 +143,7 @@ impl Conn<Synthetic> {
             after_send: AfterSend::default(),
             start_time: Instant::now(),
             peer_ip: None,
+            http_config: Arc::new(HttpConfig::default()),
         }
     }
 


### PR DESCRIPTION
this doesn't yet expose the config, but makes that possible in a future change