### PR TITLE
Fix overflow in chunked body decoding

### DIFF
--- a/http/src/received_body.rs
+++ b/http/src/received_body.rs
@@ -358,7 +358,9 @@ fn chunk_decode(
         match httparse::parse_chunk_size(buf_to_read) {
             Ok(Status::Complete((framing_bytes, chunk_size))) => {
                 chunk_start += framing_bytes as u64;
-                chunk_end = 2 + chunk_start + chunk_size;
+                chunk_end = (2 + chunk_start)
+                    .checked_add(chunk_size)
+                    .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "chunk size too long"))?;
 
                 if chunk_size == 0 {
                     break (End, slice_from(chunk_end, buf).map(Vec::from));

--- a/http/src/received_body/tests/chunked.rs
+++ b/http/src/received_body/tests/chunked.rs
@@ -85,6 +85,7 @@ fn test_full_decode() {
             assert_eq!(output, "MozillaDeveloperNetwork", "size: {size}");
 
             assert!(decode(String::new(), size).await.is_err());
+            assert!(decode("fffffffffffffff0\r\n".into(), size).await.is_err());
         }
     });
 }


### PR DESCRIPTION
This adds a test case for a network-triggered arithmetic overflow, and changes the decoding function to check for overflow. This was found with the fuzzer in #411.