### PR TITLE
fix(proxy): use Connector and ObjectSafeConnector from trillium_client

### DIFF
--- a/proxy/src/forward_proxy_connect.rs
+++ b/proxy/src/forward_proxy_connect.rs
@@ -2,8 +2,8 @@ use crate::bytes;
 use full_duplex_async_copy::full_duplex_copy;
 use std::fmt::Debug;
 use trillium::{async_trait, Conn, Handler, Upgrade};
+use trillium_client::{Connector, ObjectSafeConnector};
 use trillium_http::{Method, Status};
-use trillium_server_common::{Connector, ObjectSafeConnector};
 use url::Url;
 
 #[derive(Debug)]


### PR DESCRIPTION
without this, the crate did not build with --no-default-features

closes #587