### PR TITLE
chore: release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "deps:"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1.0.108"
 serde_path_to_error = "0.1.14"
 serde_urlencoded = { version = "0.7.1", optional = true }
 thiserror = "1.0.52"
-trillium = { path = "../trillium", version = "0.2.16" }
+trillium = { path = "../trillium", version = "0.2.17" }
 trillium-macros = { version = "0.0.5", path = "../macros" }
 url = { version = "2.5.0", optional = true }
 

--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["web-programming::http-server", "web-programming"]
 [dependencies]
 askama = "0.12.1"
 mime_guess = "2.0.4"
-trillium = { path = "../trillium", version = "0.2.13" }
+trillium = { path = "../trillium", version = "0.2.17" }
 
 [dev-dependencies]
 trillium-smol = { path = "../smol" }

--- a/async-std/Cargo.toml
+++ b/async-std/Cargo.toml
@@ -13,10 +13,10 @@ categories = ["web-programming::http-server", "web-programming"]
 [dependencies]
 async-std = { version = "1.12.0", package = "async-std" }
 log = "0.4.20"
-trillium = { path = "../trillium", version = "0.2.13" }
-trillium-http = { path = "../http", version = "0.3.11" }
+trillium = { path = "../trillium", version = "0.2.17" }
+trillium-http = { path = "../http", version = "0.3.15" }
 trillium-macros = { version = "0.0.5", path = "../macros" }
-trillium-server-common = { path = "../server-common", version = "0.4.7" }
+trillium-server-common = { path = "../server-common", version = "0.5.0" }
 url = "2.5.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/aws-lambda/Cargo.toml
+++ b/aws-lambda/Cargo.toml
@@ -19,5 +19,5 @@ serde = "1.0.193"
 serde_derive = "1.0.193"
 serde_json = "1.0.108"
 tokio = { version = "1.35.1", features = ["rt", "net", "rt-multi-thread"], package = "tokio" }
-trillium = { path = "../trillium", version = "0.2.13" }
-trillium-http = { path = "../http", version = "0.3.11" }
+trillium = { path = "../trillium", version = "0.2.17" }
+trillium-http = { path = "../http", version = "0.3.15" }

--- a/caching-headers/Cargo.toml
+++ b/caching-headers/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["web-programming::http-server", "web-programming"]
 [dependencies]
 etag = { version = "4.0.0", features = ["std"] }
 httpdate = "1.0.3"
-trillium = { path = "../trillium", version = "0.2.13" }
+trillium = { path = "../trillium", version = "0.2.17" }
 
 [dev-dependencies]
 trillium-smol = { path = "../smol" }

--- a/channels/Cargo.toml
+++ b/channels/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4.20"
 querystrong = "0.3.0"
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
-trillium = { path = "../trillium", version = "0.2.13" }
+trillium = { path = "../trillium", version = "0.2.17" }
 trillium-websockets = { path = "../websockets", version = "0.6.2" }
 
 [dev-dependencies]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -20,7 +20,7 @@ futures-lite = "2.1.0"
 httparse = "1.8.0"
 log = "0.4.20"
 size = "0.4.1"
-trillium-server-common = { version = "0.4.7", path = "../server-common" }
+trillium-server-common = { version = "0.5.0", path = "../server-common" }
 trillium-websockets = { version = "0.6.2", path = "../websockets", optional = true }
 url = "2.5.0"
 mime = "0.3.17"
@@ -34,7 +34,7 @@ memchr = "2.7.1"
 [dependencies.trillium-http]
 path = "../http"
 features = ["unstable"]
-version = "0.3.12"
+version = "0.3.15"
 
 [dev-dependencies]
 async-channel = "2.1.1"

--- a/compression/Cargo.toml
+++ b/compression/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["web-programming::http-server", "web-programming"]
 
 [dependencies]
 futures-lite = "2.1.0"
-trillium = { path = "../trillium", version = "0.2.13" }
+trillium = { path = "../trillium", version = "0.2.17" }
 log = "0.4.20"
 
 [dependencies.async-compression]

--- a/conn-id/Cargo.toml
+++ b/conn-id/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["web-programming::http-server", "web-programming"]
 
 [dependencies]
 fastrand = "2.0.1"
-trillium = { path = "../trillium", version = "0.2.13" }
+trillium = { path = "../trillium", version = "0.2.17" }
 
 [dev-dependencies]
 trillium-testing = { path = "../testing" }

--- a/cookies/Cargo.toml
+++ b/cookies/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["web-programming::http-server", "web-programming"]
 
 [dependencies]
 log = "0.4.20"
-trillium = { path = "../trillium", version = "0.2.13" }
+trillium = { path = "../trillium", version = "0.2.17" }
 
 [dependencies.cookie]
 version = "0.18.0"

--- a/forwarding/Cargo.toml
+++ b/forwarding/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["web-programming::http-server", "web-programming"]
 [dependencies]
 cidr = "0.2.2"
 log = "0.4.20"
-trillium = { path = "../trillium", version = "0.2.13" }
+trillium = { path = "../trillium", version = "0.2.17" }
 
 [dev-dependencies]
 trillium-logger = { path = "../logger" }

--- a/handlebars/Cargo.toml
+++ b/handlebars/Cargo.toml
@@ -16,7 +16,7 @@ handlebars = { version = "5.0.0", features = ["dir_source"] }
 log = "0.4.20"
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
-trillium = { path = "../trillium", version = "0.2.13" }
+trillium = { path = "../trillium", version = "0.2.17" }
 
 [dev-dependencies]
 env_logger = "0.11.0"

--- a/head/Cargo.toml
+++ b/head/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["trillium", "framework", "async"]
 categories = ["web-programming::http-server", "web-programming"]
 
 [dependencies]
-trillium = { path = "../trillium", version = "0.2.13" }
+trillium = { path = "../trillium", version = "0.2.17" }
 
 [dev-dependencies]
 trillium-smol = { path = "../smol" }

--- a/http/CHANGELOG.md
+++ b/http/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.15](https://github.com/trillium-rs/trillium/compare/trillium-http-v0.3.14...trillium-http-v0.3.15) - 2024-03-22
+
+### Added
+- *(http)* sort Host and Date headers first
+- *(test)* add corpus tests
+
+### Other
+- clippy
+- *(http)* document addition of is_valid
+
 ## [0.3.14](https://github.com/trillium-rs/trillium/compare/trillium-http-v0.3.13...trillium-http-v0.3.14) - 2024-02-08
 
 ### Added

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-http"
-version = "0.3.14"
+version = "0.3.15"
 edition = "2021"
 authors = ["Jacob Rothstein <hi@jbr.me>"]
 description = "the http implementation for the trillium toolkit"

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -15,7 +15,7 @@ colored = "2.1.0"
 log = "0.4.20"
 size = "0.4.1"
 time = { version = "0.3.31", features = ["local-offset", "formatting", "macros"] }
-trillium = { path = "../trillium", version = "0.2.13" }
+trillium = { path = "../trillium", version = "0.2.17" }
 
 [dev-dependencies]
 access_log_parser = "0.8.0"

--- a/method-override/Cargo.toml
+++ b/method-override/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["trillium", "framework", "async"]
 categories = ["web-programming::http-server", "web-programming"]
 
 [dependencies]
-trillium = { path = "../trillium", version = "0.2.13" }
+trillium = { path = "../trillium", version = "0.2.17" }
 querystrong = "0.3.0"
 
 [dev-dependencies]

--- a/native-tls/Cargo.toml
+++ b/native-tls/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["web-programming::http-server", "web-programming"]
 [dependencies]
 async-native-tls = "0.5.0"
 native-tls = "0.2.11"
-trillium-server-common = { path = "../server-common", version = "0.4.7" }
+trillium-server-common = { path = "../server-common", version = "0.5.0" }
 
 [dev-dependencies]
 env_logger = "0.11.0"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -23,11 +23,11 @@ futures-lite = "2.1.0"
 log = "0.4.20"
 size = "0.4.1"
 sluice = "0.5.5"
-trillium = { path = "../trillium", version = "0.2.13" }
+trillium = { path = "../trillium", version = "0.2.17" }
 trillium-client = { path = "../client", version = "0.5.2" }
 trillium-forwarding = { version = "0.2.3", path = "../forwarding" }
-trillium-http = { path = "../http", version = "0.3.11", features = ["unstable"] }
-trillium-server-common = { version = "0.4.7", path = "../server-common", optional = true }
+trillium-http = { path = "../http", version = "0.3.15", features = ["unstable"] }
+trillium-server-common = { version = "0.5.0", path = "../server-common", optional = true }
 url = "2.5.0"
 
 [dev-dependencies]

--- a/redirect/Cargo.toml
+++ b/redirect/Cargo.toml
@@ -11,4 +11,4 @@ keywords = ["trillium", "framework", "async"]
 categories = ["web-programming::http-server", "web-programming"]
 
 [dependencies]
-trillium = { path = "../trillium", version = "0.2.13" }
+trillium = { path = "../trillium", version = "0.2.17" }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,2 @@
+[workspace]
+release_commits = "^(feat|fix|deps)"

--- a/router/CHANGELOG.md
+++ b/router/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/trillium-rs/trillium/compare/trillium-router-v0.3.6...trillium-router-v0.4.0) - 2024-03-22
+
+### Added
+- *(router)* [**breaking**] fully remove memchr feature
+- *(router)* enable "memchr" feature by default
+- *(router)* [**breaking**] remove routefinder types from the public api
+- *(router)* expose the routefinder memchr feature
+
+### Other
+- clippy
+- *(router)* remove unused import
+- *(deps)* update env_logger requirement from 0.10.1 to 0.11.0
+- Release only rustls
+- release
+- release
+
 ## [0.3.6](https://github.com/trillium-rs/trillium/compare/trillium-router-v0.3.5...trillium-router-v0.3.6) - 2024-01-02
 
 ### Other

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-router"
-version = "0.3.6"
+version = "0.4.0"
 authors = ["Jacob Rothstein <hi@jbr.me>"]
 edition = "2021"
 description = "router for trillium.rs"
@@ -13,7 +13,7 @@ categories = ["web-programming::http-server", "web-programming"]
 [dependencies]
 log = "0.4.20"
 routefinder = { version = "0.5.4", features = ["memchr"] }
-trillium = { path = "../trillium", version = "0.2.13" }
+trillium = { path = "../trillium", version = "0.2.17" }
 
 [dev-dependencies]
 env_logger = "0.11.0"

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -24,7 +24,7 @@ log = "0.4.20"
 rustls = { version = "0.22.1", default-features = false, features = ["tls12"] }
 rustls-native-certs = { version = "0.7.0", optional = true }
 rustls-pemfile = { version = "2.0.0", optional = true }
-trillium-server-common = { path = "../server-common", version = "0.4.7" }
+trillium-server-common = { path = "../server-common", version = "0.5.0" }
 webpki-roots = { version = "0.26", optional = true }
 
 [dev-dependencies]

--- a/server-common/CHANGELOG.md
+++ b/server-common/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/trillium-rs/trillium/compare/trillium-server-common-v0.4.7...trillium-server-common-v0.5.0) - 2024-03-22
+
+### Added
+- propagate write_vectored calls in Binding
+- *(server-common)* [**breaking**] put Config in an Arc instead of cloning
+
+### Other
+- clippy
+- Release only rustls
+- release
+
 ## [0.4.7](https://github.com/trillium-rs/trillium/compare/trillium-server-common-v0.4.6...trillium-server-common-v0.4.7) - 2024-01-02
 
 ### Other

--- a/server-common/Cargo.toml
+++ b/server-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-server-common"
-version = "0.4.7"
+version = "0.5.0"
 authors = ["Jacob Rothstein <hi@jbr.me>"]
 edition = "2021"
 description = "server utilities for trillium.rs"
@@ -17,8 +17,8 @@ event-listener = "4.0.1"
 futures-lite = "2.1.0"
 log = "0.4.20"
 pin-project-lite = "0.2.13"
-trillium = { path = "../trillium", version = "0.2.13" }
-trillium-http = { path = "../http", version = "0.3.11" }
+trillium = { path = "../trillium", version = "0.2.17" }
+trillium-http = { path = "../http", version = "0.3.15" }
 url = "2.5.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/sessions/Cargo.toml
+++ b/sessions/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["web-programming::http-server", "web-programming"]
 
 [dependencies]
 trillium-cookies = { path = "../cookies", version = "0.4.1" }
-trillium = { path = "../trillium", version = "0.2.13" }
+trillium = { path = "../trillium", version = "0.2.17" }
 async-session = "3.0.0"
 log = "0.4.20"
 

--- a/smol/Cargo.toml
+++ b/smol/Cargo.toml
@@ -16,10 +16,10 @@ async-io = "2.2.2"
 async-net = "2.0.0"
 futures-lite = "2.1.0"
 log = "0.4.20"
-trillium = { path = "../trillium", version = "0.2.13" }
-trillium-http = { path = "../http", version = "0.3.11" }
+trillium = { path = "../trillium", version = "0.2.17" }
+trillium-http = { path = "../http", version = "0.3.15" }
 trillium-macros = { version = "0.0.5", path = "../macros" }
-trillium-server-common = { path = "../server-common", version = "0.4.7" }
+trillium-server-common = { path = "../server-common", version = "0.5.0" }
 url = "2.5.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/sse/Cargo.toml
+++ b/sse/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["web-programming::http-server", "web-programming"]
 
 [dependencies]
 futures-lite = "2.1.0"
-trillium = { path = "../trillium", version = "0.2.13" }
+trillium = { path = "../trillium", version = "0.2.17" }
 
 [dev-dependencies]
 broadcaster = "1.0.0"

--- a/static-compiled/Cargo.toml
+++ b/static-compiled/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["web-programming::http-server", "web-programming"]
 log = "0.4.20"
 mime = "0.3.17"
 mime_guess = "2.0.4"
-trillium = { path = "../trillium", version = "0.2.13" }
+trillium = { path = "../trillium", version = "0.2.17" }
 httpdate = "1.0.3"
 trillium-static-compiled-macros = { path = "../static-compiled-macros", version = "0.1.1" }
 

--- a/static/Cargo.toml
+++ b/static/Cargo.toml
@@ -23,7 +23,7 @@ cfg-if = "1.0.0"
 futures-lite = "2.1.0"
 log = "0.4.20"
 relative-path = "1.9.2"
-trillium = { path = "../trillium", version = "0.2.13" }
+trillium = { path = "../trillium", version = "0.2.17" }
 mime_guess = "2.0.4"
 httpdate = "1.0.3"
 etag = { version = "4.0.0", features = ["std"] }

--- a/tera/Cargo.toml
+++ b/tera/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4.20"
 mime_guess = "2.0.4"
 serde = "1.0.193"
 tera = "1.19.1"
-trillium = { path = "../trillium", version = "0.2.13" }
+trillium = { path = "../trillium", version = "0.2.17" }
 
 [dev-dependencies]
 trillium-smol = { path = "../smol" }

--- a/testing/CHANGELOG.md
+++ b/testing/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/trillium-rs/trillium/compare/trillium-testing-v0.5.4...trillium-testing-v0.6.0) - 2024-03-22
+
+### Fixed
+- *(testing)* [**breaking**] RuntimelessClientConfig must be constructed with default or new
+
+### Other
+- clippy
+
 ## [0.5.4](https://github.com/trillium-rs/trillium/compare/trillium-testing-v0.5.3...trillium-testing-v0.5.4) - 2024-02-08
 
 ### Added

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-testing"
-version = "0.5.4"
+version = "0.6.0"
 authors = ["Jacob Rothstein <hi@jbr.me>"]
 edition = "2021"
 description = "testing library for trillium applications"
@@ -23,9 +23,9 @@ default = []
 async-dup = "1.2.4"
 futures-lite = "2.1.0"
 portpicker = "0.1.1"
-trillium = { path = "../trillium", version = "0.2.13" }
-trillium-http = { path = "../http", version = "0.3.11" }
-trillium-server-common = { path = "../server-common", version = "0.4.7" }
+trillium = { path = "../trillium", version = "0.2.17" }
+trillium-http = { path = "../http", version = "0.3.15" }
+trillium-server-common = { path = "../server-common", version = "0.5.0" }
 cfg-if = "1.0.0"
 url = "2.5.0"
 async-channel = "2.1.1"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -14,10 +14,10 @@ categories = ["web-programming::http-server", "web-programming"]
 async-compat = "0.2.3"
 log = "0.4.20"
 tokio-stream = { version = "0.1.14", features = ["net"] }
-trillium = { path = "../trillium", version = "0.2.13" }
-trillium-http = { path = "../http", version = "0.3.11" }
+trillium = { path = "../trillium", version = "0.2.17" }
+trillium-http = { path = "../http", version = "0.3.15" }
 trillium-macros = { version = "0.0.5", path = "../macros" }
-trillium-server-common = { path = "../server-common", version = "0.4.7" }
+trillium-server-common = { path = "../server-common", version = "0.5.0" }
 url = "2.5.0"
 
 [dependencies.tokio]

--- a/trillium/CHANGELOG.md
+++ b/trillium/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.17](https://github.com/trillium-rs/trillium/compare/trillium-v0.2.16...trillium-v0.2.17) - 2024-03-22
+
+### Added
+- *(trillium)* improve log message when calling `Arc<Handler>::init` on a clone
+
+### Other
+- clippy
+
 ## [0.2.16](https://github.com/trillium-rs/trillium/compare/trillium-v0.2.15...trillium-v0.2.16) - 2024-02-09
 
 ### Fixed

--- a/trillium/Cargo.toml
+++ b/trillium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium"
-version = "0.2.16"
+version = "0.2.17"
 authors = ["Jacob Rothstein <hi@jbr.me>"]
 edition = "2021"
 description = "a modular toolkit for building async web apps"
@@ -20,7 +20,7 @@ serde = ["trillium-http/serde"]
 async-trait = "0.1.75"
 futures-lite = "2.1.0"
 log = "0.4.20"
-trillium-http = { path = "../http", version = "0.3.13" }
+trillium-http = { path = "../http", version = "0.3.15" }
 
 [dev-dependencies]
 async-channel = "2.1.1"

--- a/websockets/Cargo.toml
+++ b/websockets/Cargo.toml
@@ -30,8 +30,8 @@ serde_json = { version = "1.0.108", optional = true }
 sha-1 = "0.10.1"
 stopper = "0.2.3"
 thiserror = "1.0.52"
-trillium = { path = "../trillium", version = "0.2.13" }
-trillium-http = { path = "../http", version = "0.3.11" }
+trillium = { path = "../trillium", version = "0.2.17" }
+trillium-http = { path = "../http", version = "0.3.15" }
 
 [dev-dependencies]
 async-tungstenite = { version = "0.25.0", default-features = false, features = ["handshake"] }


### PR DESCRIPTION
## 🤖 New release
* `trillium`: 0.2.16 -> 0.2.17 (✓ API compatible changes)
* `trillium-http`: 0.3.14 -> 0.3.15 (✓ API compatible changes)
* `trillium-server-common`: 0.4.7 -> 0.5.0 (✓ API compatible changes)
* `trillium-testing`: 0.5.4 -> 0.6.0 (✓ API compatible changes)
* `trillium-router`: 0.3.6 -> 0.4.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `trillium`
<blockquote>

## [0.2.17](https://github.com/trillium-rs/trillium/compare/trillium-v0.2.16...trillium-v0.2.17) - 2024-03-22

### Added
- *(trillium)* improve log message when calling `Arc<Handler>::init` on a clone

### Other
- clippy
</blockquote>

## `trillium-http`
<blockquote>

## [0.3.15](https://github.com/trillium-rs/trillium/compare/trillium-http-v0.3.14...trillium-http-v0.3.15) - 2024-03-22

### Added
- *(http)* sort Host and Date headers first
- *(test)* add corpus tests

### Other
- clippy
- *(http)* document addition of is_valid
</blockquote>

## `trillium-server-common`
<blockquote>

## [0.5.0](https://github.com/trillium-rs/trillium/compare/trillium-server-common-v0.4.7...trillium-server-common-v0.5.0) - 2024-03-22

### Added
- propagate write_vectored calls in Binding
- *(server-common)* [**breaking**] put Config in an Arc instead of cloning

### Other
- clippy
- Release only rustls
- release
</blockquote>

## `trillium-testing`
<blockquote>

## [0.6.0](https://github.com/trillium-rs/trillium/compare/trillium-testing-v0.5.4...trillium-testing-v0.6.0) - 2024-03-22

### Fixed
- *(testing)* [**breaking**] RuntimelessClientConfig must be constructed with default or new

### Other
- clippy
</blockquote>

## `trillium-router`
<blockquote>

## [0.4.0](https://github.com/trillium-rs/trillium/compare/trillium-router-v0.3.6...trillium-router-v0.4.0) - 2024-03-22

### Added
- *(router)* [**breaking**] fully remove memchr feature
- *(router)* enable "memchr" feature by default
- *(router)* [**breaking**] remove routefinder types from the public api
- *(router)* expose the routefinder memchr feature

### Other
- clippy
- *(router)* remove unused import
- *(deps)* update env_logger requirement from 0.10.1 to 0.11.0
- Release only rustls
- release
- release
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).