### PR TITLE
feat(test): add corpus tests

### DIFF
--- a/http/tests/corpus.rs
+++ b/http/tests/corpus.rs
@@ -1,0 +1,101 @@
+use indoc::formatdoc;
+use pretty_assertions::assert_eq;
+use test_harness::test;
+use trillium_http::{Conn, KnownHeaderName, Stopper};
+use trillium_testing::{harness, TestTransport};
+const TEST_DATE: &str = "Tue, 21 Nov 2023 21:27:21 GMT";
+
+async fn handler(mut conn: Conn<TestTransport>) -> Conn<TestTransport> {
+    let response_body = formatdoc! {"
+        ===request===
+        method: {method}
+        path: {path}
+        version: {version}
+
+        ===headers===
+        {headers}
+        ",
+        method = conn.method(),
+        path = conn.path(),
+        version = conn.http_version(),
+        headers = conn.request_headers()
+    };
+
+    conn.response_headers_mut()
+        .insert(KnownHeaderName::Date, TEST_DATE);
+    conn.response_headers_mut()
+        .insert(KnownHeaderName::Server, "corpus-test");
+
+    match conn.request_body().await.read_string().await {
+        Ok(request_body) => {
+            conn.set_status(200);
+            conn.set_response_body(format!("{response_body}===body===\n{request_body}"));
+        }
+
+        Err(e) => {
+            conn.set_status(500);
+            conn.set_response_body(format!("{response_body}===error===\n{e}"));
+        }
+    };
+
+    conn
+}
+
+#[test(harness)]
+async fn corpus_test() {
+    env_logger::init();
+    let dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/corpus");
+    let filter = std::env::var("CORPUS_TEST_FILTER").unwrap_or_default();
+    let corpus_request_files = std::fs::read_dir(dir)
+        .unwrap()
+        .filter_map(|f| {
+            let path = f.unwrap().path();
+            if path.extension().and_then(|x| x.to_str()) == Some("request") {
+                Some(path)
+            } else {
+                None
+            }
+        })
+        .filter(|f| f.to_str().unwrap().contains(&filter));
+
+    for file in corpus_request_files {
+        let request = std::fs::read_to_string(&file)
+            .unwrap_or_else(|_| panic!("could not read {}", file.display()))
+            .replace(['\r', '\n'], "")
+            .replace("\\r", "\r")
+            .replace("\\n", "\n");
+
+        let (client, server) = TestTransport::new();
+        let stopper = Stopper::new();
+        let res = trillium_testing::spawn({
+            let stopper = stopper.clone();
+            async move { Conn::map(server, stopper, handler).await }
+        });
+
+        client.write_all(request);
+        let (response, extension) = match res.await.unwrap() {
+            Ok(None) => (client.read_available_string().await, "response"),
+            Err(e) => (e.to_string(), "error"),
+            Ok(Some(_)) => ("".to_string(), "upgrade"),
+        };
+
+        let response_file = file.with_extension(extension);
+
+        if option_env!("CORPUS_TEST_WRITE").is_some() {
+            std::fs::write(
+                response_file,
+                response.replace('\r', "\\r").replace('\n', "\\n\n"),
+            )
+            .unwrap();
+        } else {
+            let expected_response = std::fs::read_to_string(response_file)
+                .unwrap()
+                .replace(['\n', '\r'], "")
+                .replace("\\r", "\r")
+                .replace("\\n", "\n");
+            assert_eq!(expected_response, response, "{file:?}");
+        }
+
+        stopper.stop();
+    }
+}

--- a/http/tests/corpus/1.request
+++ b/http/tests/corpus/1.request
@@ -1,0 +1,7 @@
+POST http://example.com:8080/ogdlqgxkbepd HTTP/1.1\r\n
+Host: example.com:8080\r\n
+Transfer-Encoding: chunked\r\n
+Connection: close\r\n
+\r\n
+0; name=value\r\n
+\r\n

--- a/http/tests/corpus/1.response
+++ b/http/tests/corpus/1.response
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK\r\n
+Server: corpus-test\r\n
+Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
+Content-Length: 186\r\n
+\r\n
+===request===\n
+method: POST\n
+path: http://example.com:8080/ogdlqgxkbepd\n
+version: HTTP/1.1\n
+\n
+===headers===\n
+Connection: close\r\n
+Host: example.com:8080\r\n
+Transfer-Encoding: chunked\r\n
+\n
+===body===\n

--- a/http/tests/corpus/10.request
+++ b/http/tests/corpus/10.request
@@ -1,0 +1,4 @@
+GET http://example.com/ HTTP/1.1\r\n
+Host: example.com:8080\r\n
+Connection: close\r\n
+\r\n

--- a/http/tests/corpus/10.response
+++ b/http/tests/corpus/10.response
@@ -1,0 +1,15 @@
+HTTP/1.1 200 OK\r\n
+Server: corpus-test\r\n
+Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
+Content-Length: 140\r\n
+\r\n
+===request===\n
+method: GET\n
+path: http://example.com/\n
+version: HTTP/1.1\n
+\n
+===headers===\n
+Host: example.com:8080\r\n
+Connection: close\r\n
+\n
+===body===\n

--- a/http/tests/corpus/2.request
+++ b/http/tests/corpus/2.request
@@ -1,0 +1,9 @@
+POST http://example.com:8080/aedhcajqmrqy HTTP/1.1\r\n
+Transfer-Encoding: chunked\r\n
+Host: example.com:8080\r\n
+Connection: close\r\n
+\r\n
+64; name="egtaww[ ... 16363 bytes, MD5: 1c8632befae6770ccd3fd2315df745c8 ]zkhnpunivhjsafwd"\r\n
+dojsfxsbxnctecvdoeseagowpyosdnvibeagbukbjmwnqtsgxlkatbwizkaexwmycohgithrhfhzzzfykqyftuoshqygokhryoxi\r\n
+0\r\n
+\r\n

--- a/http/tests/corpus/2.response
+++ b/http/tests/corpus/2.response
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK\r\n
+Server: corpus-test\r\n
+Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
+Content-Length: 286\r\n
+\r\n
+===request===\n
+method: POST\n
+path: http://example.com:8080/aedhcajqmrqy\n
+version: HTTP/1.1\n
+\n
+===headers===\n
+Connection: close\r\n
+Host: example.com:8080\r\n
+Transfer-Encoding: chunked\r\n
+\n
+===body===\n
+dojsfxsbxnctecvdoeseagowpyosdnvibeagbukbjmwnqtsgxlkatbwizkaexwmycohgithrhfhzzzfykqyftuoshqygokhryoxi

--- a/http/tests/corpus/3.request
+++ b/http/tests/corpus/3.request
@@ -1,0 +1,9 @@
+POST http://example.com:8080/zcdkvxbjdgwt HTTP/1.1\r\n
+Transfer-Encoding: chunked\r\n
+Host: example.com:8080\r\n
+Connection: close\r\n
+\r\n
+64; name=hettnje[ ... 16362 bytes, MD5: c7fcaca7d0fe4e8fcc517bfdebad28f7 ]ibsoiezrjwttqkvo\r\n
+bqfimbbuacdeohawiumsynkjkfccpaqsqydfbezegciwmiuwegpdtzofgtjxtcqlavqbzpfhuqdgazefftkauyiarryktqyvlozk\r\n
+0\r\n
+\r\n

--- a/http/tests/corpus/3.response
+++ b/http/tests/corpus/3.response
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK\r\n
+Server: corpus-test\r\n
+Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
+Content-Length: 286\r\n
+\r\n
+===request===\n
+method: POST\n
+path: http://example.com:8080/zcdkvxbjdgwt\n
+version: HTTP/1.1\n
+\n
+===headers===\n
+Connection: close\r\n
+Host: example.com:8080\r\n
+Transfer-Encoding: chunked\r\n
+\n
+===body===\n
+bqfimbbuacdeohawiumsynkjkfccpaqsqydfbezegciwmiuwegpdtzofgtjxtcqlavqbzpfhuqdgazefftkauyiarryktqyvlozk

--- a/http/tests/corpus/4.request
+++ b/http/tests/corpus/4.request
@@ -1,0 +1,10 @@
+POST http://example.com:8080/ouepavuazxic HTTP/1.1\r\n
+Transfer-Encoding: chunked\r\n
+Host: example.com:8080\r\n
+Connection: close\r\n
+\r\n
+
+64; chunkextname\r\n
+pbcggproccuzedwmqgktnsboanhpqdqhgunojgdnixopambsvlmigpwiefzwkrermtfxaknkibzkqddnqrvyithpbgllyremlmln\r\n
+0\r\n
+\r\n

--- a/http/tests/corpus/4.response
+++ b/http/tests/corpus/4.response
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK\r\n
+Server: corpus-test\r\n
+Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
+Content-Length: 286\r\n
+\r\n
+===request===\n
+method: POST\n
+path: http://example.com:8080/ouepavuazxic\n
+version: HTTP/1.1\n
+\n
+===headers===\n
+Connection: close\r\n
+Host: example.com:8080\r\n
+Transfer-Encoding: chunked\r\n
+\n
+===body===\n
+pbcggproccuzedwmqgktnsboanhpqdqhgunojgdnixopambsvlmigpwiefzwkrermtfxaknkibzkqddnqrvyithpbgllyremlmln

--- a/http/tests/corpus/5.request
+++ b/http/tests/corpus/5.request
@@ -1,0 +1,10 @@
+POST http://example.com:8080/xtukkkklnpvi HTTP/1.1\r\n
+Transfer-Encoding: chunked\r\n
+Host: example.com:8080\r\n
+Connection: close\r\n
+\r\n
+
+64; name="quoted string"\r\n
+qjqfopqotmpbqxzzxtuvmhelmcpcwvupekwszmjuaywqxxpurksdtyriagkzbeoiokcqwlmyliojiefbqzglxxtagdzjjnraxuqv\r\n
+0\r\n
+\r\n

--- a/http/tests/corpus/5.response
+++ b/http/tests/corpus/5.response
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK\r\n
+Server: corpus-test\r\n
+Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
+Content-Length: 286\r\n
+\r\n
+===request===\n
+method: POST\n
+path: http://example.com:8080/xtukkkklnpvi\n
+version: HTTP/1.1\n
+\n
+===headers===\n
+Connection: close\r\n
+Host: example.com:8080\r\n
+Transfer-Encoding: chunked\r\n
+\n
+===body===\n
+qjqfopqotmpbqxzzxtuvmhelmcpcwvupekwszmjuaywqxxpurksdtyriagkzbeoiokcqwlmyliojiefbqzglxxtagdzjjnraxuqv

--- a/http/tests/corpus/6.request
+++ b/http/tests/corpus/6.request
@@ -1,0 +1,10 @@
+POST http://example.com:8080/mztsfqlumrlm HTTP/1.1\r\n
+Transfer-Encoding: chunked\r\n
+Host: example.com:8080\r\n
+Connection: close\r\n
+\r\n
+
+64; name = value\r\n
+stmybbtrcepyectdqextknxfchibejjwevuhyqzawqaauudlycgipepulzxrigoodkvbawcyoeyjyewygciyizsvyrngzdwcpufq\r\n
+0\r\n
+\r\n

--- a/http/tests/corpus/6.response
+++ b/http/tests/corpus/6.response
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK\r\n
+Server: corpus-test\r\n
+Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
+Content-Length: 286\r\n
+\r\n
+===request===\n
+method: POST\n
+path: http://example.com:8080/mztsfqlumrlm\n
+version: HTTP/1.1\n
+\n
+===headers===\n
+Connection: close\r\n
+Host: example.com:8080\r\n
+Transfer-Encoding: chunked\r\n
+\n
+===body===\n
+stmybbtrcepyectdqextknxfchibejjwevuhyqzawqaauudlycgipepulzxrigoodkvbawcyoeyjyewygciyizsvyrngzdwcpufq

--- a/http/tests/corpus/7.request
+++ b/http/tests/corpus/7.request
@@ -1,0 +1,10 @@
+POST http://example.com:8080/ngmmfwqdrlpe HTTP/1.1\r\n
+Transfer-Encoding: chunked\r\n
+Host: example.com:8080\r\n
+Connection: close\r\n
+\r\n
+
+64; name=value\r\n
+wyxgczrucwhsncrxxamygamgrqseegrbgrhiqyeuwlojphjnhvnqvzwpsrvwxpzdghoyhsseggpvoykxwyntzmirdgqcvphbwxbg\r\n
+0\r\n
+\r\n

--- a/http/tests/corpus/7.response
+++ b/http/tests/corpus/7.response
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK\r\n
+Server: corpus-test\r\n
+Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
+Content-Length: 286\r\n
+\r\n
+===request===\n
+method: POST\n
+path: http://example.com:8080/ngmmfwqdrlpe\n
+version: HTTP/1.1\n
+\n
+===headers===\n
+Connection: close\r\n
+Host: example.com:8080\r\n
+Transfer-Encoding: chunked\r\n
+\n
+===body===\n
+wyxgczrucwhsncrxxamygamgrqseegrbgrhiqyeuwlojphjnhvnqvzwpsrvwxpzdghoyhsseggpvoykxwyntzmirdgqcvphbwxbg

--- a/http/tests/corpus/8.request
+++ b/http/tests/corpus/8.request
@@ -1,0 +1,4 @@
+PATCH http://example.com:8080/ogdlqgxkbepd HTTP/1.1\r\n
+Host: example.com:8080\r\n
+Connection: close\r\n
+\r\n

--- a/http/tests/corpus/8.response
+++ b/http/tests/corpus/8.response
@@ -1,0 +1,15 @@
+HTTP/1.1 200 OK\r\n
+Server: corpus-test\r\n
+Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
+Content-Length: 159\r\n
+\r\n
+===request===\n
+method: PATCH\n
+path: http://example.com:8080/ogdlqgxkbepd\n
+version: HTTP/1.1\n
+\n
+===headers===\n
+Host: example.com:8080\r\n
+Connection: close\r\n
+\n
+===body===\n

--- a/http/tests/corpus/9.request
+++ b/http/tests/corpus/9.request
@@ -1,0 +1,5 @@
+PATCH http://example.com:8080/ HTTP/1.1\r\n
+Host: example.com:8080\r\n
+Connection: close\r\n
+X-Unknown-Header: 111\r\n
+\r\n

--- a/http/tests/corpus/9.response
+++ b/http/tests/corpus/9.response
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK\r\n
+Server: corpus-test\r\n
+Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
+Content-Length: 170\r\n
+\r\n
+===request===\n
+method: PATCH\n
+path: http://example.com:8080/\n
+version: HTTP/1.1\n
+\n
+===headers===\n
+Host: example.com:8080\r\n
+Connection: close\r\n
+X-Unknown-Header: 111\r\n
+\n
+===body===\n

--- a/http/tests/corpus/footers.error
+++ b/http/tests/corpus/footers.error
@@ -1,0 +1,1 @@
+invalid new line

--- a/http/tests/corpus/footers.request
+++ b/http/tests/corpus/footers.request
@@ -1,0 +1,14 @@
+GET / HTTP/1.1
+Host: example.com
+Trailer: Expires
+Transfer-Encoding: Chunked
+
+7\r\n
+Mozilla\r\n
+9\r\n
+Developer\r\n
+7\r\n
+Network\r\n
+0\r\n
+Expires: Wed, 21 Oct 2015 07:28:00 GMT\r\n
+\r\n

--- a/http/tests/corpus/unsupported-http-version.error
+++ b/http/tests/corpus/unsupported-http-version.error
@@ -1,0 +1,1 @@
+invalid HTTP version

--- a/http/tests/corpus/unsupported-http-version.request
+++ b/http/tests/corpus/unsupported-http-version.request
@@ -1,0 +1,3 @@
+GET / HTTP/0.9\r\n
+\r\n
+


### PR DESCRIPTION
These tests are currently descriptive, not normative. In particular, the two errors should be resolved.

The addition of these tests provides further test coverage for fully exercising the parser