### PR TITLE
Fix synthetic body and is_disconnected

### DIFF
--- a/http/src/conn.rs
+++ b/http/src/conn.rs
@@ -442,7 +442,7 @@ where
     /// }
     /// ```
     pub async fn is_disconnected(&mut self) -> bool {
-        future::poll_once(LivenessFut(self)).await.is_none()
+        future::poll_once(LivenessFut(self)).await.is_some()
     }
 
     fn needs_100_continue(&self) -> bool {

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -32,6 +32,7 @@ async-channel = "2.1.1"
 trillium-macros = { version = "0.0.5", path = "../macros" }
 dashmap = "5.5.3"
 once_cell = "1.19.0"
+fastrand = "2.0.1"
 
 [dependencies.trillium-smol]
 path = "../smol"

--- a/testing/src/runtimeless.rs
+++ b/testing/src/runtimeless.rs
@@ -38,15 +38,27 @@ impl Server for RuntimelessServer {
     where
         A: Acceptor<Self::Transport>,
     {
+        let mut port = config.port();
+        let host = config.host();
+        if port == 0 {
+            loop {
+                port = fastrand::u16(..);
+                if !SERVERS.contains_key(&(host.clone(), port)) {
+                    break;
+                }
+            }
+        }
+
         let entry = SERVERS
-            .entry((config.host(), config.port()))
+            .entry((host.clone(), port))
             .or_insert_with(async_channel::unbounded);
+
         let (_, channel) = entry.value();
 
         Self {
-            host: config.host(),
+            host,
             channel: channel.clone(),
-            port: config.port(),
+            port,
         }
     }
 

--- a/testing/src/test_transport.rs
+++ b/testing/src/test_transport.rs
@@ -75,6 +75,12 @@ impl TestTransport {
     }
 }
 
+impl Drop for TestTransport {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
 #[derive(Default)]
 struct CloseableCursorInner {
     data: Vec<u8>,
@@ -248,7 +254,6 @@ impl AsyncWrite for &CloseableCursor {
     }
 
     fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        self.close();
         Poll::Ready(Ok(()))
     }
 }

--- a/testing/tests/cancel_on_disconnect.rs
+++ b/testing/tests/cancel_on_disconnect.rs
@@ -1,0 +1,25 @@
+use test_harness::test;
+use trillium_testing::prelude::*;
+
+#[test]
+fn body_does_not_report_closure() {
+    let handler = |mut conn: Conn| async move {
+        let body = conn.request_body().await.read_string().await.unwrap();
+
+        if conn.is_disconnected().await {
+            return conn.with_status(500);
+        }
+
+        if conn
+            .cancel_on_disconnect(futures_lite::future::yield_now())
+            .await
+            .is_none()
+        {
+            return conn.with_status(501);
+        }
+
+        conn.ok("ok").with_body(body)
+    };
+
+    assert_ok!(get("/").with_request_body("body").on(&handler), "body");
+}

--- a/trillium/Cargo.toml
+++ b/trillium/Cargo.toml
@@ -23,6 +23,7 @@ log = "0.4.20"
 trillium-http = { path = "../http", version = "0.3.13" }
 
 [dev-dependencies]
+async-channel = "2.1.1"
 async-io = "2.3.1"
 fastrand = "2.0.1"
 test-harness = "0.2.0"

--- a/trillium/tests/liveness.rs
+++ b/trillium/tests/liveness.rs
@@ -86,7 +86,8 @@ async fn is_disconnected() -> TestResult {
     client
         .write_all(b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
         .await?;
-    client.close().await?;
+    drop(client);
+
     delay_sender.send(()).await?;
     assert!(disconnected_receiver.recv().await?);
 

--- a/trillium/tests/liveness.rs
+++ b/trillium/tests/liveness.rs
@@ -1,5 +1,10 @@
-use futures_lite::{future::poll_once, AsyncReadExt, AsyncWriteExt};
-use std::future::pending;
+use futures_lite::{future::poll_once, AsyncRead, AsyncReadExt, AsyncWriteExt};
+use std::{
+    future::{pending, Future},
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
 use test_harness::test;
 use trillium::Conn;
 use trillium_testing::{config, harness, ClientConfig, Connector, ObjectSafeConnector, TestResult};
@@ -36,4 +41,84 @@ async fn infinitely_pending_task() -> TestResult {
                          // pending future
 
     Ok(())
+}
+
+#[test(harness)]
+async fn is_disconnected() -> TestResult {
+    let (delay_sender, delay_receiver) = async_channel::unbounded();
+    let (disconnected_sender, disconnected_receiver) = async_channel::unbounded();
+    let handle = config()
+        .with_host("localhost")
+        .with_port(0)
+        .spawn(move |mut conn: Conn| {
+            let disconnected_sender = disconnected_sender.clone();
+            let delay_receiver = delay_receiver.clone();
+            async move {
+                delay_receiver.recv().await.unwrap();
+                disconnected_sender
+                    .send(dbg!(conn.is_disconnected().await))
+                    .await
+                    .unwrap();
+                conn.ok("ok")
+            }
+        });
+
+    let info = handle.info().await;
+
+    let url = format!("http://{}", info.listener_description())
+        .parse()
+        .unwrap();
+    let mut client = Connector::connect(&ClientConfig::default().boxed(), &url).await?;
+
+    client
+        .write_all(b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+        .await?;
+
+    delay_sender.send(()).await?;
+
+    assert!(!disconnected_receiver.recv().await?);
+
+    let s = String::from_utf8(ReadAvailable(&mut client).await?)?;
+    assert!(s.starts_with("HTTP/1.1 200 OK\r\n"));
+    client.close().await?;
+
+    let mut client = Connector::connect(&ClientConfig::default().boxed(), &url).await?;
+    client
+        .write_all(b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+        .await?;
+    client.close().await?;
+    delay_sender.send(()).await?;
+    assert!(disconnected_receiver.recv().await?);
+
+    handle.stop().await;
+
+    Ok(())
+}
+
+struct ReadAvailable<T>(T);
+impl<T: AsyncRead + Unpin> Future for ReadAvailable<T> {
+    type Output = io::Result<Vec<u8>>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut buf = vec![];
+        let mut bytes_read = 0;
+        loop {
+            if buf.len() == bytes_read {
+                buf.reserve(32);
+                buf.resize(buf.capacity(), 0);
+            }
+            match Pin::new(&mut self.0).poll_read(cx, &mut buf[bytes_read..]) {
+                Poll::Ready(Ok(0)) => break,
+                Poll::Ready(Ok(new_bytes)) => {
+                    bytes_read += new_bytes;
+                }
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending if bytes_read == 0 => return Poll::Pending,
+                Poll::Pending => break,
+            }
+        }
+
+        buf.truncate(bytes_read);
+        Poll::Ready(Ok(buf))
+    }
 }


### PR DESCRIPTION
Prior to this PR, `Conn<Synthetic>` and `trillium_testing::TestConn` were incompatible with disconnection testing because a cursor that has been read to end returns `Poll::Ready(Ok(0))`, which we use one indication of a closed connection.

Additionally, the logic in Conn::is_disconnected was exactly backwards because I had written it as `Conn::is_connected` and then changed the name because all usage was negating the result. However, I did not change the logic to follow the name so it was always wrong. This was possible because it was untested. Tests have now been added for Conn::is_disconnected.