### PR TITLE
 trillium-client: Add client WebSocket support 

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["trillium", "framework", "async"]
 categories = ["web-programming", "web-programming::http-client"]
 
 [features]
+websocket = ["dep:trillium-websockets"]
 json = ["serde_json", "serde", "thiserror"]
 
 [dependencies]
@@ -20,6 +21,7 @@ httparse = "1.8.0"
 log = "0.4.20"
 size = "0.4.1"
 trillium-server-common = { version = "0.4.7", path = "../server-common" }
+trillium-websockets = { version = "0.6.2", path = "../websockets", optional = true }
 url = "2.5.0"
 mime = "0.3.17"
 serde_json = { version = "1.0.108", optional = true }
@@ -42,6 +44,7 @@ indoc = "2.0.4"
 pretty_assertions = "1.4.0"
 test-harness = "0.2.0"
 trillium = { path = "../trillium" }
+trillium-client = { path = ".", features = ["websocket"] }
 trillium-smol = { path = "../smol/" }
 trillium-testing = { path = "../testing" }
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["trillium", "framework", "async"]
 categories = ["web-programming", "web-programming::http-client"]
 
 [features]
-websocket = ["dep:trillium-websockets"]
+websockets = ["dep:trillium-websockets"]
 json = ["serde_json", "serde", "thiserror"]
 
 [dependencies]
@@ -44,7 +44,7 @@ indoc = "2.0.4"
 pretty_assertions = "1.4.0"
 test-harness = "0.2.0"
 trillium = { path = "../trillium" }
-trillium-client = { path = ".", features = ["websocket"] }
+trillium-client = { path = ".", features = ["websockets"] }
 trillium-smol = { path = "../smol/" }
 trillium-testing = { path = "../testing" }
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["trillium", "framework", "async"]
 categories = ["web-programming", "web-programming::http-client"]
 
 [features]
-websockets = ["dep:trillium-websockets"]
+websockets = ["dep:trillium-websockets", "thiserror"]
 json = ["serde_json", "serde", "thiserror"]
 
 [dependencies]

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -36,11 +36,11 @@ pub use conn::{Conn, UnexpectedStatusError, USER_AGENT};
 #[cfg(feature = "json")]
 pub use conn::ClientSerdeError;
 
-#[cfg(feature = "websocket")]
+#[cfg(feature = "websockets")]
 pub mod websocket;
-#[cfg(feature = "websocket")]
+#[cfg(feature = "websockets")]
 pub use trillium_websockets::{async_tungstenite, tungstenite, WebSocketConfig, WebSocketConn};
-#[cfg(feature = "websocket")]
+#[cfg(feature = "websockets")]
 pub use websocket::WebSocketUpgradeError;
 
 mod pool;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -36,6 +36,13 @@ pub use conn::{Conn, UnexpectedStatusError, USER_AGENT};
 #[cfg(feature = "json")]
 pub use conn::ClientSerdeError;
 
+#[cfg(feature = "websocket")]
+pub mod websocket;
+#[cfg(feature = "websocket")]
+pub use trillium_websockets::{async_tungstenite, tungstenite, WebSocketConfig, WebSocketConn};
+#[cfg(feature = "websocket")]
+pub use websocket::WebSocketUpgradeError;
+
 mod pool;
 // open an issue if you have a reason for pool to be public
 pub(crate) use pool::Pool;

--- a/client/src/websocket.rs
+++ b/client/src/websocket.rs
@@ -1,0 +1,101 @@
+//! Support for client-side WebSockets
+
+use std::fmt::{self, Display};
+use std::ops::{Deref, DerefMut};
+
+use trillium_http::{
+    KnownHeaderName::{self, SecWebsocketAccept, SecWebsocketKey},
+    Status, Upgrade,
+};
+use trillium_websockets::{websocket_accept_hash, websocket_key, Role};
+
+use crate::{Conn, WebSocketConfig, WebSocketConn};
+
+pub use trillium_websockets::Message;
+
+impl Conn {
+    /// Set the appropriate headers for upgrading to a WebSocket
+    pub fn with_websocket_upgrade_headers(self) -> Conn {
+        self.with_header(KnownHeaderName::Upgrade, "websocket")
+            .with_header(KnownHeaderName::Connection, "upgrade")
+            .with_header(KnownHeaderName::SecWebsocketVersion, "13")
+            .with_header(SecWebsocketKey, websocket_key())
+    }
+
+    /// Turn this `Conn` into a [`WebSocketConn`]
+    pub async fn into_websocket(self) -> Result<WebSocketConn, WebSocketUpgradeError> {
+        self.into_websocket_with_config(WebSocketConfig::default())
+            .await
+    }
+
+    /// Turn this `Conn` into a [`WebSocketConn`], with a custom [`WebSocketConfig`]
+    pub async fn into_websocket_with_config(
+        self,
+        config: WebSocketConfig,
+    ) -> Result<WebSocketConn, WebSocketUpgradeError> {
+        let status = self
+            .status()
+            .expect("into_websocket() with request not yet sent; remember to call .await");
+        if status != Status::SwitchingProtocols {
+            return Err(WebSocketUpgradeError::new(
+                self,
+                "Expected status 101 (Switching Protocols)",
+            ));
+        }
+        let Some(key) = self.request_headers().get_str(SecWebsocketKey) else {
+            return Err(WebSocketUpgradeError::new(
+                self,
+                "Request did not include Sec-WebSocket-Key",
+            ));
+        };
+        let accept_key = websocket_accept_hash(key);
+        if self.response_headers().get_str(SecWebsocketAccept) != Some(&accept_key) {
+            return Err(WebSocketUpgradeError::new(
+                self,
+                "Response did not contain valid Sec-WebSocket-Accept",
+            ));
+        }
+        let peer_ip = self.peer_addr().map(|addr| addr.ip());
+        let mut conn = WebSocketConn::new(Upgrade::from(self), Some(config), Role::Client).await;
+        conn.set_peer_ip(peer_ip);
+        Ok(conn)
+    }
+}
+
+/// An attempted upgrade to a WebSocket failed. You can transform this back into the Conn with
+/// [`From::from`]/[`Into::into`].
+#[derive(Debug)]
+pub struct WebSocketUpgradeError(Box<Conn>, &'static str);
+
+impl WebSocketUpgradeError {
+    fn new(conn: Conn, msg: &'static str) -> Self {
+        Self(Box::new(conn), msg)
+    }
+}
+
+impl From<WebSocketUpgradeError> for Conn {
+    fn from(value: WebSocketUpgradeError) -> Self {
+        *value.0
+    }
+}
+
+impl Deref for WebSocketUpgradeError {
+    type Target = Conn;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl DerefMut for WebSocketUpgradeError {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl std::error::Error for WebSocketUpgradeError {}
+
+impl Display for WebSocketUpgradeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.1)
+    }
+}

--- a/client/tests/websocket.rs
+++ b/client/tests/websocket.rs
@@ -1,0 +1,37 @@
+use futures_lite::StreamExt;
+use trillium_client::{websocket::Message, Client, WebSocketConn};
+use trillium_testing::ClientConfig;
+use trillium_websockets::websocket;
+
+#[test]
+fn test_websocket() {
+    let handler = websocket(|mut conn: WebSocketConn| async move {
+        while let Some(Ok(Message::Text(input))) = conn.next().await {
+            conn.send_string(format!("Server received your message: {}", &input))
+                .await
+                .expect("send_string");
+        }
+    });
+
+    let client = Client::new(ClientConfig::new());
+
+    trillium_testing::with_server(handler, move |url| async move {
+        let mut ws = client
+            .get(url)
+            .with_websocket_upgrade_headers()
+            .await?
+            .into_websocket()
+            .await?;
+
+        ws.send_string("Client test message".to_string()).await?;
+
+        let response = ws.next().await.expect("response")?;
+
+        assert_eq!(
+            response,
+            Message::Text("Server received your message: Client test message".to_string()),
+        );
+
+        Ok(())
+    })
+}

--- a/client/tests/websocket.rs
+++ b/client/tests/websocket.rs
@@ -4,7 +4,7 @@ use trillium_testing::ClientConfig;
 use trillium_websockets::websocket;
 
 #[test]
-fn test_websocket() {
+fn test_websockets() {
     let handler = websocket(|mut conn: WebSocketConn| async move {
         while let Some(Ok(Message::Text(input))) = conn.next().await {
             conn.send_string(format!("Server received your message: {}", &input))

--- a/websockets/Cargo.toml
+++ b/websockets/Cargo.toml
@@ -18,7 +18,7 @@ default = []
 json = ["serde_json", "serde"]
 
 [dependencies]
-async-tungstenite = "0.24.0"
+async-tungstenite = { version = "0.24.0", default-features = false }
 base64 = "0.21.5"
 fastrand = "2.0.1"
 futures-lite = "2.1.0"
@@ -34,6 +34,7 @@ trillium = { path = "../trillium", version = "0.2.13" }
 trillium-http = { path = "../http", version = "0.3.11" }
 
 [dev-dependencies]
+async-tungstenite = { version = "0.24.0", default-features = false, features = ["handshake"] }
 serde = { version = "1.0.193", features = ["derive"] }
 async-channel = "2.1.1"
 async-net = "2.0.0"

--- a/websockets/src/websocket_connection.rs
+++ b/websockets/src/websocket_connection.rs
@@ -68,6 +68,7 @@ impl WebSocketConn {
     ///
     /// You should not typically need to call this; the trillium client and server both provide
     /// your code with a `WebSocketConn`.
+    #[doc(hidden)]
     pub async fn new(upgrade: Upgrade, config: Option<WebSocketConfig>, role: Role) -> Self {
         let Upgrade {
             request_headers,


### PR DESCRIPTION
Add a `websocket` feature gating support for client-side WebSocket
support. When set, provide methods on `trillium_client::Conn` that allow
upgrading to a `WebSocketConn`.

Usage:

```rust
let mut ws = client
    .get(url)
    .with_websocket_upgrade_headers()
    .await?
    .into_websocket()
    .await?;

ws.send_string(format!("Hello from a WebSocket client!")).await?;
```

Having this support natively in trillium allows reusing a connection
from the connection pool when establishing a WebSocket connection
(though of course the connection cannot go *back* to the pool). It also
allows using any headers and base already set on the client. And
finally, it allows clients to avoid some of async-tungstenite's
dependencies, such as async-tls and rustls, in favor of
trillium-client's dependencies.