### PR TITLE
feat(http): cancel on disconnect

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.7.3
       - name: Generate code coverage
-        run: cargo +nightly tarpaulin --verbose --features smol,trillium-testing/smol,serde --workspace --timeout 120 --out xml
+        run: cargo +nightly tarpaulin --verbose --features smol,trillium-testing/smol,trillium-http/serde --workspace --timeout 120 --out xml
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v4
         with:

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["trillium", "framework", "async"]
 categories = ["web-programming", "web-programming::http-client"]
 
 [features]
-websockets = ["dep:trillium-websockets", "thiserror"]
-json = ["serde_json", "serde", "thiserror"]
+websockets = ["dep:trillium-websockets", "dep:thiserror"]
+json = ["dep:serde_json", "dep:serde", "dep:thiserror"]
 
 [dependencies]
 encoding_rs = "0.8.33"

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["web-programming::http-server", "web-programming"]
 
 [features]
 unstable = []
-http-compat = ["http0"]
-http-compat-1 = ["http1"]
+http-compat = ["dep:http0"]
+http-compat-1 = ["dep:http1"]
 serde = ["dep:serde"]
 
 [dependencies]

--- a/http/src/conn.rs
+++ b/http/src/conn.rs
@@ -111,7 +111,7 @@ where
         handler: F,
     ) -> Result<Option<Upgrade<Transport>>>
     where
-        F: Fn(Conn<Transport>) -> Fut,
+        F: FnMut(Conn<Transport>) -> Fut,
         Fut: Future<Output = Conn<Transport>> + Send,
     {
         Self::map_with_config(DEFAULT_CONFIG, transport, stopper, handler).await
@@ -140,10 +140,10 @@ where
         http_config: HttpConfig,
         transport: Transport,
         stopper: Stopper,
-        handler: F,
+        mut handler: F,
     ) -> Result<Option<Upgrade<Transport>>>
     where
-        F: Fn(Conn<Transport>) -> Fut,
+        F: FnMut(Conn<Transport>) -> Fut,
         Fut: Future<Output = Conn<Transport>> + Send,
     {
         let mut conn = Conn::new_with_config(

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -155,3 +155,5 @@ mod copy;
 pub use copy::copy;
 #[cfg(not(feature = "unstable"))]
 pub(crate) use copy::copy;
+
+mod liveness;

--- a/http/src/liveness.rs
+++ b/http/src/liveness.rs
@@ -1,0 +1,68 @@
+use crate::Conn;
+use futures_lite::{AsyncRead, AsyncWrite};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+pub(crate) struct LivenessFut<'a, T>(pub(crate) &'a mut Conn<T>);
+impl<T> Future for LivenessFut<'_, T>
+where
+    T: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
+{
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let LivenessFut(Conn {
+            buffer, transport, ..
+        }) = &mut *self;
+
+        let len = buffer.len();
+        buffer.expand();
+        match Pin::new(transport).poll_read(cx, &mut buffer[len..]) {
+            Poll::Pending => {
+                buffer.truncate(len);
+                Poll::Pending
+            }
+
+            Poll::Ready(Err(_)) => {
+                buffer.truncate(len);
+                Poll::Ready(())
+            }
+
+            Poll::Ready(Ok(n)) => {
+                buffer.truncate(len + n);
+                if n == 0 {
+                    Poll::Ready(())
+                } else {
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            }
+        }
+    }
+}
+
+pub(crate) struct CancelOnDisconnect<'a, Fut, T>(
+    pub(crate) &'a mut Conn<T>,
+    pub(crate) Pin<&'a mut Fut>,
+);
+impl<'a, Fut, T> Future for CancelOnDisconnect<'a, Fut, T>
+where
+    Fut: Future + Send + 'a,
+    T: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
+{
+    type Output = Option<Fut::Output>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let CancelOnDisconnect(conn, fut) = &mut *self;
+        let fut_poll = fut.as_mut().poll(cx);
+        let disconnect = Pin::new(&mut LivenessFut(conn)).poll(cx);
+        match (fut_poll, disconnect) {
+            (Poll::Ready(output), _) => Poll::Ready(Some(output)),
+            (Poll::Pending, Poll::Ready(())) => Poll::Ready(None),
+            (Poll::Pending, Poll::Pending) => Poll::Pending,
+        }
+    }
+}

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -103,7 +103,8 @@ pub use futures_lite::{AsyncRead, AsyncReadExt, AsyncWrite};
 mod server_connector;
 pub use server_connector::{connector, ServerConnector};
 
-use trillium_server_common::{Config, Connector, Server};
+use trillium_server_common::Config;
+pub use trillium_server_common::{Connector, ObjectSafeConnector, Server};
 
 #[derive(Debug)]
 /// A droppable future

--- a/testing/src/runtimeless.rs
+++ b/testing/src/runtimeless.rs
@@ -51,7 +51,7 @@ impl Server for RuntimelessServer {
     }
 
     fn info(&self) -> Info {
-        Info::from(&*format!("test server {}:{}", self.host, self.port))
+        Info::from(&*format!("{}:{}", &self.host, &self.port))
     }
 
     fn block_on(fut: impl Future<Output = ()> + 'static) {

--- a/testing/src/test_transport.rs
+++ b/testing/src/test_transport.rs
@@ -48,6 +48,7 @@ impl TestTransport {
 
     /// close this transport, representing a disconnection
     pub fn close(&mut self) {
+        self.read.close();
         self.write.close();
     }
 

--- a/trillium/Cargo.toml
+++ b/trillium/Cargo.toml
@@ -10,6 +10,12 @@ readme = "../README.md"
 keywords = ["trillium", "framework", "async"]
 categories = ["web-programming::http-server", "web-programming"]
 
+[features]
+unstable = ["trillium-http/unstable"]
+http-compat = ["trillium-http/http-compat"]
+http-compat-1 = ["trillium-http/http-compat-1"]
+serde = ["trillium-http/serde"]
+
 [dependencies]
 async-trait = "0.1.75"
 futures-lite = "2.1.0"

--- a/trillium/Cargo.toml
+++ b/trillium/Cargo.toml
@@ -17,6 +17,8 @@ log = "0.4.20"
 trillium-http = { path = "../http", version = "0.3.11" }
 
 [dev-dependencies]
+async-io = "2.3.1"
+fastrand = "2.0.1"
 trillium-smol = { path = "../smol" }
 trillium-testing = { path = "../testing" }
 

--- a/trillium/Cargo.toml
+++ b/trillium/Cargo.toml
@@ -25,6 +25,7 @@ trillium-http = { path = "../http", version = "0.3.11" }
 [dev-dependencies]
 async-io = "2.3.1"
 fastrand = "2.0.1"
+test-harness = "0.2.0"
 trillium-smol = { path = "../smol" }
 trillium-testing = { path = "../testing" }
 

--- a/trillium/examples/liveness.rs
+++ b/trillium/examples/liveness.rs
@@ -1,0 +1,26 @@
+use std::time::{Duration, Instant};
+
+use async_io::Timer;
+
+fn main() {
+    trillium_smol::run(|mut conn: trillium::Conn| async move {
+        let start = Instant::now();
+        let count = conn
+            .cancel_on_disconnect(async move {
+                let count = fastrand::u8(..10);
+                for i in 0..count {
+                    Timer::after(Duration::from_millis(500)).await;
+                    println!("{i}: {:?} elapsed", start.elapsed());
+                }
+                count
+            })
+            .await;
+        if let Some(count) = count {
+            println!("completed");
+            conn.ok(format!("ok: {count}"))
+        } else {
+            println!("disconnected");
+            conn
+        }
+    });
+}

--- a/trillium/tests/liveness.rs
+++ b/trillium/tests/liveness.rs
@@ -1,0 +1,39 @@
+use futures_lite::{future::poll_once, AsyncReadExt, AsyncWriteExt};
+use std::future::pending;
+use test_harness::test;
+use trillium::Conn;
+use trillium_testing::{config, harness, ClientConfig, Connector, ObjectSafeConnector, TestResult};
+
+#[test(harness)]
+async fn infinitely_pending_task() -> TestResult {
+    let handle = config()
+        .with_host("localhost")
+        .with_port(0)
+        .spawn(|mut conn: Conn| async move {
+            conn.cancel_on_disconnect(pending::<()>()).await;
+            conn
+        });
+
+    let info = handle.info().await;
+
+    let url = format!("http://{}", info.listener_description())
+        .parse()
+        .unwrap();
+    let mut client = Connector::connect(&ClientConfig::default().boxed(), &url).await?;
+
+    client
+        .write_all(b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+        .await?;
+
+    let mut byte = [0u8];
+    assert!(poll_once(client.read(&mut byte)).await.is_none()); // nothing to read; the handler has
+                                                                // not responded
+
+    client.close().await?; // closing the client before we receive a response
+
+    handle.stop().await; // wait for a graceful shutdown the fact that we terminate here indicates
+                         // that the handler is not still running even though it polls an infinitely
+                         // pending future
+
+    Ok(())
+}


### PR DESCRIPTION
This introduces `conn.cancel_on_disconnect(async { … }).await`, which polls the transport for empty reads (or io errors) and cancels the wrapped future, returning None. If the future completes without the client disconnecting, it will return Some with the output of the future

This PR also includes some small improvements encountered along the way