### PR TITLE
Minimal support for downcasting to a custom transport type

### DIFF
--- a/http/src/conn.rs
+++ b/http/src/conn.rs
@@ -862,6 +862,21 @@ where
         }
     }
 
+    /// Get a reference to the transport.
+    pub fn transport(&self) -> &Transport {
+        &self.transport
+    }
+
+    /// Get a mutable reference to the transport.
+    ///
+    /// This should only be used to call your own custom methods on the transport that do not read
+    /// or write any data. Calling any method that reads from or writes to the transport will
+    /// disrupt the HTTP protocol. If you're looking to transition from HTTP to another protocol,
+    /// use an HTTP upgrade.
+    pub fn transport_mut(&mut self) -> &mut Transport {
+        &mut self.transport
+    }
+
     /// sets the remote ip address for this conn, if available.
     pub fn set_peer_ip(&mut self, peer_ip: Option<IpAddr>) {
         self.peer_ip = peer_ip;

--- a/http/src/transport/boxed_transport.rs
+++ b/http/src/transport/boxed_transport.rs
@@ -14,6 +14,8 @@ use trillium_macros::{AsyncRead, AsyncWrite};
 pub(crate) trait AnyTransport: Transport + Any {
     fn as_box_any(self: Box<Self>) -> Box<dyn Any>;
     fn as_box_transport(self: Box<Self>) -> Box<dyn Transport>;
+    fn as_any(&self) -> &dyn Any;
+    fn as_mut_any(&mut self) -> &mut dyn Any;
     fn as_transport(&self) -> &dyn Transport;
 }
 impl<T: Transport + Any> AnyTransport for T {
@@ -21,6 +23,12 @@ impl<T: Transport + Any> AnyTransport for T {
         self
     }
     fn as_box_transport(self: Box<Self>) -> Box<dyn Transport> {
+        self
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_mut_any(&mut self) -> &mut dyn Any {
         self
     }
     fn as_transport(&self) -> &dyn Transport {
@@ -84,6 +92,24 @@ impl BoxedTransport {
     #[must_use = "downcasting takes the inner transport, so you should use it"]
     pub fn downcast<T: 'static>(self) -> Option<Box<T>> {
         self.0.as_box_any().downcast().ok()
+    }
+
+    /**
+    Attempt to get a reference to the trait object as a specific transport type T. This will only
+    succeed if T is the type that was originally passed to [`BoxedTransport::new`], and will return
+    None otherwise
+    */
+    pub fn downcast_ref<T: Transport>(&self) -> Option<&T> {
+        self.0.as_any().downcast_ref()
+    }
+
+    /**
+    Attempt to get a mutable reference to the trait object as a specific transport type T. This
+    will only succeed if T is the type that was originally passed to [`BoxedTransport::new`], and
+    will return None otherwise
+    */
+    pub fn downcast_mut<T: Transport>(&mut self) -> Option<&mut T> {
+        self.0.as_mut_any().downcast_mut()
     }
 }
 


### PR DESCRIPTION
This PR is an alternative to the approach in
https://github.com/trillium-rs/trillium/pull/432 , based on the comment at
https://github.com/trillium-rs/trillium/pull/432#discussion_r1379128491 .

I added methods on `trillium_http::Conn` to get a `&Transport` or `&mut Transport`.

I then added methods on `BoxedTransport` to downcast to a specific type
implementing `Transport`. I went with downcast methods on `BoxedTransport`
rather than exposing `as_any()` and `as_mut_any()` directly, because the latter
would have been the same amount of code and with a more complex interface.

With both of these changes, given a `trillium::Conn`, you can call
`conn.inner().transport().downcast_ref()` or
`conn.inner().transport_mut().downcast_mut()` to get your custom transport
type.

I think this is the minimal amount of support needed to make this possible.
