### PR TITLE
feat(router): enable "memchr" feature by default

### DIFF
--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["trillium", "framework", "async", "router"]
 categories = ["web-programming::http-server", "web-programming"]
 
 [features]
+default = ["memchr"]
 memchr = ["routefinder/memchr"]
 
 [dependencies]
@@ -23,4 +24,3 @@ env_logger = "0.11.0"
 trillium-logger = { path = "../logger" }
 trillium-smol = { path = "../smol" }
 trillium-testing = { path = "../testing" }
-


### PR DESCRIPTION
closes #552 

this wasn't worth a breaking change bump, but the next breaking change will remove the feature entirely, as there really isn't any reason a trillium user wouldn't want memchr currently