### PR TITLE
client bugfix: check the existing buffer before attempting to read from the transport

### DIFF
--- a/client/src/conn.rs
+++ b/client/src/conn.rs
@@ -699,6 +699,14 @@ impl Conn {
         let mut len = buffer.len();
         let mut search_start = 0;
         let finder = Finder::new(b"\r\n\r\n");
+
+        if len > 0 {
+            if let Some(index) = finder.find(buffer) {
+                return Ok(index + 4);
+            }
+            search_start = len.saturating_sub(3);
+        }
+
         loop {
             buffer.expand();
             let bytes = transport.read(&mut buffer[len..]).await?;


### PR DESCRIPTION
this resolves the lingering intermittent test timeout