### PR TITLE
Use a trillium-specific header parser instead of httparse

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -2,7 +2,7 @@ use crate::{Conn, IntoUrl, Pool, USER_AGENT};
 use std::{convert::TryInto, fmt::Debug, sync::Arc};
 use trillium_http::{
     transport::BoxedTransport, HeaderName, HeaderValues, Headers, KnownHeaderName, Method,
-    ReceivedBodyState,
+    ReceivedBodyState, Version::Http1_1,
 };
 use trillium_server_common::{Connector, ObjectSafeConnector, Url};
 use url::Origin;
@@ -158,6 +158,8 @@ impl Client {
             response_body_state: ReceivedBodyState::Start,
             config: Arc::clone(&self.config),
             headers_finalized: false,
+            http_version: Http1_1,
+            max_head_length: 8 * 1024,
         }
     }
 

--- a/client/src/conn.rs
+++ b/client/src/conn.rs
@@ -4,26 +4,21 @@ use futures_lite::{future::poll_once, io, AsyncReadExt, AsyncWriteExt};
 use memchr::memmem::Finder;
 use size::{Base, Size};
 use std::{
-    convert::TryInto,
     fmt::{self, Debug, Display, Formatter},
     future::{Future, IntoFuture},
     io::{ErrorKind, Write},
     ops::{Deref, DerefMut},
     pin::Pin,
-    str::FromStr,
     sync::Arc,
 };
 use trillium_http::{
     transport::BoxedTransport,
-    Body, Error, HeaderName, HeaderValue, HeaderValues, Headers,
+    Body, Error, HeaderName, HeaderValues, Headers,
     KnownHeaderName::{Connection, ContentLength, Expect, Host, TransferEncoding},
-    Method, ReceivedBody, ReceivedBodyState, Result, StateSet, Status, Stopper, Upgrade,
+    Method, ReceivedBody, ReceivedBodyState, Result, StateSet, Status, Stopper, Upgrade, Version,
 };
 use trillium_server_common::{Connector, ObjectSafeConnector, Transport};
 use url::{Origin, Url};
-
-const MAX_HEADERS: usize = 128;
-const MAX_HEAD_LENGTH: usize = 2 * 1024;
 
 /**
 A wrapper error for [`trillium_http::Error`] or
@@ -60,6 +55,8 @@ pub struct Conn {
     pub(crate) response_body_state: ReceivedBodyState,
     pub(crate) config: Arc<dyn ObjectSafeConnector>,
     pub(crate) headers_finalized: bool,
+    pub(crate) http_version: Version,
+    pub(crate) max_head_length: usize,
 }
 
 /// default http user-agent header
@@ -78,6 +75,8 @@ impl Debug for Conn {
             .field("buffer", &String::from_utf8_lossy(&self.buffer))
             .field("response_body_state", &self.response_body_state)
             .field("config", &self.config)
+            .field("http_version", &self.http_version)
+            .field("max_head_length", &self.max_head_length)
             .finish()
     }
 }
@@ -491,6 +490,14 @@ impl Conn {
             .and_then(|t| t.peer_addr().ok().flatten())
     }
 
+    /// returns the http version for this conn.
+    ///
+    /// prior to conn execution, this reflects the request http version that will be sent, and after
+    /// execution this reflects the server-indicated http version
+    pub fn http_version(&self) -> Version {
+        self.http_version
+    }
+
     // --- everything below here is private ---
 
     fn finalize_headers(&mut self) -> Result<()> {
@@ -597,7 +604,7 @@ impl Conn {
             }
         }
 
-        write!(buf, " HTTP/1.1\r\n")?;
+        write!(buf, " {}\r\n", self.http_version)?;
 
         for (name, values) in &self.request_headers {
             if !name.is_valid() {
@@ -672,7 +679,7 @@ impl Conn {
                 }
             }
 
-            if len >= MAX_HEAD_LENGTH {
+            if len >= self.max_head_length {
                 return Err(Error::HeadersTooLong);
             }
         }
@@ -680,23 +687,19 @@ impl Conn {
 
     async fn parse_head(&mut self) -> Result<()> {
         let head_offset = self.read_head().await?;
-        let mut headers = [httparse::EMPTY_HEADER; MAX_HEADERS];
-        let mut httparse_res = httparse::Response::new(&mut headers);
-        let parse_result = httparse_res.parse(&self.buffer[..head_offset])?;
+        let space = memchr::memchr(b' ', &self.buffer[..head_offset]).ok_or(Error::PartialHead)?;
+        self.http_version = std::str::from_utf8(&self.buffer[..space])
+            .map_err(|_| Error::PartialHead)?
+            .parse()
+            .map_err(|_| Error::PartialHead)?;
+        self.status = Some(std::str::from_utf8(&self.buffer[space + 1..space + 4])?.parse()?);
+        let end_of_first_line = 2 + Finder::new("\r\n")
+            .find(&self.buffer[..head_offset])
+            .ok_or(Error::PartialHead)?;
 
-        match parse_result {
-            httparse::Status::Complete(n) if n == head_offset => {}
-            _ => return Err(Error::PartialHead),
-        }
-
-        self.status = httparse_res.code.map(|code| code.try_into().unwrap());
-
-        self.response_headers.reserve(httparse_res.headers.len());
-        for header in httparse_res.headers {
-            let header_name = HeaderName::from_str(header.name)?;
-            let header_value = HeaderValue::from(header.value.to_owned());
-            self.response_headers.append(header_name, header_value);
-        }
+        self.response_headers
+            .extend_parse(&self.buffer[end_of_first_line..head_offset])
+            .map_err(|_| Error::PartialHead)?;
 
         self.buffer.ignore_front(head_offset);
 

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -4,6 +4,8 @@ use std::str::Utf8Error;
 
 use thiserror::Error;
 
+use crate::Version;
+
 /// Concrete errors that occur within trillium's http implementation
 #[derive(Error, Debug)]
 #[non_exhaustive]
@@ -46,13 +48,22 @@ pub enum Error {
     #[error("malformed http header {0}")]
     MalformedHeader(Cow<'static, str>),
 
-    /// async-h1 doesn't speak this http version
+    /// trillium doesn't speak this http version
     /// this error is deprecated
+    #[deprecated = "trillium will only return RecognizedBufUnsupportedVersion now"]
     #[error("unsupported http version 1.{0}")]
     UnsupportedVersion(u8),
 
+    /// trillium recognizes this http version but does not support it
+    #[error("unsupported http version {0}")]
+    RecognizedButUnsupportedVersion(Version),
+
+    /// trillium cannot parse this http version
+    #[error("unrecognized version {0}")]
+    UnrecognizedVersion(String),
+
     /// we were unable to parse this http method
-    #[error("unsupported http method {0}")]
+    #[error("unsupported or unrecognized http method {0}")]
     UnrecognizedMethod(String),
 
     /// this request did not have a method
@@ -90,6 +101,10 @@ pub enum Error {
     /// implementation on ReceivedBody
     #[error("Received body too long. Maximum {0} bytes")]
     ReceivedBodyTooLong(u64),
+
+    /// Something went wrong with header parsing
+    #[error("Malformed header")]
+    MalformedHeaders,
 }
 
 /// this crate's result type

--- a/http/src/headers/header_name.rs
+++ b/http/src/headers/header_name.rs
@@ -14,6 +14,14 @@ use HeaderNameInner::{KnownHeader, UnknownHeader};
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct HeaderName<'a>(pub(super) HeaderNameInner<'a>);
 
+impl<'a> HeaderName<'a> {
+    pub(crate) fn parse(bytes: &'a [u8]) -> Result<Self, Error> {
+        std::str::from_utf8(bytes)
+            .map_err(|_| Error::MalformedHeaders)
+            .map(HeaderName::from)
+    }
+}
+
 #[cfg(feature = "serde")]
 impl serde::Serialize for HeaderName<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/http/src/headers/header_value.rs
+++ b/http/src/headers/header_value.rs
@@ -68,6 +68,13 @@ impl HeaderValue {
             }
         })
     }
+
+    pub(crate) fn parse(bytes: &[u8]) -> Self {
+        match std::str::from_utf8(bytes) {
+            Ok(s) => Self(Utf8(SmartCow::Owned(s.into()))),
+            Err(_) => Self(Bytes(bytes.into())),
+        }
+    }
 }
 
 impl Display for HeaderValue {

--- a/http/src/method.rs
+++ b/http/src/method.rs
@@ -1,7 +1,7 @@
 // originally from https://github.com/http-rs/http-types/blob/main/src/method.rs
 use std::{
     fmt::{self, Display},
-    str::FromStr,
+    str::{self, FromStr},
 };
 
 /// HTTP request methods.
@@ -432,6 +432,12 @@ impl Method {
             Self::VersionControl => "VERSION-CONTROL",
         }
     }
+
+    pub(crate) fn parse(bytes: &[u8]) -> crate::Result<Self> {
+        str::from_utf8(bytes)
+            .map_err(|_| crate::Error::UnrecognizedMethod(String::from_utf8_lossy(bytes).into()))?
+            .parse()
+    }
 }
 
 impl Display for Method {
@@ -485,9 +491,7 @@ impl FromStr for Method {
             "UPDATE" => Ok(Self::Update),
             "UPDATEREDIRECTREF" => Ok(Self::UpdateRedirectRef),
             "VERSION-CONTROL" => Ok(Self::VersionControl),
-            _ => Err(crate::Error::UnrecognizedMethod(
-                "Invalid HTTP method".into(),
-            )),
+            _ => Err(crate::Error::UnrecognizedMethod(s.to_string())),
         }
     }
 }

--- a/http/src/received_body.rs
+++ b/http/src/received_body.rs
@@ -1,7 +1,6 @@
 use crate::{copy, http_config::DEFAULT_CONFIG, Body, Buffer, HttpConfig, MutCow};
 use encoding_rs::Encoding;
 use futures_lite::{ready, AsyncRead, AsyncReadExt, AsyncWrite, Stream};
-use httparse::{InvalidChunkSize, Status};
 use std::{
     fmt::{self, Debug, Formatter},
     future::{Future, IntoFuture},

--- a/http/src/status.rs
+++ b/http/src/status.rs
@@ -3,6 +3,7 @@ use crate::Error;
 use std::{
     convert::TryFrom,
     fmt::{self, Debug, Display},
+    str::FromStr,
 };
 
 /// HTTP response status codes.
@@ -633,5 +634,13 @@ impl Debug for Status {
 impl Display for Status {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}", *self as u16, self.canonical_reason())
+    }
+}
+
+impl FromStr for Status {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        u16::from_str(s).map_err(|_| Error::PartialHead)?.try_into()
     }
 }

--- a/http/src/version.rs
+++ b/http/src/version.rs
@@ -1,6 +1,10 @@
 // originally from https://github.com/http-rs/http-types/blob/main/src/version.rs
 
-use std::{error::Error, fmt::Display, str::FromStr};
+use std::{
+    error::Error,
+    fmt::Display,
+    str::{self, FromStr},
+};
 
 /// The version of the HTTP protocol in use.
 #[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -68,6 +72,13 @@ impl Version {
             Version::Http2_0 => "HTTP/2",
             Version::Http3_0 => "HTTP/3",
         }
+    }
+
+    pub(crate) fn parse(buf: &[u8]) -> crate::Result<Self> {
+        str::from_utf8(buf)
+            .map_err(|_| crate::Error::UnrecognizedVersion(String::from_utf8_lossy(buf).into()))?
+            .parse()
+            .map_err(|UnrecognizedVersion(v)| crate::Error::UnrecognizedVersion(v))
     }
 }
 

--- a/http/tests/corpus/1.response
+++ b/http/tests/corpus/1.response
@@ -10,7 +10,7 @@ version: HTTP/1.1\n
 \n
 ===headers===\n
 Host: example.com:8080\r\n
-Connection: close\r\n
 Transfer-Encoding: chunked\r\n
+Connection: close\r\n
 \n
 ===body===\n

--- a/http/tests/corpus/2.response
+++ b/http/tests/corpus/2.response
@@ -10,8 +10,8 @@ version: HTTP/1.1\n
 \n
 ===headers===\n
 Host: example.com:8080\r\n
-Connection: close\r\n
 Transfer-Encoding: chunked\r\n
+Connection: close\r\n
 \n
 ===body===\n
 dojsfxsbxnctecvdoeseagowpyosdnvibeagbukbjmwnqtsgxlkatbwizkaexwmycohgithrhfhzzzfykqyftuoshqygokhryoxi

--- a/http/tests/corpus/3.response
+++ b/http/tests/corpus/3.response
@@ -10,8 +10,8 @@ version: HTTP/1.1\n
 \n
 ===headers===\n
 Host: example.com:8080\r\n
-Connection: close\r\n
 Transfer-Encoding: chunked\r\n
+Connection: close\r\n
 \n
 ===body===\n
 bqfimbbuacdeohawiumsynkjkfccpaqsqydfbezegciwmiuwegpdtzofgtjxtcqlavqbzpfhuqdgazefftkauyiarryktqyvlozk

--- a/http/tests/corpus/4.response
+++ b/http/tests/corpus/4.response
@@ -10,8 +10,8 @@ version: HTTP/1.1\n
 \n
 ===headers===\n
 Host: example.com:8080\r\n
-Connection: close\r\n
 Transfer-Encoding: chunked\r\n
+Connection: close\r\n
 \n
 ===body===\n
 pbcggproccuzedwmqgktnsboanhpqdqhgunojgdnixopambsvlmigpwiefzwkrermtfxaknkibzkqddnqrvyithpbgllyremlmln

--- a/http/tests/corpus/5.response
+++ b/http/tests/corpus/5.response
@@ -10,8 +10,8 @@ version: HTTP/1.1\n
 \n
 ===headers===\n
 Host: example.com:8080\r\n
-Connection: close\r\n
 Transfer-Encoding: chunked\r\n
+Connection: close\r\n
 \n
 ===body===\n
 qjqfopqotmpbqxzzxtuvmhelmcpcwvupekwszmjuaywqxxpurksdtyriagkzbeoiokcqwlmyliojiefbqzglxxtagdzjjnraxuqv

--- a/http/tests/corpus/6.response
+++ b/http/tests/corpus/6.response
@@ -10,8 +10,8 @@ version: HTTP/1.1\n
 \n
 ===headers===\n
 Host: example.com:8080\r\n
-Connection: close\r\n
 Transfer-Encoding: chunked\r\n
+Connection: close\r\n
 \n
 ===body===\n
 stmybbtrcepyectdqextknxfchibejjwevuhyqzawqaauudlycgipepulzxrigoodkvbawcyoeyjyewygciyizsvyrngzdwcpufq

--- a/http/tests/corpus/7.response
+++ b/http/tests/corpus/7.response
@@ -10,8 +10,8 @@ version: HTTP/1.1\n
 \n
 ===headers===\n
 Host: example.com:8080\r\n
-Connection: close\r\n
 Transfer-Encoding: chunked\r\n
+Connection: close\r\n
 \n
 ===body===\n
 wyxgczrucwhsncrxxamygamgrqseegrbgrhiqyeuwlojphjnhvnqvzwpsrvwxpzdghoyhsseggpvoykxwyntzmirdgqcvphbwxbg

--- a/http/tests/corpus/footers.error
+++ b/http/tests/corpus/footers.error
@@ -1,1 +1,1 @@
-invalid new line
+partial http head

--- a/http/tests/corpus/unsupported-http-version.error
+++ b/http/tests/corpus/unsupported-http-version.error
@@ -1,1 +1,1 @@
-invalid HTTP version
+unsupported http version HTTP/0.9

--- a/macros/tests/async_io.rs
+++ b/macros/tests/async_io.rs
@@ -4,14 +4,14 @@ use trillium_macros::{AsyncRead, AsyncWrite};
 struct Inner(#[async_write] Vec<u8>, #[async_read] &'static [u8]);
 
 #[derive(AsyncRead, AsyncWrite)]
-struct Middle(&'static str, #[async_io] Inner);
+struct Middle((), #[async_io] Inner);
 
 #[derive(AsyncRead, AsyncWrite)]
 struct Outer(Middle);
 
 #[test]
 fn test() -> std::io::Result<()> {
-    let mut outer = Outer(Middle("unrelated", Inner(vec![100; 0], b"content to read")));
+    let mut outer = Outer(Middle((), Inner(vec![100; 0], b"content to read")));
     let mut string = String::new();
     block_on(outer.read_to_string(&mut string))?;
     assert_eq!(string, "content to read");


### PR DESCRIPTION
This is a step towards dropping the httparse dependency. Unfortunately that will require a major version change because there is an error variant.

This is still a draft because I have not benchmarked it yet, and I'd like to add some more difficult, malicious, and malformed requests to the corpus before merging this. Additionally, fuzz testing for identical output would be reassuring.

This opens the door to do things like zero-copy parsing for received headers