### PR TITLE
Add functions to downcast the transport as a reference or mutable reference

### DIFF
--- a/http/src/conn.rs
+++ b/http/src/conn.rs
@@ -3,6 +3,7 @@ use crate::{
     copy,
     http_config::DEFAULT_CONFIG,
     received_body::ReceivedBodyState,
+    transport::BoxedTransport,
     util::encoding,
     Body, BufWriter, ConnectionStatus, Error, HeaderName, HeaderValue, HeaderValues, Headers,
     HttpConfig,
@@ -892,5 +893,26 @@ where
     /// retrieves the remote ip address for this conn, if available.
     pub fn peer_ip(&self) -> Option<IpAddr> {
         self.peer_ip
+    }
+}
+
+impl Conn<BoxedTransport> {
+    /// Attempt to get a reference to the transport as a specific transport type T.
+    ///
+    /// If the type does not match the original transport type, this will return `None`.
+    pub fn downcast_transport_ref<T: crate::transport::Transport>(&self) -> Option<&T> {
+        self.transport.downcast_ref()
+    }
+
+    /// Attempt to get a mutable reference to the transport as a specific transport type T.
+    ///
+    /// If the type does not match the original transport type, this will return `None`.
+    ///
+    /// This should only be used to call your own custom methods on the transport that do not read
+    /// or write any data. Calling any method that reads or writes to the transport will disrupt
+    /// the HTTP protocol. If you're looking to transition from HTTP to another protocol, use an
+    /// HTTP upgrade.
+    pub fn downcast_transport_mut<T: crate::transport::Transport>(&mut self) -> Option<&mut T> {
+        self.transport.downcast_mut()
     }
 }

--- a/http/src/transport/boxed_transport.rs
+++ b/http/src/transport/boxed_transport.rs
@@ -14,6 +14,8 @@ use trillium_macros::{AsyncRead, AsyncWrite};
 pub(crate) trait AnyTransport: Transport + Any {
     fn as_box_any(self: Box<Self>) -> Box<dyn Any>;
     fn as_box_transport(self: Box<Self>) -> Box<dyn Transport>;
+    fn as_any(&self) -> &dyn Any;
+    fn as_mut_any(&mut self) -> &mut dyn Any;
     fn as_transport(&self) -> &dyn Transport;
 }
 impl<T: Transport + Any> AnyTransport for T {
@@ -21,6 +23,12 @@ impl<T: Transport + Any> AnyTransport for T {
         self
     }
     fn as_box_transport(self: Box<Self>) -> Box<dyn Transport> {
+        self
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_mut_any(&mut self) -> &mut dyn Any {
         self
     }
     fn as_transport(&self) -> &dyn Transport {
@@ -84,6 +92,24 @@ impl BoxedTransport {
     #[must_use = "downcasting takes the inner transport, so you should use it"]
     pub fn downcast<T: 'static>(self) -> Option<Box<T>> {
         self.0.as_box_any().downcast().ok()
+    }
+
+    /**
+    Attempt to get a reference to the trait object as a specific transport type T. This will only
+    succeed if T is the type that was originally passed to [`BoxedTransport::new`], and will return
+    None otherwise
+    */
+    pub fn downcast_ref<T: Transport>(&self) -> Option<&T> {
+        self.0.as_any().downcast_ref()
+    }
+
+    /**
+    Attempt to get a mutable reference to the trait object as a specific transport type T. This
+    will only succeed if T is the type that was originally passed to [`BoxedTransport::new`], and
+    will return None otherwise
+    */
+    pub fn downcast_mut<T: Transport>(&mut self) -> Option<&mut T> {
+        self.0.as_mut_any().downcast_mut()
     }
 }
 

--- a/trillium/src/conn.rs
+++ b/trillium/src/conn.rs
@@ -547,6 +547,25 @@ impl Conn {
         })
     }
 
+    /// Attempt to get a reference to the trait object as a specific transport type T.
+    ///
+    /// If the type does not match the original transport type, this will return `None`.
+    pub fn downcast_transport_ref<T: Transport>(&self) -> Option<&T> {
+        self.inner.downcast_transport_ref()
+    }
+
+    /// Attempt to get a mutable reference to the trait object as a specific transport type T.
+    ///
+    /// If the type does not match the original transport type, this will return `None`.
+    ///
+    /// This should only be used to call your own custom methods on the transport that do not read
+    /// or write any data. Calling any method that reads or writes to the transport will disrupt
+    /// the HTTP protocol. If you're looking to transition from HTTP to another protocol, use an
+    /// HTTP upgrade.
+    pub fn downcast_transport_mut<T: Transport>(&mut self) -> Option<&mut T> {
+        self.inner.downcast_transport_mut()
+    }
+
     /// retrieves the remote ip address for this conn, if available.
     pub fn peer_ip(&self) -> Option<IpAddr> {
         self.inner().peer_ip()


### PR DESCRIPTION
These functions are useful for getting access to an application-specific
custom transport type that has additional methods.
