### PR TITLE
client, proxy, and http header tweaks

### DIFF
--- a/client/src/conn.rs
+++ b/client/src/conn.rs
@@ -904,7 +904,7 @@ impl From<Conn> for Body {
 
 impl From<Conn> for ReceivedBody<'static, BoxedTransport> {
     fn from(mut conn: Conn) -> Self {
-        conn.finalize_headers();
+        let _ = conn.finalize_headers();
         let origin = conn.url.origin();
 
         let on_completion =

--- a/client/tests/one_hundred_continue.rs
+++ b/client/tests/one_hundred_continue.rs
@@ -4,7 +4,7 @@ use indoc::{formatdoc, indoc};
 use pretty_assertions::assert_eq;
 use std::future::Future;
 use test_harness::test;
-use trillium_client::{Client, Status, USER_AGENT};
+use trillium_client::{Client, Conn, Error, Status, USER_AGENT};
 use trillium_server_common::{async_trait, Connector, Url};
 use trillium_testing::{harness, TestResult, TestTransport};
 
@@ -15,6 +15,7 @@ async fn extra_one_hundred_continue() -> TestResult {
 
     let expected_request_head = formatdoc! {"
         POST / HTTP/1.1\r
+        Accept: */*\r
         Expect: 100-continue\r
         User-Agent: {USER_AGENT}\r
         Host: example.com\r
@@ -68,6 +69,7 @@ async fn one_hundred_continue() -> TestResult {
 
     let expected_request = formatdoc! {"
         POST / HTTP/1.1\r
+        Accept: */*\r
         Expect: 100-continue\r
         User-Agent: {USER_AGENT}\r
         Host: example.com\r
@@ -83,6 +85,7 @@ async fn one_hundred_continue() -> TestResult {
 
     transport.write_all(formatdoc! {"
         HTTP/1.1 200 Ok\r
+        Accept: */*\r
         Server: text\r
         Date: {TEST_DATE}\r
         Connection: close\r
@@ -110,10 +113,10 @@ async fn empty_body_no_100_continue() -> TestResult {
 
     let expected_request = formatdoc! {"
         POST / HTTP/1.1\r
+        Accept: */*\r
         User-Agent: {USER_AGENT}\r
         Host: example.com\r
         Connection: close\r
-        Content-Length: 0\r
         \r
     "};
 
@@ -140,6 +143,7 @@ async fn two_small_continues() -> TestResult {
         test_conn(|client| client.post("http://example.com").with_body("body")).await;
     let expected_request = formatdoc! {"
         POST / HTTP/1.1\r
+        Accept: */*\r
         Expect: 100-continue\r
         User-Agent: {USER_AGENT}\r
         Host: example.com\r
@@ -178,6 +182,7 @@ async fn little_continue_big_continue() -> TestResult {
 
     let expected_request = formatdoc! {"
         POST / HTTP/1.1\r
+        Accept: */*\r
         Expect: 100-continue\r
         User-Agent: {USER_AGENT}\r
         Host: example.com\r
@@ -228,11 +233,8 @@ impl Connector for TestConnector {
 }
 
 async fn test_conn(
-    setup: impl FnOnce(Client) -> trillium_client::Conn + Send + 'static,
-) -> (
-    TestTransport,
-    impl Future<Output = Result<trillium_client::Conn, trillium_client::Error>>,
-) {
+    setup: impl FnOnce(Client) -> Conn + Send + 'static,
+) -> (TestTransport, impl Future<Output = Result<Conn, Error>>) {
     let (sender, receiver) = async_channel::unbounded();
     let client = Client::new(TestConnector(sender));
     let conn_fut = trillium_testing::spawn(async move { setup(client).await });

--- a/http/src/conn.rs
+++ b/http/src/conn.rs
@@ -627,12 +627,6 @@ where
 
         if self.stopper.is_stopped() {
             self.response_headers.insert(Connection, "close");
-        } else if !self
-            .request_headers
-            .eq_ignore_ascii_case(Connection, "close")
-            && self.version == Version::Http1_1
-        {
-            self.response_headers.try_insert(Connection, "keep-alive");
         }
     }
 

--- a/http/src/version.rs
+++ b/http/src/version.rs
@@ -22,6 +22,28 @@ pub enum Version {
     Http3_0,
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for Version {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Version {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
 impl PartialEq<&Version> for Version {
     fn eq(&self, other: &&Version) -> bool {
         self == *other

--- a/proxy/examples/proxy.rs
+++ b/proxy/examples/proxy.rs
@@ -1,3 +1,4 @@
+use trillium_client::Client;
 use trillium_logger::Logger;
 use trillium_proxy::{
     upstream::{ConnectionCounting, IntoUpstreamSelector, UpstreamSelector},
@@ -19,6 +20,10 @@ pub fn main() {
 
     trillium_smol::run((
         Logger::new(),
-        Proxy::new(ClientConfig::default(), upstream).with_via_pseudonym("trillium-proxy"),
+        Proxy::new(
+            Client::new(ClientConfig::default()).with_default_pool(),
+            upstream,
+        )
+        .with_via_pseudonym("trillium-proxy"),
     ));
 }

--- a/proxy/examples/upstream.rs
+++ b/proxy/examples/upstream.rs
@@ -32,7 +32,8 @@ pub fn main() {
                 "headers": conn.request_headers(),
                 "ip": conn.inner().peer_ip(),
                 "query": query,
-                "body": body
+                "body": body,
+                "version": conn.inner().http_version()
             });
             conn.with_json(&json).with_status(Status::Ok)
         },

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -242,13 +242,12 @@ impl<U: UpstreamSelector> Handler for Proxy<U> {
         }
 
         self.set_via_pseudonym(&mut request_headers, conn.inner().http_version());
-        let content_length = match conn
-            .request_headers()
-            .get_str(KnownHeaderName::ContentLength)
-        {
-            Some("0") | None => false,
-            _ => true,
-        };
+        let content_length = !matches!(
+            conn.request_headers()
+                .get_str(KnownHeaderName::ContentLength),
+            Some("0") | None
+        );
+
         let chunked = conn
             .request_headers()
             .eq_ignore_ascii_case(KnownHeaderName::TransferEncoding, "chunked");


### PR DESCRIPTION
Across the three crates, this adds support for GET requests with bodies and reduces unnecessary headers, such as `Connection: keep-alive` (the default for http/1.1) and `Content-Length: 0` (the same as sending neither `Content-Length` nor `Transfer-Encoding: chunked`)

Nobody should use GET requests with bodies, but the proxy previously wouldn't ignore them gracefully, and kept the connection open until the other side disconnected. I don't believe this represents a security concern, but it's not particularly difficult to just check for the presence of a body instead of special-casing GET requests.