### PR TITLE
feat(client): reexport trillium_http::{Body, Method}

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -44,7 +44,8 @@ mod client;
 pub use client::Client;
 
 pub use trillium_http::{
-    Error, HeaderName, HeaderValue, HeaderValues, Headers, KnownHeaderName, Result, Status, Version,
+    Body, Error, HeaderName, HeaderValue, HeaderValues, Headers, KnownHeaderName, Method, Result,
+    Status, Version,
 };
 
 mod util;


### PR DESCRIPTION
in order to facilitate use of trillium_client without additional dependencies other than connectors