### PR TITLE
chore: rm .cargo/config

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[target.x86_64-unknown-linux-musl]
-linker = "x86_64-linux-musl-gcc"


### PR DESCRIPTION
this was only necessary for testing the aws lambda runtime