### PR TITLE
allow trillium-static to build without any features enabled, panic at runtime

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,9 +19,9 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         rust: [stable]
         features:
-          - "--features smol,trillium-testing/smol"
-          - "--features tokio,trillium-testing/tokio"
-          - "--features async-std,trillium-testing/async-std"
+          - "--features trillium-static/smol,trillium-testing/smol"
+          - "--features trillium-static/tokio,trillium-testing/tokio"
+          - "--features trillium-static/async-std,trillium-testing/async-std"
           - ""
     steps:
       - uses: actions/checkout@master

--- a/static/Cargo.toml
+++ b/static/Cargo.toml
@@ -10,9 +10,6 @@ readme = "../README.md"
 keywords = ["trillium", "framework", "async"]
 categories = ["web-programming::http-server", "web-programming"]
 
-[package.metadata.docs.rs]
-features = ["smol"]
-
 [features]
 async-std = ["async_std_crate"]
 default = []

--- a/static/src/fs_shims.rs
+++ b/static/src/fs_shims.rs
@@ -1,21 +1,44 @@
 cfg_if::cfg_if! {
-   if #[cfg(feature = "smol")] {
-       pub(crate) use async_fs::{self as fs, File};
-    } else if #[cfg(feature = "tokio")] {
+    if #[cfg(feature = "tokio")] {
        pub(crate) use tokio_crate::fs::{self, File};
     } else if #[cfg(feature = "async-std")] {
         pub(crate) use async_std_crate::fs::{self, File};
+    } else if #[cfg(feature = "smol")] {
+        pub(crate) use async_fs::{self as fs, File};
     } else {
-        compile_error!("trillium-static:
-You must enable one of the three runtime feature flags
-to use this crate:
+        #[derive(Debug, Clone, Copy)]
+        pub struct File;
+        impl File {
+            pub(crate) async fn open(_path: impl AsRef<std::path::Path>) -> std::io::Result<Self> {
+                unimplemented!("please enable the tokio, async-std, or smol runtime feature")
+            }
 
-* tokio
-* async-std
-* smol
+            pub(crate) async fn metadata(&self) -> std::io::Result<std::fs::Metadata> {
+                unimplemented!("please enable the tokio, async-std, or smol runtime feature")
+            }
+        }
 
-This is a temporary constraint, and hopefully soon this
-will not require the use of cargo feature flags."
-);
+        impl futures_lite::AsyncRead for File {
+            fn poll_read(
+                self: std::pin::Pin<&mut Self>,
+                _cx: &mut std::task::Context<'_>,
+                _buf: &mut [u8],
+            ) -> std::task::Poll<std::io::Result<usize>> {
+                unimplemented!("please enable the tokio, async-std, or smol runtime feature")
+
+            }
+        }
+
+
+
+        pub(crate) mod fs {
+            pub(crate) async fn canonicalize(_path: impl AsRef<std::path::Path>) -> std::io::Result<std::path::PathBuf> {
+                unimplemented!("please enable the tokio, async-std, or smol runtime feature")
+            }
+
+            pub(crate) async fn metadata(_path: impl AsRef<std::path::Path>) -> std::io::Result<std::fs::Metadata> {
+                unimplemented!("please enable the tokio, async-std, or smol runtime feature")
+            }
+        }
     }
 }

--- a/static/src/handler.rs
+++ b/static/src/handler.rs
@@ -75,20 +75,22 @@ impl StaticFileHandler {
     ```
     # #[cfg(not(unix))] fn main() {}
     # #[cfg(unix)] fn main() {
+    # use trillium::Handler;
+    # trillium_testing::block_on(async {
     use trillium_static::{StaticFileHandler, crate_relative_path};
-    let mut handler = StaticFileHandler::new(crate_relative_path!("examples/files"));
-
     use trillium_testing::prelude::*;
-    init(&mut handler);
 
-    assert_not_handled!(get("/").on(&handler)); // no index file configured
+    let mut handler = StaticFileHandler::new(crate_relative_path!("examples/files"));
+    # handler.init(&mut "testing".into()).await;
+
+    assert_not_handled!(get("/").run_async(&handler).await); // no index file configured
 
     assert_ok!(
-        get("/index.html").on(&handler),
+        get("/index.html").run_async(&handler).await,
         "<h1>hello world</h1>",
         "content-type" => "text/html; charset=utf-8"
     );
-    # }
+    # }); }
     ```
     */
     pub fn new(fs_root: impl AsRef<Path>) -> Self {
@@ -118,15 +120,21 @@ impl StaticFileHandler {
     ```
     # #[cfg(not(unix))] fn main() {}
     # #[cfg(unix)] fn main() {
+    # use trillium::Handler;
+    # trillium_testing::block_on(async {
 
     use trillium_static::{StaticFileHandler, crate_relative_path};
 
-    let handler = StaticFileHandler::new(crate_relative_path!("examples/files"))
+    let mut handler = StaticFileHandler::new(crate_relative_path!("examples/files"))
         .with_index_file("index.html");
+    # handler.init(&mut "testing".into()).await;
 
     use trillium_testing::prelude::*;
-    assert_ok!(get("/").on(&handler), "<h1>hello world</h1>", "content-type" => "text/html; charset=utf-8");
-    # }
+    assert_ok!(
+        get("/").run_async(&handler).await,
+        "<h1>hello world</h1>", "content-type" => "text/html; charset=utf-8"
+    );
+    # }); }
     ```
     */
     pub fn with_index_file(mut self, file: &str) -> Self {

--- a/static/src/static_conn_ext.rs
+++ b/static/src/static_conn_ext.rs
@@ -78,7 +78,7 @@ impl StaticConnExt for Conn {
                 .try_insert(KnownHeaderName::Etag, etag.to_string());
         }
 
-        #[cfg(all(feature = "tokio", not(feature = "smol"), not(feature = "async-std")))]
+        #[cfg(feature = "tokio")]
         let file = async_compat::Compat::new(file);
 
         self.ok(Body::new_streaming(file, Some(metadata.len())))


### PR DESCRIPTION
this improves the release process. When #398 releases, it'll be possible to optionally plumb an `Arc<dyn AsyncFs>` through shared state or something like that