### PR TITLE
Expose `start_time()` on `trillium::Conn` to avoid needing `inner()`

### DIFF
--- a/trillium/src/conn.rs
+++ b/trillium/src/conn.rs
@@ -506,6 +506,12 @@ impl Conn {
         self.inner.is_secure()
     }
 
+    /// The [`Instant`] that the first header bytes for this conn were
+    /// received, before any processing or parsing has been performed.
+    pub fn start_time(&self) -> std::time::Instant {
+        self.inner.start_time()
+    }
+
     /// returns an immutable reference to the inner
     /// [`trillium_http::Conn`]. please open an issue if you need to do
     /// this in application code.


### PR DESCRIPTION
`trillium_http::Conn` has a `start_time()` that's useful for tracing and
similar. Expose it directly on `trillium::Conn` to avoid having to call
`conn.inner().start_time()`.
