### PR TITLE
Bugfix: add a default limiter to received request bodies

### DIFF
--- a/http/src/after_send.rs
+++ b/http/src/after_send.rs
@@ -1,0 +1,50 @@
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum SendStatus {
+    Success,
+    Failure,
+}
+impl From<bool> for SendStatus {
+    fn from(success: bool) -> Self {
+        if success {
+            Self::Success
+        } else {
+            Self::Failure
+        }
+    }
+}
+
+impl SendStatus {
+    pub fn is_success(self) -> bool {
+        SendStatus::Success == self
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct AfterSend(Option<Box<dyn FnOnce(SendStatus) + Send + Sync + 'static>>);
+
+impl AfterSend {
+    pub(crate) fn call(&mut self, send_status: SendStatus) {
+        if let Some(after_send) = self.0.take() {
+            after_send(send_status);
+        }
+    }
+
+    pub(crate) fn append<F>(&mut self, after_send: F)
+    where
+        F: FnOnce(SendStatus) + Send + Sync + 'static,
+    {
+        self.0 = Some(match self.0.take() {
+            Some(existing_after_send) => Box::new(move |ss| {
+                existing_after_send(ss);
+                after_send(ss);
+            }),
+            None => Box::new(after_send),
+        });
+    }
+}
+
+impl Drop for AfterSend {
+    fn drop(&mut self) {
+        self.call(SendStatus::Failure);
+    }
+}

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -80,10 +80,16 @@ pub enum Error {
     #[error("unexpected header: {0}")]
     UnexpectedHeader(&'static str),
 
-    /// for security reasons, we do not allow request headers beyond
-    /// 8kb.
-    #[error("Head byte length should be less than 8kb")]
+    /// to mitigate against malicious http clients, we do not allow request headers beyond this
+    /// length.
+    #[error("Headers were malformed or longer than allowed")]
     HeadersTooLong,
+
+    /// to mitigate against malicious http clients, we do not read received bodies beyond this
+    /// length to memory. If you need to receive longer bodies, use the Stream or AsyncRead
+    /// implementation on ReceivedBody
+    #[error("Received body too long. Maximum {0} bytes")]
+    ReceivedBodyTooLong(u64),
 }
 
 /// this crate's result type

--- a/http/src/http_config.rs
+++ b/http/src/http_config.rs
@@ -1,0 +1,67 @@
+#![allow(dead_code)]
+
+#[derive(Clone, Copy, Debug)]
+pub struct HttpConfig {
+    pub(crate) write_buffer_len: usize,
+    pub(crate) read_buffer_len: usize,
+    pub(crate) max_head_len: usize,
+    pub(crate) max_headers: usize,
+    pub(crate) initial_header_capacity: usize,
+    pub(crate) copy_loops_per_yield: usize,
+    pub(crate) received_body_max_len: u64,
+    pub(crate) received_body_initial_len: usize,
+}
+
+impl HttpConfig {
+    pub(crate) fn with_write_buffer_len(mut self, write_buffer_len: usize) -> Self {
+        self.write_buffer_len = write_buffer_len;
+        self
+    }
+
+    pub(crate) fn with_read_buffer_len(mut self, read_buffer_len: usize) -> Self {
+        self.read_buffer_len = read_buffer_len;
+        self
+    }
+
+    pub(crate) fn with_max_head_len(mut self, max_head_len: usize) -> Self {
+        self.max_head_len = max_head_len;
+        self
+    }
+
+    pub(crate) fn with_max_headers(mut self, max_headers: usize) -> Self {
+        self.max_headers = max_headers;
+        self
+    }
+
+    pub(crate) fn with_initial_header_capacity(mut self, initial_header_capacity: usize) -> Self {
+        self.initial_header_capacity = initial_header_capacity;
+        self
+    }
+
+    pub(crate) fn with_copy_loops_per_yield(mut self, copy_loops_per_yield: usize) -> Self {
+        self.copy_loops_per_yield = copy_loops_per_yield;
+        self
+    }
+
+    pub(crate) fn with_received_body_max_len(mut self, received_body_max_len: u64) -> Self {
+        self.received_body_max_len = received_body_max_len;
+        self
+    }
+}
+
+impl Default for HttpConfig {
+    fn default() -> Self {
+        DEFAULT_CONFIG
+    }
+}
+
+pub const DEFAULT_CONFIG: HttpConfig = HttpConfig {
+    write_buffer_len: 512,
+    read_buffer_len: 128,
+    max_head_len: 8 * 1024,
+    max_headers: 128,
+    initial_header_capacity: 16,
+    copy_loops_per_yield: 16,
+    received_body_max_len: 524_288_000u64,
+    received_body_initial_len: 128,
+};

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -135,3 +135,8 @@ pub(crate) use copy::copy;
 
 mod bufwriter;
 pub(crate) use bufwriter::BufWriter;
+
+mod http_config;
+pub(crate) use http_config::HttpConfig;
+
+pub(crate) mod after_send;

--- a/http/src/received_body/tests.rs
+++ b/http/src/received_body/tests.rs
@@ -1,0 +1,3 @@
+use super::*;
+mod chunked;
+mod fixed_length;

--- a/http/src/received_body/tests/chunked.rs
+++ b/http/src/received_body/tests/chunked.rs
@@ -1,0 +1,220 @@
+use super::{chunk_decode, ReceivedBody, ReceivedBodyState};
+use crate::{http_config::DEFAULT_CONFIG, HttpConfig};
+use encoding_rs::UTF_8;
+use futures_lite::{io::Cursor, AsyncRead, AsyncReadExt};
+use trillium_testing::block_on;
+
+fn assert_decoded(
+    (remaining, input_data): (u64, &str),
+    expected_output: (Option<u64>, &str, Option<&str>),
+) {
+    let mut buf = input_data.to_string().into_bytes();
+
+    let (output_state, bytes, unused) = chunk_decode(
+        remaining,
+        0,
+        0,
+        &mut buf,
+        DEFAULT_CONFIG.received_body_max_len,
+    )
+    .unwrap();
+
+    assert_eq!(
+        (
+            match output_state {
+                ReceivedBodyState::Chunked { remaining, .. } => Some(remaining),
+                ReceivedBodyState::End => None,
+                _ => panic!("unexpected output state {output_state:?}"),
+            },
+            &*String::from_utf8_lossy(&buf[0..bytes]),
+            unused.as_deref().map(String::from_utf8_lossy).as_deref()
+        ),
+        expected_output
+    );
+}
+
+async fn read_with_buffers_of_size<R>(reader: &mut R, size: usize) -> crate::Result<String>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut return_buffer = vec![];
+    loop {
+        let mut buf = vec![0; size];
+        match reader.read(&mut buf).await? {
+            0 => break Ok(String::from_utf8_lossy(&return_buffer).into()),
+            bytes_read => return_buffer.extend_from_slice(&buf[..bytes_read]),
+        }
+    }
+}
+
+fn new_with_config(input: String, config: &HttpConfig) -> ReceivedBody<'_, Cursor<String>> {
+    ReceivedBody::new_with_config(
+        None,
+        None,
+        Cursor::new(input),
+        ReceivedBodyState::Start,
+        None,
+        UTF_8,
+        config,
+    )
+}
+
+async fn decode_with_config(
+    input: String,
+    poll_size: usize,
+    config: &HttpConfig,
+) -> crate::Result<String> {
+    let mut rb = new_with_config(input, config);
+    read_with_buffers_of_size(&mut rb, poll_size).await
+}
+
+async fn decode(input: String, poll_size: usize) -> crate::Result<String> {
+    decode_with_config(input, poll_size, &DEFAULT_CONFIG).await
+}
+
+#[test]
+fn test_full_decode() {
+    block_on(async {
+        for size in 3..50 {
+            let input = "5\r\n12345\r\n1\r\na\r\n2\r\nbc\r\n3\r\ndef\r\n0\r\n";
+            let output = decode(input.into(), size).await.unwrap();
+            assert_eq!(output, "12345abcdef", "size: {size}");
+
+            let input = "7\r\nMozilla\r\n9\r\nDeveloper\r\n7\r\nNetwork\r\n0\r\n\r\n";
+            let output = decode(input.into(), size).await.unwrap();
+            assert_eq!(output, "MozillaDeveloperNetwork", "size: {size}");
+
+            assert!(decode(String::new(), size).await.is_err());
+        }
+    });
+}
+
+async fn build_chunked_body(input: String) -> String {
+    let mut output = Vec::with_capacity(10);
+    let len = crate::copy(
+        crate::Body::new_streaming(Cursor::new(input), None),
+        &mut output,
+        16,
+    )
+    .await
+    .unwrap();
+
+    output.truncate(len.try_into().unwrap());
+    String::from_utf8(output).unwrap()
+}
+
+#[test]
+fn test_read_buffer_too_short() {
+    block_on(async {
+        let input = "test ".repeat(50);
+        let chunked = build_chunked_body(input.clone()).await;
+        assert!(chunked.starts_with("FA\r\n"));
+
+        for size in 1..4 {
+            assert!(decode(chunked.clone(), size).await.is_err());
+        }
+
+        for size in 4..10 {
+            assert_eq!(&decode(chunked.clone(), size).await.unwrap(), &input);
+        }
+    });
+}
+
+#[test]
+fn test_max_len() {
+    block_on(async {
+        let input = build_chunked_body("test ".repeat(10)).await;
+
+        for size in 4..10 {
+            assert!(decode_with_config(
+                input.clone(),
+                size,
+                &HttpConfig::default().with_received_body_max_len(5)
+            )
+            .await
+            .is_err());
+
+            assert!(
+                decode_with_config(input.clone(), size, &HttpConfig::default())
+                    .await
+                    .is_ok()
+            );
+        }
+    });
+}
+
+#[test]
+fn test_chunk_start() {
+    assert_decoded((0, "5\r\n12345\r\n"), (Some(0), "12345", None));
+    assert_decoded((0, "F\r\n1"), (Some(14 + 2), "1", None));
+    assert_decoded((0, "5\r\n123"), (Some(2 + 2), "123", None));
+    assert_decoded((0, "1\r\nX\r\n1\r\nX\r\n"), (Some(0), "XX", None));
+    assert_decoded((0, "1\r\nX\r\n1\r\nX\r\n1"), (Some(0), "XX", Some("1")));
+    assert_decoded((0, "FFF\r\n"), (Some(0xfff + 2), "", None));
+    assert_decoded((10, "hello"), (Some(5), "hello", None));
+    assert_decoded(
+        (7, "hello\r\nA\r\n world"),
+        (Some(4 + 2), "hello world", None),
+    );
+    assert_decoded(
+        (0, "e\r\ntest test test\r\n0\r\n\r\n"),
+        (None, "test test test", None),
+    );
+    assert_decoded(
+        (0, "1\r\n_\r\n0\r\n\r\nnext request"),
+        (None, "_", Some("next request")),
+    );
+    assert_decoded((7, "hello\r\n0\r\n\r\n"), (None, "hello", None));
+}
+
+#[test]
+fn read_string_and_read_bytes() {
+    block_on(async {
+        let content = build_chunked_body("test ".repeat(100)).await;
+        assert_eq!(
+            new_with_config(content.clone(), &DEFAULT_CONFIG)
+                .read_string()
+                .await
+                .unwrap()
+                .len(),
+            500
+        );
+
+        assert_eq!(
+            new_with_config(content.clone(), &DEFAULT_CONFIG)
+                .read_bytes()
+                .await
+                .unwrap()
+                .len(),
+            500
+        );
+
+        assert!(new_with_config(
+            content.clone(),
+            &DEFAULT_CONFIG.with_received_body_max_len(400)
+        )
+        .read_string()
+        .await
+        .is_err());
+
+        assert!(new_with_config(
+            content.clone(),
+            &DEFAULT_CONFIG.with_received_body_max_len(400)
+        )
+        .read_bytes()
+        .await
+        .is_err());
+
+        assert!(new_with_config(content.clone(), &DEFAULT_CONFIG)
+            .with_max_len(400)
+            .read_bytes()
+            .await
+            .is_err());
+
+        assert!(new_with_config(content.clone(), &DEFAULT_CONFIG)
+            .with_max_len(400)
+            .read_string()
+            .await
+            .is_err());
+    });
+}

--- a/http/src/received_body/tests/fixed_length.rs
+++ b/http/src/received_body/tests/fixed_length.rs
@@ -1,0 +1,115 @@
+use super::{ReceivedBody, ReceivedBodyState};
+use crate::{http_config::DEFAULT_CONFIG, HttpConfig};
+use encoding_rs::UTF_8;
+use futures_lite::{future::block_on, io::Cursor, AsyncRead, AsyncReadExt};
+
+fn new_with_config(input: String, config: &HttpConfig) -> ReceivedBody<'static, Cursor<String>> {
+    ReceivedBody::new_with_config(
+        Some(input.len() as u64),
+        None,
+        Cursor::new(input),
+        ReceivedBodyState::Start,
+        None,
+        UTF_8,
+        config,
+    )
+}
+
+fn decode_with_config(
+    input: String,
+    poll_size: usize,
+    config: &HttpConfig,
+) -> crate::Result<String> {
+    let mut rb = new_with_config(input, config);
+
+    block_on(read_with_buffers_of_size(&mut rb, poll_size))
+}
+
+async fn read_with_buffers_of_size<R>(reader: &mut R, size: usize) -> crate::Result<String>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut return_buffer = vec![];
+    loop {
+        let mut buf = vec![0; size];
+        match reader.read(&mut buf).await? {
+            0 => break Ok(String::from_utf8_lossy(&return_buffer).into()),
+            bytes_read => return_buffer.extend_from_slice(&buf[..bytes_read]),
+        }
+    }
+}
+
+#[test]
+fn test() {
+    for size in 3..50 {
+        let input = "12345abcdef";
+        let output = decode_with_config(input.into(), size, &DEFAULT_CONFIG).unwrap();
+        assert_eq!(output, "12345abcdef", "size: {size}");
+
+        let input = "MozillaDeveloperNetwork";
+        let output = decode_with_config(input.into(), size, &DEFAULT_CONFIG).unwrap();
+        assert_eq!(output, "MozillaDeveloperNetwork", "size: {size}");
+
+        assert!(decode_with_config(String::new(), size, &DEFAULT_CONFIG).is_ok());
+
+        let input = "MozillaDeveloperNetwork";
+        assert!(decode_with_config(
+            input.into(),
+            size,
+            &DEFAULT_CONFIG.with_received_body_max_len(5)
+        )
+        .is_err());
+    }
+}
+
+#[test]
+fn read_string_and_read_bytes() {
+    block_on(async {
+        let content = "test ".repeat(1000);
+        assert_eq!(
+            new_with_config(content.clone(), &DEFAULT_CONFIG)
+                .read_string()
+                .await
+                .unwrap()
+                .len(),
+            5000
+        );
+
+        assert_eq!(
+            new_with_config(content.clone(), &DEFAULT_CONFIG)
+                .read_bytes()
+                .await
+                .unwrap()
+                .len(),
+            5000
+        );
+
+        assert!(new_with_config(
+            content.clone(),
+            &DEFAULT_CONFIG.with_received_body_max_len(750)
+        )
+        .read_string()
+        .await
+        .is_err());
+
+        assert!(new_with_config(
+            content.clone(),
+            &DEFAULT_CONFIG.with_received_body_max_len(750)
+        )
+        .read_bytes()
+        .await
+        .is_err());
+
+        assert!(new_with_config(content.clone(), &DEFAULT_CONFIG)
+            .with_max_len(750)
+            .read_bytes()
+            .await
+            .is_err());
+
+        assert!(new_with_config(content.clone(), &DEFAULT_CONFIG)
+            .with_max_len(750)
+            .read_string()
+            .await
+            .is_err());
+    });
+}

--- a/http/src/synthetic.rs
+++ b/http/src/synthetic.rs
@@ -1,10 +1,13 @@
 use crate::{
-    conn::AfterSend, received_body::ReceivedBodyState, transport::Transport, Conn, Headers,
-    KnownHeaderName, Method, StateSet, Stopper, Version,
+    conn::{AfterSend, HttpConfig},
+    received_body::ReceivedBodyState,
+    transport::Transport,
+    Conn, Headers, KnownHeaderName, Method, StateSet, Stopper, Version,
 };
 use futures_lite::io::{AsyncRead, AsyncWrite, Result};
 use std::{
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
     time::Instant,
 };
@@ -140,6 +143,7 @@ impl Conn<Synthetic> {
             after_send: AfterSend::default(),
             start_time: Instant::now(),
             peer_ip: None,
+            http_config: Arc::new(HttpConfig::default()),
         }
     }
 

--- a/http/src/synthetic.rs
+++ b/http/src/synthetic.rs
@@ -1,13 +1,10 @@
 use crate::{
-    conn::{AfterSend, HttpConfig},
-    received_body::ReceivedBodyState,
-    transport::Transport,
-    Conn, Headers, KnownHeaderName, Method, StateSet, Stopper, Version,
+    after_send::AfterSend, http_config::DEFAULT_CONFIG, received_body::ReceivedBodyState,
+    transport::Transport, Conn, Headers, KnownHeaderName, Method, StateSet, Stopper, Version,
 };
 use futures_lite::io::{AsyncRead, AsyncWrite, Result};
 use std::{
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
     time::Instant,
 };
@@ -143,7 +140,7 @@ impl Conn<Synthetic> {
             after_send: AfterSend::default(),
             start_time: Instant::now(),
             peer_ip: None,
-            http_config: Arc::new(HttpConfig::default()),
+            http_config: DEFAULT_CONFIG,
         }
     }
 


### PR DESCRIPTION
additionally, partially address a bug in which polling a chunked body with a long chunk size and a short buffer never completes.