### PR TITLE
feat(router)!: remove routefinder types from the public api

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -106,3 +106,6 @@ macro_rules! routes {
 pub fn router() -> Router {
     Router::new()
 }
+
+pub(crate) struct CapturesNewType<'a, 'b>(routefinder::Captures<'a, 'b>);
+pub(crate) struct RouteSpecNewType(routefinder::RouteSpec);

--- a/router/src/router.rs
+++ b/router/src/router.rs
@@ -1,4 +1,4 @@
-use crate::RouterRef;
+use crate::{CapturesNewType, RouteSpecNewType, RouterRef};
 use routefinder::{Captures, Match, RouteSpec, Router as Routefinder};
 use std::{
     collections::BTreeSet,
@@ -411,7 +411,7 @@ impl Router {
 impl Handler for Router {
     async fn run(&self, mut conn: Conn) -> Conn {
         let method = conn.method();
-        let original_captures = conn.take_state::<Captures>();
+        let original_captures = conn.take_state();
         let path = conn.path();
         let mut has_path = false;
 
@@ -420,7 +420,7 @@ impl Handler for Router {
 
             let route = m.route().clone();
 
-            if let Some(mut original_captures) = original_captures {
+            if let Some(CapturesNewType(mut original_captures)) = original_captures {
                 original_captures.append(captures);
                 captures = original_captures;
             }
@@ -435,7 +435,8 @@ impl Handler for Router {
                         has_path = true;
                     }
 
-                    conn.with_state(captures).with_state(route)
+                    conn.with_state(CapturesNewType(captures))
+                        .with_state(RouteSpecNewType(route))
                 })
                 .await;
 

--- a/router/src/router_conn_ext.rs
+++ b/router/src/router_conn_ext.rs
@@ -1,4 +1,4 @@
-use routefinder::{Captures, RouteSpec};
+use crate::{CapturesNewType, RouteSpecNewType};
 use trillium::Conn;
 
 /**
@@ -71,20 +71,20 @@ pub trait RouterConnExt {
     ///     "route was /pages/:page_id"
     /// );
     /// ```
-    fn route(&self) -> Option<&RouteSpec>;
+    fn route(&self) -> Option<&str>;
 }
 
 impl RouterConnExt for Conn {
     fn param<'a>(&'a self, param: &str) -> Option<&'a str> {
-        self.state::<Captures>().and_then(|p| p.get(param))
+        self.state().and_then(|CapturesNewType(p)| p.get(param))
     }
 
     fn wildcard(&self) -> Option<&str> {
-        self.state::<Captures>().and_then(|p| p.wildcard())
+        self.state().and_then(|CapturesNewType(p)| p.wildcard())
     }
 
-    fn route(&self) -> Option<&RouteSpec> {
-        self.state()
+    fn route(&self) -> Option<&str> {
+        self.state().and_then(|RouteSpecNewType(r)| r.source())
     }
 }
 


### PR DESCRIPTION
Motivation: trillium-router should be able to update a major version of routefinder and release as a patch release if the public trillium-router interface does not change. Previously, we were leaking routefinder types through state and the RouterConnExt::route interface.