### PR TITLE
trillium-macros: Add `derive(Transport)` macro and improve documentation

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -20,6 +20,8 @@ syn = { version = "2.0.41", features = ["full", "visit"] }
 
 [dev-dependencies]
 trillium = { path = "../trillium" }
+trillium-http = { path = "../http" }
+trillium-server-common = { path = "../server-common" }
 trillium-testing = { path = "../testing" }
 syn = { version = "2.0.41", features = ["extra-traits"] }
 futures-lite = "2.1.0"

--- a/macros/README.md
+++ b/macros/README.md
@@ -8,7 +8,7 @@ enums as well. Note that it will only delegate to a single inner Handler type.
 In the case of a newtype struct or named struct with only a single
 field, `#[derive(Handler)]` is all that's required. If there is more
 than one field in the struct, annotate exactly one of them with
-#[handler].
+`#[handler]`.
 
 As of v0.0.2, deriving Handler makes an effort at adding Handler
 bounds to generics contained within the `#[handler]` type. It may be
@@ -71,7 +71,7 @@ assert_handler(ContainsHandler {
 
 Annotate the handler with a
 [`trillium::Handler`](https://docs.rs/trillium/latest/trillium/trait.Handler.html)
-function name `#[handler(overrride = FN_NAME)]` where FN_NAME is one of
+function name `#[handler(overrride = FN_NAME)]` where `FN_NAME` is one of
 `run`, `before_send`, `name`, `has_upgrade`, or `upgrade`, and
 implement the same signature on Self. The rest of the Handler
 interface will be delegated to the inner Handler, but your custom

--- a/macros/README.md
+++ b/macros/README.md
@@ -1,6 +1,6 @@
 # Welcome to the `trillium-macros` crate!
 
-This crate derive macros for `Handler`, `AsyncRead`, and `AsyncWrite`.
+This crate provides derive macros for `Handler`, `AsyncRead`, and `AsyncWrite`.
 
 ## `derive(Handler)`
 
@@ -137,3 +137,30 @@ impl CustomName { // note that this is not a trait impl
 let handler = CustomName { inner: "handler" };
 assert_handler(handler);
 ```
+
+## `derive(AsyncRead)` and `derive(AsyncWrite)`
+
+To ease the development of `Transport` types, this crate provides proc macros
+to derive `AsyncRead` and `AsyncWrite` and delegate them to a field of the
+type.
+
+To delegate all methods of `AsyncRead` and `AsyncWrite` to the corresponding
+methods on a field, mark that field with `#[async_io]`:
+
+```rust
+use trillium_http::transport::BoxedTransport;
+use trillium_macros::{AsyncRead, AsyncWrite};
+use trillium_server_common::{AsyncRead, AsyncWrite};
+
+#[derive(Debug, AsyncRead, AsyncWrite)]
+struct TransportWrapper {
+    #[async_io]
+    inner: BoxedTransport,
+    another_field: u32,
+}
+```
+
+To delegate `AsyncRead` and `AsyncWrite` to different fields,
+mark the fields with `#[async_read]` and `#[async_write]`, respectively.
+
+These annotations are optional for structs with a single field.

--- a/macros/README.md
+++ b/macros/README.md
@@ -1,5 +1,9 @@
 # Welcome to the `trillium-macros` crate!
 
+This crate derive macros for `Handler`, `AsyncRead`, and `AsyncWrite`.
+
+## `derive(Handler)`
+
 This crate currently offers a derive macro for Handler that can be
 used to delegate Handler behavior to a contained Handler
 type. Currently it only works for structs, but will eventually support
@@ -66,8 +70,7 @@ assert_handler(ContainsHandler {
 
 ```
 
-
-# Overriding a single trait function
+### Overriding a single trait function
 
 Annotate the handler with a
 [`trillium::Handler`](https://docs.rs/trillium/latest/trillium/trait.Handler.html)
@@ -98,7 +101,7 @@ assert_eq!(trillium::Handler::name(&handler), "custom name (handler)");
 assert_handler(handler);
 ```
 
-# Overriding several trait functions
+### Overriding several trait functions
 
 Annotate the handler with any number of
 [`trillium::Handler`](https://docs.rs/trillium/latest/trillium/trait.Handler.html)

--- a/macros/README.md
+++ b/macros/README.md
@@ -1,6 +1,6 @@
 # Welcome to the `trillium-macros` crate!
 
-This crate provides derive macros for `Handler`, `AsyncRead`, and `AsyncWrite`.
+This crate provides derive macros for `Handler`, `AsyncRead`, `AsyncWrite`, and `Transport`.
 
 ## `derive(Handler)`
 
@@ -164,3 +164,43 @@ To delegate `AsyncRead` and `AsyncWrite` to different fields,
 mark the fields with `#[async_read]` and `#[async_write]`, respectively.
 
 These annotations are optional for structs with a single field.
+
+## `derive(Transport)`
+
+This crate provides a proc macro to derive the `Transport` type and delegate it
+to a field of the type:
+
+```rust
+use trillium_http::transport::BoxedTransport;
+use trillium_macros::{AsyncRead, AsyncWrite, Transport};
+use trillium_server_common::{AsyncRead, AsyncWrite, Transport};
+
+#[derive(Debug, AsyncRead, AsyncWrite, Transport)]
+struct TransportWrapper {
+    #[transport] #[async_io]
+    inner: BoxedTransport,
+    another_field: u32,
+}
+```
+
+This supports the same mechanism that `derive(Handler)` does for overriding
+individual methods:
+
+```rust
+use trillium_http::transport::BoxedTransport;
+use trillium_macros::{AsyncRead, AsyncWrite, Transport};
+use trillium_server_common::{AsyncRead, AsyncWrite, Transport};
+
+#[derive(Debug, AsyncRead, AsyncWrite, Transport)]
+struct TransportWrapper {
+    #[transport(except = peer_addr)] #[async_io]
+    inner: BoxedTransport,
+    another_field: u32,
+}
+
+impl TransportWrapper { // note that this is not a trait impl
+    fn peer_addr(&self) -> std::io::Result<Option<std::net::SocketAddr>> {
+        Ok(None)
+    }
+}
+```

--- a/macros/src/async_read.rs
+++ b/macros/src/async_read.rs
@@ -65,7 +65,7 @@ impl Parse for DeriveOptions {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let input = DeriveInput::parse(input)?;
         let Data::Struct(ds) = &input.data else {
-            return Err(Error::new(input.span(), "second erro"));
+            return Err(Error::new(input.span(), "second error"));
         };
 
         for (field_index, field) in ds.fields.iter().enumerate() {

--- a/macros/src/async_read.rs
+++ b/macros/src/async_read.rs
@@ -96,7 +96,7 @@ impl Parse for DeriveOptions {
         } else {
             Err(Error::new(
                 input.span(),
-                "Structs with more than one field need an #[async_io] annotation",
+                "Structs with more than one field need an #[async_io] or #[async_read] annotation",
             ))
         }
     }

--- a/macros/src/async_write.rs
+++ b/macros/src/async_write.rs
@@ -96,7 +96,7 @@ impl Parse for DeriveOptions {
         } else {
             Err(Error::new(
                 input.span(),
-                "Structs with more than one field need an #[async_io] annotation",
+                "Structs with more than one field need an #[async_io] or #[async_write] annotation",
             ))
         }
     }

--- a/macros/src/handler.rs
+++ b/macros/src/handler.rs
@@ -68,7 +68,7 @@ impl TryFrom<&Path> for Override {
         } else {
             Err(Error::new(
                 path.span(),
-                "unrecognized trillium::Handler function name",
+                "unrecognized trillium::Handler method name",
             ))
         }
     }

--- a/macros/src/handler.rs
+++ b/macros/src/handler.rs
@@ -141,7 +141,7 @@ impl Parse for DeriveOptions {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let input = DeriveInput::parse(input)?;
         let Data::Struct(ds) = &input.data else {
-            return Err(Error::new(input.span(), "second erro"));
+            return Err(Error::new(input.span(), "second error"));
         };
 
         for (field_index, field) in ds.fields.iter().enumerate() {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -18,6 +18,13 @@ pub fn derive_handler(input: proc_macro::TokenStream) -> proc_macro::TokenStream
     handler::derive_handler(input)
 }
 
+mod transport;
+///
+#[proc_macro_derive(Transport, attributes(transport))]
+pub fn derive_transport(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    transport::derive_transport(input)
+}
+
 mod async_read;
 ///
 #[proc_macro_derive(AsyncRead, attributes(async_read, async_io))]

--- a/macros/src/transport.rs
+++ b/macros/src/transport.rs
@@ -1,0 +1,252 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use std::{collections::HashSet, iter::once};
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input, parse_quote,
+    punctuated::Punctuated,
+    spanned::Spanned,
+    token::{Comma, Where},
+    visit::{visit_type_path, Visit},
+    Attribute, Data, DeriveInput, Error, Expr, ExprArray, ExprAssign, ExprPath, Field, Ident,
+    Index, Member, Meta, Path, Type, TypePath, WhereClause,
+};
+
+fn is_required_generic_for_type(ty: &Type, generic: &Ident) -> bool {
+    struct PathVisitor<'g> {
+        generic: &'g Ident,
+        generic_is_required: bool,
+    }
+    impl<'g, 'ast> Visit<'ast> for PathVisitor<'g> {
+        fn visit_type_path(&mut self, node: &'ast TypePath) {
+            if node.qself.is_none() {
+                if let Some(first_segment) = node.path.segments.first() {
+                    if first_segment.ident == *self.generic {
+                        self.generic_is_required = true;
+                    }
+                }
+            }
+            visit_type_path(self, node);
+        }
+    }
+
+    let mut path_visitor = PathVisitor {
+        generic,
+        generic_is_required: false,
+    };
+
+    path_visitor.visit_type(ty);
+
+    path_visitor.generic_is_required
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Override {
+    SetLinger,
+    SetNodelay,
+    SetIpTtl,
+    PeerAddr,
+}
+
+impl TryFrom<&Path> for Override {
+    type Error = Error;
+    fn try_from(path: &Path) -> Result<Self, Self::Error> {
+        if path.is_ident("set_linger") {
+            Ok(Self::SetLinger)
+        } else if path.is_ident("set_nodelay") {
+            Ok(Self::SetNodelay)
+        } else if path.is_ident("set_ip_ttl") {
+            Ok(Self::SetIpTtl)
+        } else if path.is_ident("peer_addr") {
+            Ok(Self::PeerAddr)
+        } else {
+            Err(Error::new(
+                path.span(),
+                "unrecognized Transport method name",
+            ))
+        }
+    }
+}
+
+struct DeriveOptions {
+    overrides: Vec<Override>,
+    input: DeriveInput,
+    field: Field,
+    field_index: usize,
+}
+
+fn overrides<'a, I: Iterator<Item = &'a Expr>>(iter: I) -> syn::Result<Vec<Override>> {
+    iter.map(|expr| match expr {
+        Expr::Path(ExprPath { path, .. }) => path.try_into(),
+        _ => Err(Error::new(expr.span(), "unrecognized override. valid options are set_linger, set_nodelay, set_ip_ttl, and peer_addr")),
+    })
+    .collect()
+}
+
+fn parse_attribute(attr: &Attribute) -> syn::Result<Option<Vec<Override>>> {
+    if attr.path().is_ident("transport") {
+        match &attr.meta {
+            Meta::Path(_) => Ok(Some(vec![])),
+            Meta::List(metalist) => {
+                let tokens = metalist.tokens.clone();
+                let ExprAssign { left, right, .. } = syn::parse(tokens.into())?;
+                match (*left, *right) {
+                    (Expr::Path(ExprPath { path: left, .. }), right @ Expr::Path(_))
+                        if left.is_ident("except") =>
+                    {
+                        Ok(Some(overrides(once(&right))?))
+                    }
+
+                    (
+                        Expr::Path(ExprPath { path: left, .. }),
+                        Expr::Array(ExprArray { elems: right, .. }),
+                    ) if left.is_ident("except") => Ok(Some(overrides(right.iter())?)),
+
+                    (_x, _y) => Err(Error::new(
+                        metalist.span(),
+                        "unrecognized #[transport] attributes",
+                    )),
+                }
+            }
+            Meta::NameValue(nv) => Err(Error::new(
+                nv.span(),
+                "unrecognized #[transport] attributes",
+            )),
+        }
+    } else {
+        Ok(None)
+    }
+}
+
+fn generics(field: &Field, input: &DeriveInput) -> Vec<Ident> {
+    input
+        .generics
+        .type_params()
+        .filter_map(|g| {
+            if is_required_generic_for_type(&field.ty, &g.ident) {
+                Some(g.ident.clone())
+            } else {
+                None
+            }
+        })
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+impl Parse for DeriveOptions {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let input = DeriveInput::parse(input)?;
+        let Data::Struct(ds) = &input.data else {
+            return Err(Error::new(input.span(), "second error"));
+        };
+
+        for (field_index, field) in ds.fields.iter().enumerate() {
+            for attr in &field.attrs {
+                if let Some(overrides) = parse_attribute(attr)? {
+                    let field = field.clone();
+                    return Ok(Self {
+                        overrides,
+                        input,
+                        field,
+                        field_index,
+                    });
+                }
+            }
+        }
+
+        if ds.fields.len() == 1 {
+            let field = ds
+                .fields
+                .iter()
+                .next()
+                .expect("len == 1 should have one element")
+                .clone();
+            Ok(Self {
+                overrides: vec![],
+                input,
+                field,
+                field_index: 0,
+            })
+        } else {
+            Err(Error::new(
+                input.span(),
+                "Structs with more than one field need a #[transport] annotation",
+            ))
+        }
+    }
+}
+
+pub fn derive_transport(input: TokenStream) -> TokenStream {
+    let DeriveOptions {
+        overrides,
+        field,
+        input,
+        field_index,
+    } = parse_macro_input!(input as DeriveOptions);
+
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let generics = generics(&field, &input);
+
+    let struct_name = input.ident;
+
+    let mut where_clause = where_clause.map_or_else(
+        || WhereClause {
+            where_token: Where::default(),
+            predicates: Punctuated::new(),
+        },
+        |where_clause| where_clause.to_owned(),
+    );
+
+    for generic in generics {
+        where_clause
+            .predicates
+            .push_value(parse_quote! { #generic: trillium_server_common::Transport });
+        where_clause.predicates.push_punct(Comma::default());
+    }
+
+    where_clause
+        .predicates
+        .push_value(parse_quote! { Self: Send + Sync + 'static });
+
+    let transport = field
+        .ident
+        .map_or_else(|| Member::Unnamed(Index::from(field_index)), Member::Named);
+
+    let transport = quote!(self.#transport);
+
+    let set_linger = if overrides.contains(&Override::SetLinger) {
+        quote!(Self::set_linger(self, linger))
+    } else {
+        quote!(trillium_server_common::Transport::set_linger(&mut #transport, linger))
+    };
+
+    let set_nodelay = if overrides.contains(&Override::SetNodelay) {
+        quote!(Self::set_nodelay(self, nodelay))
+    } else {
+        quote!(trillium_server_common::Transport::set_nodelay(&mut #transport, nodelay))
+    };
+
+    let set_ip_ttl = if overrides.contains(&Override::SetIpTtl) {
+        quote!(Self::set_ip_ttl(self, ttl))
+    } else {
+        quote!(trillium_server_common::Transport::set_ip_ttl(&mut #transport, ttl))
+    };
+
+    let peer_addr = if overrides.contains(&Override::PeerAddr) {
+        quote!(Self::peer_addr(self))
+    } else {
+        quote!(trillium_server_common::Transport::peer_addr(&#transport))
+    };
+
+    quote! {
+        impl #impl_generics trillium_server_common::Transport for #struct_name #ty_generics #where_clause {
+            fn set_linger(&mut self, linger: Option<core::time::Duration>) -> std::io::Result<()> { #set_linger }
+            fn set_nodelay(&mut self, nodelay: bool) -> std::io::Result<()> { #set_nodelay }
+            fn set_ip_ttl(&mut self, ttl: u32) -> std::io::Result<()> { #set_ip_ttl }
+            fn peer_addr(&self) -> std::io::Result<Option<std::net::SocketAddr>> { #peer_addr }
+        }
+    }
+    .into()
+}

--- a/macros/tests/transport.rs
+++ b/macros/tests/transport.rs
@@ -1,0 +1,171 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use trillium_http::Synthetic;
+use trillium_macros::{AsyncRead, AsyncWrite, Transport};
+use trillium_server_common::{AsyncRead, AsyncWrite, Transport};
+
+#[derive(Debug)]
+struct CallStats(Arc<Mutex<HashMap<&'static str, usize>>>);
+
+impl CallStats {
+    fn new() -> Self {
+        Self(Arc::new(Mutex::new(HashMap::new())))
+    }
+
+    fn inc(&self, name: &'static str) {
+        *self.0.lock().unwrap().entry(name).or_insert(0) += 1;
+    }
+
+    fn get(&self, name: &'static str) -> usize {
+        *self.0.lock().unwrap().get(name).unwrap_or(&0)
+    }
+}
+
+#[derive(Debug, AsyncRead, AsyncWrite)]
+struct InnerTransport {
+    #[async_io]
+    inner: Synthetic,
+    stats: CallStats,
+}
+
+impl InnerTransport {
+    fn new() -> Self {
+        Self {
+            inner: Synthetic::from(()),
+            stats: CallStats::new(),
+        }
+    }
+}
+
+impl Transport for InnerTransport {
+    fn set_linger(&mut self, _linger: Option<std::time::Duration>) -> std::io::Result<()> {
+        self.stats.inc("set_linger");
+        Ok(())
+    }
+
+    fn set_nodelay(&mut self, _nodelay: bool) -> std::io::Result<()> {
+        self.stats.inc("set_nodelay");
+        Ok(())
+    }
+
+    fn set_ip_ttl(&mut self, _ttl: u32) -> std::io::Result<()> {
+        self.stats.inc("set_ip_ttl");
+        Ok(())
+    }
+
+    fn peer_addr(&self) -> std::io::Result<Option<std::net::SocketAddr>> {
+        self.stats.inc("peer_addr");
+        Ok(None)
+    }
+}
+
+fn call_all_once(t: &mut impl Transport) {
+    t.set_linger(None).unwrap();
+    t.set_nodelay(true).unwrap();
+    t.set_ip_ttl(0).unwrap();
+    t.peer_addr().unwrap();
+}
+
+macro_rules! define_transport_with_except {
+    ($t:ident $(, except = $e:tt)? $(,)?) => {
+        #[derive(Debug, AsyncRead, AsyncWrite, Transport)]
+        struct $t {
+            #[transport$((except = $e))?] #[async_io]
+            inner: InnerTransport,
+            stats: CallStats,
+        }
+        #[allow(unused)]
+        impl $t {
+            fn new() -> Self {
+                Self {
+                    inner: InnerTransport::new(),
+                    stats: CallStats::new(),
+                }
+            }
+
+            fn set_linger(&mut self, _linger: Option<std::time::Duration>) -> std::io::Result<()> {
+                self.stats.inc("set_linger");
+                Ok(())
+            }
+
+            fn set_nodelay(&mut self, _nodelay: bool) -> std::io::Result<()> {
+                self.stats.inc("set_nodelay");
+                Ok(())
+            }
+
+            fn set_ip_ttl(&mut self, _ttl: u32) -> std::io::Result<()> {
+                self.stats.inc("set_ip_ttl");
+                Ok(())
+            }
+
+            fn peer_addr(&self) -> std::io::Result<Option<std::net::SocketAddr>> {
+                self.stats.inc("peer_addr");
+                Ok(None)
+            }
+        }
+    }
+}
+
+#[test]
+fn full_derive() {
+    define_transport_with_except!(OuterTransport);
+    let mut outer = OuterTransport::new();
+    call_all_once(&mut outer);
+    assert_eq!(outer.stats.get("set_linger"), 0);
+    assert_eq!(outer.stats.get("set_nodelay"), 0);
+    assert_eq!(outer.stats.get("set_ip_ttl"), 0);
+    assert_eq!(outer.stats.get("peer_addr"), 0);
+    assert_eq!(outer.inner.stats.get("set_linger"), 1);
+    assert_eq!(outer.inner.stats.get("set_nodelay"), 1);
+    assert_eq!(outer.inner.stats.get("set_ip_ttl"), 1);
+    assert_eq!(outer.inner.stats.get("peer_addr"), 1);
+}
+
+#[test]
+fn override_one() {
+    define_transport_with_except!(OuterTransport, except = set_linger);
+    let mut outer = OuterTransport::new();
+    call_all_once(&mut outer);
+    assert_eq!(outer.stats.get("set_linger"), 1);
+    assert_eq!(outer.stats.get("set_nodelay"), 0);
+    assert_eq!(outer.stats.get("set_ip_ttl"), 0);
+    assert_eq!(outer.stats.get("peer_addr"), 0);
+    assert_eq!(outer.inner.stats.get("set_linger"), 0);
+    assert_eq!(outer.inner.stats.get("set_nodelay"), 1);
+    assert_eq!(outer.inner.stats.get("set_ip_ttl"), 1);
+    assert_eq!(outer.inner.stats.get("peer_addr"), 1);
+}
+
+#[test]
+fn override_two() {
+    define_transport_with_except!(OuterTransport, except = [set_nodelay, peer_addr]);
+    let mut outer = OuterTransport::new();
+    call_all_once(&mut outer);
+    assert_eq!(outer.stats.get("set_linger"), 0);
+    assert_eq!(outer.stats.get("set_nodelay"), 1);
+    assert_eq!(outer.stats.get("set_ip_ttl"), 0);
+    assert_eq!(outer.stats.get("peer_addr"), 1);
+    assert_eq!(outer.inner.stats.get("set_linger"), 1);
+    assert_eq!(outer.inner.stats.get("set_nodelay"), 0);
+    assert_eq!(outer.inner.stats.get("set_ip_ttl"), 1);
+    assert_eq!(outer.inner.stats.get("peer_addr"), 0);
+}
+
+#[test]
+fn override_all() {
+    define_transport_with_except!(
+        OuterTransport,
+        except = [set_linger, set_nodelay, set_ip_ttl, peer_addr],
+    );
+    let mut outer = OuterTransport::new();
+    call_all_once(&mut outer);
+    assert_eq!(outer.stats.get("set_linger"), 1);
+    assert_eq!(outer.stats.get("set_nodelay"), 1);
+    assert_eq!(outer.stats.get("set_ip_ttl"), 1);
+    assert_eq!(outer.stats.get("peer_addr"), 1);
+    assert_eq!(outer.inner.stats.get("set_linger"), 0);
+    assert_eq!(outer.inner.stats.get("set_nodelay"), 0);
+    assert_eq!(outer.inner.stats.get("set_ip_ttl"), 0);
+    assert_eq!(outer.inner.stats.get("peer_addr"), 0);
+}


### PR DESCRIPTION
Implement a proc macro for deriving `Transport`, delegating to a field.

Improve documentation in `README.md`, which did not previously document the
derives for `AsyncRead` or `AsyncWrite`.

All the commits except the last one are bugfixes; the last is the new
`derive(Transport)` macro.
