### PR TITLE
Allow creating an empty HeaderValues with impl From<()> for HeaderValues

### DIFF
--- a/http/src/headers/header_values.rs
+++ b/http/src/headers/header_values.rs
@@ -91,8 +91,10 @@ where
 }
 
 impl HeaderValues {
-    /// Builds an empty `HeaderValues`. This is not generally necessary
-    /// in application code. Using a `From` implementation is preferable.
+    /// Builds an empty `HeaderValues`.
+    ///
+    /// This is not generally necessary in application code. Using a `From` implementation is
+    /// preferable. If you need an empty `HeaderValues`, use `()`.
     #[must_use]
     pub fn new() -> Self {
         Self(SmallVec::with_capacity(1))
@@ -139,6 +141,12 @@ impl HeaderValues {
 //         self.one().as_ref()
 //     }
 // }
+
+impl From<()> for HeaderValues {
+    fn from((): ()) -> Self {
+        HeaderValues::new()
+    }
+}
 
 impl From<&'static [u8]> for HeaderValues {
     fn from(value: &'static [u8]) -> Self {

--- a/http/tests/serialize_headers.rs
+++ b/http/tests/serialize_headers.rs
@@ -13,13 +13,15 @@ fn header_serialization() {
     headers.insert("multi-values", "value1");
     headers.append("multi-values", "value2");
     headers.append("multi-values", "value3");
+    headers.insert("no-values", ());
     assert_eq!(
         serde_json::json!({
             "Accept": "Known",
             "non-utf8": vec![
                 0xC0, 0xC1, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF,
             ],
-            "multi-values": ["value1", "value2", "value3"]
+            "multi-values": ["value1", "value2", "value3"],
+            "no-values": []
         }),
         serde_json::to_value(&headers).unwrap()
     );


### PR DESCRIPTION
This makes it easy to omit a default header using
`.with_header("Header", ())`, and thus makes it easier to fulfill the
comment on `HeaderValues::new()` saying that it shouldn't be necessary.
