### PR TITLE
client: impl into url for slices, arrays and vecs

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -157,6 +157,11 @@ impl Client {
         conn
     }
 
+    /// borrow the connector for this client
+    pub fn connector(&self) -> &Arc<dyn ObjectSafeConnector> {
+        &self.config
+    }
+
     /**
     The pool implementation currently accumulates a small memory
     footprint for each new host. If your application is reusing a pool

--- a/client/src/into_url.rs
+++ b/client/src/into_url.rs
@@ -40,3 +40,28 @@ impl IntoUrl for String {
         self.as_str().into_url(base)
     }
 }
+
+impl<S: AsRef<str>> IntoUrl for &[S] {
+    fn into_url(self, base: Option<&Url>) -> Result<Url> {
+        let Some(mut url) = base.cloned() else {
+            return Err(Error::UnexpectedUriFormat);
+        };
+        url.path_segments_mut()
+            .map_err(|_| Error::UnexpectedUriFormat)?
+            .pop_if_empty()
+            .extend(self);
+        Ok(url)
+    }
+}
+
+impl<S: AsRef<str>, const N: usize> IntoUrl for [S; N] {
+    fn into_url(self, base: Option<&Url>) -> Result<Url> {
+        self.as_slice().into_url(base)
+    }
+}
+
+impl<S: AsRef<str>> IntoUrl for Vec<S> {
+    fn into_url(self, base: Option<&Url>) -> Result<Url> {
+        self.as_slice().into_url(base)
+    }
+}

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -49,7 +49,7 @@ pub use trillium_http::{
 
 mod util;
 
-pub use trillium_server_common::{async_trait, Connector, Url};
+pub use trillium_server_common::{async_trait, Connector, ObjectSafeConnector, Url};
 
 /// constructs a new [`Client`] -- alias for [`Client::new`]
 pub fn client(connector: impl Connector) -> Client {

--- a/client/tests/base.rs
+++ b/client/tests/base.rs
@@ -36,6 +36,16 @@ async fn with_base() -> TestResult {
         .build_url("http://example.test/") // does not start with http://example.com/a/b/
         .is_err());
 
+    let id = 10usize;
+    assert_eq!(
+        client.build_url(["c", &id.to_string(), "d"])?.as_str(),
+        "http://example.com/a/b/c/10/d"
+    );
+    assert_eq!(
+        client.build_url(vec!["c", &id.to_string(), "d"])?.as_str(),
+        "http://example.com/a/b/c/10/d"
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
This uses `client.path_segments_mut()?.extend(…)`