### PR TITLE
feat: parse directly into trillium::Headers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,19 +45,25 @@ jobs:
           command: test
           args: --workspace
 
-      - name: Run tests
+      - name: Run tests (parse)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: -p trillium-http -p trillium-client --features parse
+
+      - name: Run tests (smol)
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --workspace --features trillium-static/smol,trillium-testing/smol
 
-      - name: Run tests
+      - name: Run tests (tokio)
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --workspace --features trillium-static/tokio,trillium-testing/tokio
 
-      - name: Run tests
+      - name: Run tests (async-std)
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.7.3
       - name: Generate code coverage
-        run: cargo +nightly tarpaulin --features smol,trillium-testing/smol,trillium-http/serde --workspace --timeout 120 --out xml
+        run: cargo +nightly tarpaulin
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v4
         with:

--- a/async-std/src/server/tcp.rs
+++ b/async-std/src/server/tcp.rs
@@ -1,7 +1,7 @@
 use crate::AsyncStdTransport;
 use async_std::net::{TcpListener, TcpStream};
 use async_std::task::{block_on, spawn};
-use std::{convert::TryInto, env, future::Future, io::Result, pin::Pin};
+use std::{convert::TryInto, env, future::Future, io::Result};
 use trillium::Info;
 use trillium_server_common::Server;
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["web-programming", "web-programming::http-client"]
 [features]
 websockets = ["dep:trillium-websockets", "dep:thiserror"]
 json = ["dep:serde_json", "dep:serde", "dep:thiserror"]
+parse = ["trillium-http/parse"]
 
 [dependencies]
 encoding_rs = "0.8.33"

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -2,7 +2,7 @@ use crate::{Conn, IntoUrl, Pool, USER_AGENT};
 use std::{fmt::Debug, sync::Arc, time::Duration};
 use trillium_http::{
     transport::BoxedTransport, HeaderName, HeaderValues, Headers, KnownHeaderName, Method,
-    ReceivedBodyState,
+    ReceivedBodyState, Version::Http1_1,
 };
 use trillium_server_common::{
     url::{Origin, Url},
@@ -169,6 +169,8 @@ impl Client {
             config: self.config.clone(),
             headers_finalized: false,
             timeout: self.timeout,
+            http_version: Http1_1,
+            max_head_length: 8 * 1024,
         }
     }
 

--- a/client/tests/one_hundred_continue.rs
+++ b/client/tests/one_hundred_continue.rs
@@ -17,10 +17,10 @@ async fn extra_one_hundred_continue() -> TestResult {
         POST / HTTP/1.1\r
         Host: example.com\r
         Accept: */*\r
-        Expect: 100-continue\r
-        User-Agent: {USER_AGENT}\r
         Connection: close\r
         Content-Length: 4\r
+        Expect: 100-continue\r
+        User-Agent: {USER_AGENT}\r
         \r
     "};
 
@@ -37,9 +37,9 @@ async fn extra_one_hundred_continue() -> TestResult {
     let response_head = formatdoc! {"
         HTTP/1.1 200 Ok\r
         Date: {TEST_DATE}\r
-        Server: text\r
         Connection: close\r
         Content-Length: 20\r
+        Server: text\r
         \r
         response: 0123456789\
     "};
@@ -71,10 +71,10 @@ async fn one_hundred_continue() -> TestResult {
         POST / HTTP/1.1\r
         Host: example.com\r
         Accept: */*\r
-        Expect: 100-continue\r
-        User-Agent: {USER_AGENT}\r
         Connection: close\r
         Content-Length: 4\r
+        Expect: 100-continue\r
+        User-Agent: {USER_AGENT}\r
         \r
     "};
 
@@ -87,9 +87,9 @@ async fn one_hundred_continue() -> TestResult {
         HTTP/1.1 200 Ok\r
         Date: {TEST_DATE}\r
         Accept: */*\r
-        Server: text\r
         Connection: close\r
         Content-Length: 20\r
+        Server: text\r
         \r
         response: 0123456789\
     "});
@@ -115,8 +115,8 @@ async fn empty_body_no_100_continue() -> TestResult {
         POST / HTTP/1.1\r
         Host: example.com\r
         Accept: */*\r
-        User-Agent: {USER_AGENT}\r
         Connection: close\r
+        User-Agent: {USER_AGENT}\r
         \r
     "};
 
@@ -125,9 +125,9 @@ async fn empty_body_no_100_continue() -> TestResult {
     transport.write_all(formatdoc! {"
         HTTP/1.1 200 Ok\r
         Date: {TEST_DATE}\r
-        Server: text\r
         Connection: close\r
         Content-Length: 20\r
+        Server: text\r
         \r
         response: 0123456789\
     "});
@@ -145,10 +145,10 @@ async fn two_small_continues() -> TestResult {
         POST / HTTP/1.1\r
         Host: example.com\r
         Accept: */*\r
-        Expect: 100-continue\r
-        User-Agent: {USER_AGENT}\r
         Connection: close\r
         Content-Length: 4\r
+        Expect: 100-continue\r
+        User-Agent: {USER_AGENT}\r
         \r
     "};
 
@@ -184,10 +184,10 @@ async fn little_continue_big_continue() -> TestResult {
         POST / HTTP/1.1\r
         Host: example.com\r
         Accept: */*\r
-        Expect: 100-continue\r
-        User-Agent: {USER_AGENT}\r
         Connection: close\r
         Content-Length: 4\r
+        Expect: 100-continue\r
+        User-Agent: {USER_AGENT}\r
         \r
     "};
 

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -15,6 +15,7 @@ unstable = []
 http-compat = ["dep:http0"]
 http-compat-1 = ["dep:http1"]
 serde = ["dep:serde"]
+parse = []
 
 [dependencies]
 encoding_rs = "0.8.33"

--- a/http/src/headers.rs
+++ b/http/src/headers.rs
@@ -10,6 +10,7 @@ pub use header_values::HeaderValues;
 pub use known_header_name::KnownHeaderName;
 
 use header_name::HeaderNameInner;
+use memchr::memmem::Finder;
 use unknown_header_name::UnknownHeaderName;
 
 use hashbrown::{
@@ -17,16 +18,22 @@ use hashbrown::{
     HashMap,
 };
 use smartcow::SmartCow;
+use std::collections::{
+    btree_map::{self, Entry as BTreeEntry},
+    BTreeMap,
+};
 use std::{
     fmt::{self, Debug, Display, Formatter},
-    hash::{BuildHasherDefault, Hasher},
+    hash::Hasher,
 };
 
+use crate::Error;
+
 /// Trillium's header map type
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[must_use]
 pub struct Headers {
-    known: HashMap<KnownHeaderName, HeaderValues, BuildHasherDefault<DirectHasher>>,
+    known: BTreeMap<KnownHeaderName, HeaderValues>,
     unknown: HashMap<UnknownHeaderName<'static>, HeaderValues>,
 }
 
@@ -45,12 +52,6 @@ impl serde::Serialize for Headers {
     }
 }
 
-impl Default for Headers {
-    fn default() -> Self {
-        Self::with_capacity(15)
-    }
-}
-
 impl Display for Headers {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         for (n, v) in self {
@@ -62,23 +63,86 @@ impl Display for Headers {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct ParseError;
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str("parse error")
+    }
+}
+
+fn is_tchar(c: u8) -> bool {
+    matches!(
+        c,
+        b'a'..=b'z'
+        | b'A'..=b'Z'
+        | b'0'..=b'9'
+        | b'!'
+        | b'#'
+        | b'$'
+        | b'%'
+        | b'&'
+        | b'\''
+        | b'*'
+        | b'+'
+        | b'-'
+        | b'.'
+        | b'^'
+        | b'_'
+        | b'`'
+        | b'|'
+        | b'~'
+    )
+}
+
 impl Headers {
-    /// Construct a new Headers, expecting to see at least this many known headers.
-    pub fn with_capacity(capacity: usize) -> Self {
-        Self {
-            known: HashMap::with_capacity_and_hasher(capacity, BuildHasherDefault::default()),
-            unknown: HashMap::with_capacity(0),
+    #[doc(hidden)]
+    pub fn extend_parse(&mut self, bytes: &[u8]) -> Result<usize, Error> {
+        let newlines = Finder::new(b"\r\n").find_iter(bytes).collect::<Vec<_>>();
+        //        self.reserve(newlines.len().saturating_sub(1));
+        let mut new_header_count = 0;
+        let mut last_line = 0;
+        for newline in newlines {
+            if newline == last_line {
+                continue;
+            }
+
+            let token_start = last_line;
+            let mut token_end = token_start;
+            while is_tchar(bytes[token_end]) {
+                token_end += 1;
+            }
+
+            let header_name = HeaderName::parse(&bytes[token_start..token_end])?.to_owned();
+
+            if bytes[token_end] != b':' {
+                return Err(Error::InvalidHead);
+            }
+
+            let mut value_start = token_end + 1;
+            while (bytes[value_start] as char).is_whitespace() {
+                value_start += 1;
+            }
+
+            let header_value = HeaderValue::parse(&bytes[value_start..newline]);
+            self.append(header_name, header_value);
+            new_header_count += 1;
+            last_line = newline + 2;
         }
+        Ok(new_header_count)
     }
 
-    /// Construct a new headers with a default capacity of 15 known headers
+    #[cfg(feature = "parse")]
+    #[doc(hidden)]
+    pub fn parse(bytes: &[u8]) -> Result<Self, Error> {
+        let mut headers = Headers::new();
+        headers.extend_parse(bytes)?;
+        Ok(headers)
+    }
+
+    /// Construct a new headers with a default capacity
     pub fn new() -> Self {
         Self::default()
-    }
-
-    /// Extend the capacity of the known headers map by this many
-    pub fn reserve(&mut self, additional: usize) {
-        self.known.reserve(additional);
     }
 
     /// Return an iterator over borrowed header names and header
@@ -107,10 +171,10 @@ impl Headers {
         let value = value.into();
         match name.into().0 {
             HeaderNameInner::KnownHeader(known) => match self.known.entry(known) {
-                Entry::Occupied(mut o) => {
+                BTreeEntry::Occupied(mut o) => {
                     o.get_mut().extend(value);
                 }
-                Entry::Vacant(v) => {
+                BTreeEntry::Vacant(v) => {
                     v.insert(value);
                 }
             },
@@ -129,13 +193,12 @@ impl Headers {
     /// A slightly more efficient way to combine two [`Headers`] than
     /// using [`Extend`]
     pub fn append_all(&mut self, other: Headers) {
-        self.known.reserve(other.known.len());
         for (name, value) in other.known {
             match self.known.entry(name) {
-                Entry::Occupied(mut entry) => {
+                BTreeEntry::Occupied(mut entry) => {
                     entry.get_mut().extend(value);
                 }
-                Entry::Vacant(entry) => {
+                BTreeEntry::Vacant(entry) => {
                     entry.insert(value);
                 }
             }
@@ -155,7 +218,6 @@ impl Headers {
 
     /// Combine two [`Headers`], replacing any existing header values
     pub fn insert_all(&mut self, other: Headers) {
-        self.known.reserve(other.known.len());
         for (name, value) in other.known {
             self.known.insert(name, value);
         }
@@ -365,12 +427,6 @@ where
     HV: Into<HeaderValues>,
 {
     fn extend<T: IntoIterator<Item = (HN, HV)>>(&mut self, iter: T) {
-        let iter = iter.into_iter();
-        match iter.size_hint() {
-            (additional, _) if additional > 0 => self.known.reserve(additional),
-            _ => {}
-        };
-
         for (name, values) in iter {
             self.append(name, values);
         }
@@ -384,11 +440,7 @@ where
 {
     fn from_iter<T: IntoIterator<Item = (HN, HV)>>(iter: T) -> Self {
         let iter = iter.into_iter();
-        let mut headers = match iter.size_hint() {
-            (0, _) => Self::new(),
-            (n, _) => Self::with_capacity(n),
-        };
-
+        let mut headers = Self::new();
         for (name, values) in iter {
             headers.append(name, values);
         }
@@ -428,7 +480,7 @@ impl<'a> IntoIterator for &'a Headers {
 
 #[derive(Debug)]
 pub struct IntoIter {
-    known: hash_map::IntoIter<KnownHeaderName, HeaderValues>,
+    known: btree_map::IntoIter<KnownHeaderName, HeaderValues>,
     unknown: hash_map::IntoIter<UnknownHeaderName<'static>, HeaderValues>,
 }
 
@@ -454,7 +506,7 @@ impl From<Headers> for IntoIter {
 
 #[derive(Debug)]
 pub struct Iter<'a> {
-    known: hash_map::Iter<'a, KnownHeaderName, HeaderValues>,
+    known: btree_map::Iter<'a, KnownHeaderName, HeaderValues>,
     unknown: hash_map::Iter<'a, UnknownHeaderName<'static>, HeaderValues>,
 }
 

--- a/http/src/headers/header_name.rs
+++ b/http/src/headers/header_name.rs
@@ -14,6 +14,14 @@ use HeaderNameInner::{KnownHeader, UnknownHeader};
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct HeaderName<'a>(pub(super) HeaderNameInner<'a>);
 
+impl<'a> HeaderName<'a> {
+    pub(crate) fn parse(bytes: &'a [u8]) -> Result<Self, Error> {
+        std::str::from_utf8(bytes)
+            .map_err(|_| Error::InvalidHeaderName)
+            .map(HeaderName::from)
+    }
+}
+
 #[cfg(feature = "serde")]
 impl serde::Serialize for HeaderName<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/http/src/headers/header_value.rs
+++ b/http/src/headers/header_value.rs
@@ -70,6 +70,13 @@ impl HeaderValue {
             }
         })
     }
+
+    pub(crate) fn parse(bytes: &[u8]) -> Self {
+        match std::str::from_utf8(bytes) {
+            Ok(s) => Self(Utf8(SmartCow::Owned(s.into()))),
+            Err(_) => Self(Bytes(bytes.into())),
+        }
+    }
 }
 
 impl Display for HeaderValue {

--- a/http/src/headers/known_header_name.rs
+++ b/http/src/headers/known_header_name.rs
@@ -4,7 +4,6 @@ use std::{
     hash::Hash,
     str::FromStr,
 };
-use HeaderNameInner::{KnownHeader, UnknownHeader};
 
 impl Display for KnownHeaderName {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -14,16 +13,13 @@ impl Display for KnownHeaderName {
 
 impl From<KnownHeaderName> for HeaderName<'_> {
     fn from(khn: KnownHeaderName) -> Self {
-        Self(KnownHeader(khn))
+        Self(HeaderNameInner::KnownHeader(khn))
     }
 }
 
 impl PartialEq<HeaderName<'_>> for KnownHeaderName {
     fn eq(&self, other: &HeaderName) -> bool {
-        match &other.0 {
-            KnownHeader(k) => self == k,
-            UnknownHeader(_) => false,
-        }
+        matches!(&other.0, HeaderNameInner::KnownHeader(k) if self == k)
     }
 }
 
@@ -38,7 +34,7 @@ macro_rules! known_headers {
         /// represent as a u8. Use a `KnownHeaderName` variant instead
         /// of a &'static str anywhere possible, as it allows trillium
         /// to skip parsing the header entirely.
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
         #[non_exhaustive]
         #[repr(u8)]
         pub enum KnownHeaderName {

--- a/http/src/method.rs
+++ b/http/src/method.rs
@@ -1,7 +1,7 @@
 // originally from https://github.com/http-rs/http-types/blob/main/src/method.rs
 use std::{
     fmt::{self, Display},
-    str::FromStr,
+    str::{self, FromStr},
 };
 
 /// HTTP request methods.
@@ -432,6 +432,13 @@ impl Method {
             Self::VersionControl => "VERSION-CONTROL",
         }
     }
+
+    #[cfg(feature = "parse")]
+    pub(crate) fn parse(bytes: &[u8]) -> crate::Result<Self> {
+        str::from_utf8(bytes)
+            .map_err(|_| crate::Error::UnrecognizedMethod(String::from_utf8_lossy(bytes).into()))?
+            .parse()
+    }
 }
 
 impl Display for Method {
@@ -485,9 +492,7 @@ impl FromStr for Method {
             "UPDATE" => Ok(Self::Update),
             "UPDATEREDIRECTREF" => Ok(Self::UpdateRedirectRef),
             "VERSION-CONTROL" => Ok(Self::VersionControl),
-            _ => Err(crate::Error::UnrecognizedMethod(
-                "Invalid HTTP method".into(),
-            )),
+            _ => Err(crate::Error::UnrecognizedMethod(s.to_string())),
         }
     }
 }

--- a/http/src/received_body.rs
+++ b/http/src/received_body.rs
@@ -1,7 +1,6 @@
 use crate::{copy, http_config::DEFAULT_CONFIG, Body, Buffer, HttpConfig, MutCow};
 use encoding_rs::Encoding;
 use futures_lite::{ready, AsyncRead, AsyncReadExt, AsyncWrite};
-use httparse::{InvalidChunkSize, Status};
 use std::{
     fmt::{self, Debug, Formatter},
     future::{Future, IntoFuture},

--- a/http/src/received_body/chunked.rs
+++ b/http/src/received_body/chunked.rs
@@ -1,7 +1,34 @@
+use std::io::ErrorKind::InvalidData;
+
 use super::{
-    io, ready, slice_from, AsyncRead, Buffer, Chunked, Context, End, ErrorKind, InvalidChunkSize,
-    PartialChunkSize, Pin, Ready, ReceivedBody, ReceivedBodyState, StateOutput, Status,
+    io, ready, slice_from, AsyncRead, Buffer, Chunked, Context, End, ErrorKind, PartialChunkSize,
+    Pin, Ready, ReceivedBody, ReceivedBodyState, StateOutput,
 };
+
+#[cfg(feature = "parse")]
+fn parse_chunk_size(buf: &[u8]) -> Result<Option<(usize, u64)>, ()> {
+    use memchr::memmem::Finder;
+    use std::str;
+
+    let Some(index) = memchr::memchr2(b';', b'\r', &buf[..buf.len().min(17)]) else {
+        return if buf.len() < 17 { Ok(None) } else { Err(()) };
+    };
+    let src = str::from_utf8(&buf[..index]).map_err(|_| ())?;
+    let chunk_size = u64::from_str_radix(src, 16).map_err(|_| ())?;
+    Ok(Finder::new("\r\n")
+        .find(&buf[index..])
+        .map(|end| (index + end + 2, chunk_size + 2)))
+}
+
+#[cfg(not(feature = "parse"))]
+fn parse_chunk_size(buf: &[u8]) -> Result<Option<(usize, u64)>, ()> {
+    use httparse::{parse_chunk_size, Status};
+    match parse_chunk_size(buf) {
+        Ok(Status::Complete((index, next_chunk))) => Ok(Some((index, next_chunk + 2))),
+        Ok(Status::Partial) => Ok(None),
+        Err(_) => Err(()),
+    }
+}
 
 impl<'conn, Transport> ReceivedBody<'conn, Transport>
 where
@@ -45,29 +72,18 @@ where
 
         self.buffer.extend_from_slice(&buf[..bytes]);
 
-        match httparse::parse_chunk_size(&self.buffer) {
-            Ok(Status::Complete((framing_bytes, remaining))) => {
-                self.buffer.ignore_front(framing_bytes);
-                Ready(Ok((
-                    if remaining == 0 {
-                        End
-                    } else {
-                        Chunked {
-                            remaining: remaining + 2,
-                            total,
-                        }
-                    },
-                    0,
-                )))
+        Ready(match parse_chunk_size(&self.buffer) {
+            Ok(Some((used, remaining))) => {
+                self.buffer.ignore_front(used);
+                if remaining == 2 {
+                    Ok((End, 0))
+                } else {
+                    Ok((Chunked { remaining, total }, 0))
+                }
             }
-
-            Ok(Status::Partial) => Ready(Ok((PartialChunkSize { total }, 0))),
-
-            Err(InvalidChunkSize) => Ready(Err(io::Error::new(
-                ErrorKind::InvalidData,
-                "invalid chunk framing",
-            ))),
-        }
+            Ok(None) => Ok((PartialChunkSize { total }, 0)),
+            Err(()) => Err(io::Error::new(InvalidData, "invalid chunk size")),
+        })
     }
 }
 
@@ -113,14 +129,14 @@ pub(super) fn chunk_decode(
             };
         }
 
-        match httparse::parse_chunk_size(buf_to_read) {
-            Ok(Status::Complete((framing_bytes, chunk_size))) => {
+        match parse_chunk_size(buf_to_read) {
+            Ok(Some((framing_bytes, chunk_size))) => {
                 chunk_start += framing_bytes as u64;
-                chunk_end = (2 + chunk_start)
+                chunk_end = chunk_start
                     .checked_add(chunk_size)
-                    .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "chunk size too long"))?;
+                    .ok_or_else(|| io::Error::new(InvalidData, "chunk size too long"))?;
 
-                if chunk_size == 0 {
+                if chunk_size == 2 {
                     if let Some(buf) = slice_from(chunk_end, buf) {
                         self_buffer.extend_from_slice(buf);
                     }
@@ -128,13 +144,13 @@ pub(super) fn chunk_decode(
                 }
             }
 
-            Ok(Status::Partial) => {
+            Ok(None) => {
                 self_buffer.extend_from_slice(buf_to_read);
                 break PartialChunkSize { total };
             }
 
-            Err(InvalidChunkSize) => {
-                return Err(io::Error::new(ErrorKind::InvalidData, "invalid chunk size"));
+            Err(()) => {
+                return Err(io::Error::new(InvalidData, "invalid chunk size"));
             }
         }
     };
@@ -322,6 +338,33 @@ mod tests {
             (None, "_", "next request"),
         );
         assert_decoded((7, "hello\r\n0\r\n\r\n"), (None, "hello", ""));
+    }
+
+    #[test]
+    fn test_chunk_start_with_ext() {
+        assert_decoded((0, "5;abcdefg\r\n12345\r\n"), (Some(0), "12345", ""));
+        assert_decoded((0, "F;aaa\taaaaa\taaa aaa\r\n1"), (Some(14 + 2), "1", ""));
+        assert_decoded((0, "5;;;;;;;;;;;;;;;;\r\n123"), (Some(2 + 2), "123", ""));
+        assert_decoded(
+            (0, "1;   a = b\"\" \r\nX\r\n1;;;\r\nX\r\n"),
+            (Some(0), "XX", ""),
+        );
+        assert_decoded((0, "1\r\nX\r\n1;\r\nX\r\n1"), (Some(0), "XX", "1"));
+        assert_decoded((0, "FFF; 000\r\n"), (Some(0xfff + 2), "", ""));
+        assert_decoded((10, "hello"), (Some(5), "hello", ""));
+        assert_decoded(
+            (7, "hello\r\nA;111\r\n world"),
+            (Some(4 + 2), "hello world", ""),
+        );
+        assert_decoded(
+            (0, "e\r\ntest test test\r\n0;00\r\n\r\n"),
+            (None, "test test test", ""),
+        );
+        assert_decoded(
+            (0, "1;\r\n_\r\n0;\r\n\r\nnext request"),
+            (None, "_", "next request"),
+        );
+        assert_decoded((7, "hello\r\n0;\r\n\r\n"), (None, "hello", ""));
     }
 
     #[test]

--- a/http/src/status.rs
+++ b/http/src/status.rs
@@ -1,6 +1,10 @@
 // originally from https://github.com/http-rs/http-types/blob/main/src/status_code.rs
 use crate::Error;
-use std::fmt::{self, Debug, Display};
+use std::{
+    convert::TryFrom,
+    fmt::{self, Debug, Display},
+    str::FromStr,
+};
 
 /// HTTP response status codes.
 ///
@@ -630,5 +634,15 @@ impl Debug for Status {
 impl Display for Status {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}", *self as u16, self.canonical_reason())
+    }
+}
+
+impl FromStr for Status {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        u16::from_str(s)
+            .map_err(|_| Error::InvalidStatus)?
+            .try_into()
     }
 }

--- a/http/src/version.rs
+++ b/http/src/version.rs
@@ -1,6 +1,11 @@
 // originally from https://github.com/http-rs/http-types/blob/main/src/version.rs
 
-use std::{error::Error, fmt::Display, str::FromStr};
+use std::{
+    fmt::Display,
+    str::{self, FromStr},
+};
+
+use crate::Error;
 
 /// The version of the HTTP protocol in use.
 #[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -69,19 +74,17 @@ impl Version {
             Version::Http3_0 => "HTTP/3",
         }
     }
-}
 
-#[derive(Debug, Clone)]
-pub struct UnrecognizedVersion(String);
-impl Display for UnrecognizedVersion {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("unrecognized http version: {}", self.0))
+    #[cfg(feature = "parse")]
+    pub(crate) fn parse(buf: &[u8]) -> crate::Result<Self> {
+        str::from_utf8(buf)
+            .map_err(|_| Error::InvalidVersion)?
+            .parse()
     }
 }
-impl Error for UnrecognizedVersion {}
 
 impl FromStr for Version {
-    type Err = UnrecognizedVersion;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
@@ -90,7 +93,7 @@ impl FromStr for Version {
             "HTTP/1.1" | "http/1.1" | "1.1" => Ok(Self::Http1_1),
             "HTTP/2" | "http/2" | "2" => Ok(Self::Http2_0),
             "HTTP/3" | "http/3" | "3" => Ok(Self::Http3_0),
-            _ => Err(UnrecognizedVersion(s.to_string())),
+            _ => Err(Error::InvalidVersion),
         }
     }
 }
@@ -133,7 +136,7 @@ mod test {
 
         assert_eq!(
             "not a version".parse::<Version>().unwrap_err().to_string(),
-            "unrecognized http version: not a version"
+            "Invalid or missing version"
         );
     }
 

--- a/http/tests/corpus/1.response
+++ b/http/tests/corpus/1.response
@@ -1,7 +1,7 @@
 HTTP/1.1 200 OK\r\n
 Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
-Server: corpus-test\r\n
 Content-Length: 186\r\n
+Server: corpus-test\r\n
 \r\n
 ===request===\n
 method: POST\n

--- a/http/tests/corpus/10.response
+++ b/http/tests/corpus/10.response
@@ -1,7 +1,7 @@
 HTTP/1.1 200 OK\r\n
 Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
-Server: corpus-test\r\n
 Content-Length: 140\r\n
+Server: corpus-test\r\n
 \r\n
 ===request===\n
 method: GET\n

--- a/http/tests/corpus/2.response
+++ b/http/tests/corpus/2.response
@@ -1,7 +1,7 @@
 HTTP/1.1 200 OK\r\n
 Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
-Server: corpus-test\r\n
 Content-Length: 286\r\n
+Server: corpus-test\r\n
 \r\n
 ===request===\n
 method: POST\n

--- a/http/tests/corpus/3.response
+++ b/http/tests/corpus/3.response
@@ -1,7 +1,7 @@
 HTTP/1.1 200 OK\r\n
 Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
-Server: corpus-test\r\n
 Content-Length: 286\r\n
+Server: corpus-test\r\n
 \r\n
 ===request===\n
 method: POST\n

--- a/http/tests/corpus/4.response
+++ b/http/tests/corpus/4.response
@@ -1,7 +1,7 @@
 HTTP/1.1 200 OK\r\n
 Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
-Server: corpus-test\r\n
 Content-Length: 286\r\n
+Server: corpus-test\r\n
 \r\n
 ===request===\n
 method: POST\n

--- a/http/tests/corpus/5.response
+++ b/http/tests/corpus/5.response
@@ -1,7 +1,7 @@
 HTTP/1.1 200 OK\r\n
 Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
-Server: corpus-test\r\n
 Content-Length: 286\r\n
+Server: corpus-test\r\n
 \r\n
 ===request===\n
 method: POST\n

--- a/http/tests/corpus/6.response
+++ b/http/tests/corpus/6.response
@@ -1,7 +1,7 @@
 HTTP/1.1 200 OK\r\n
 Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
-Server: corpus-test\r\n
 Content-Length: 286\r\n
+Server: corpus-test\r\n
 \r\n
 ===request===\n
 method: POST\n

--- a/http/tests/corpus/7.response
+++ b/http/tests/corpus/7.response
@@ -1,7 +1,7 @@
 HTTP/1.1 200 OK\r\n
 Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
-Server: corpus-test\r\n
 Content-Length: 286\r\n
+Server: corpus-test\r\n
 \r\n
 ===request===\n
 method: POST\n

--- a/http/tests/corpus/8.response
+++ b/http/tests/corpus/8.response
@@ -1,7 +1,7 @@
 HTTP/1.1 200 OK\r\n
 Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
-Server: corpus-test\r\n
 Content-Length: 159\r\n
+Server: corpus-test\r\n
 \r\n
 ===request===\n
 method: PATCH\n

--- a/http/tests/corpus/9.response
+++ b/http/tests/corpus/9.response
@@ -1,7 +1,7 @@
 HTTP/1.1 200 OK\r\n
 Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
-Server: corpus-test\r\n
 Content-Length: 170\r\n
+Server: corpus-test\r\n
 \r\n
 ===request===\n
 method: PATCH\n

--- a/http/tests/corpus/unsupported-http-version.error
+++ b/http/tests/corpus/unsupported-http-version.error
@@ -1,1 +1,0 @@
-Invalid or missing version

--- a/http/tests/corpus/unsupported-http-version.request
+++ b/http/tests/corpus/unsupported-http-version.request
@@ -1,3 +1,0 @@
-GET / HTTP/0.9\r\n
-\r\n
-

--- a/http/tests/one_hundred_continue.rs
+++ b/http/tests/one_hundred_continue.rs
@@ -44,9 +44,9 @@ async fn one_hundred_continue() -> TestResult {
     let expected_response = formatdoc! {"
         HTTP/1.1 200 OK\r
         Date: {TEST_DATE}\r
-        Server: {SERVER}\r
         Connection: close\r
         Content-Length: 20\r
+        Server: {SERVER}\r
         \r
         response: 0123456789\
     "};
@@ -77,9 +77,9 @@ async fn one_hundred_continue_http_one_dot_zero() -> TestResult {
     let expected_response = formatdoc! {"
         HTTP/1.0 200 OK\r
         Date: {TEST_DATE}\r
-        Server: {SERVER}\r
         Connection: close\r
         Content-Length: 20\r
+        Server: {SERVER}\r
         \r
         response: 0123456789\
     "};

--- a/http/tests/unsafe_headers.rs
+++ b/http/tests/unsafe_headers.rs
@@ -37,8 +37,8 @@ async fn bad_headers() -> TestResult {
     let expected_response = formatdoc! {"
         HTTP/1.1 200 OK\r
         Date: {TEST_DATE}\r
-        Server: {SERVER}\r
         Content-Length: 20\r
+        Server: {SERVER}\r
         \r
         response: 0123456789\
     "};

--- a/smol/src/server/tcp.rs
+++ b/smol/src/server/tcp.rs
@@ -2,7 +2,7 @@ use crate::SmolTransport;
 use async_global_executor::{block_on, spawn};
 use async_net::{TcpListener, TcpStream};
 use futures_lite::prelude::*;
-use std::{convert::TryInto, env, io::Result, pin::Pin};
+use std::{convert::TryInto, env, io::Result};
 use trillium::Info;
 use trillium_server_common::Server;
 

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -10,16 +10,16 @@ features = "trillium-http/parse trillium-client/parse"
 packages = ["trillium-http", "trillium-client"]
 
 [smol]
-features = "trillium-testing/smol,trillium-static/smol"
-workspace = true
+features = "trillium-testing/smol trillium-static/smol"
+packages = ["trillium", "trillium-client", "trillium-static"]
 
 [tokio]
-features = "trillium-testing/tokio,trillium-static/tokio"
-workspace = true
+features = "trillium-testing/tokio trillium-static/tokio"
+packages = ["trillium", "trillium-client", "trillium-static"]
 
 [async-std]
-features = "trillium-testing/async-std,trillium-static/async-std"
-workspace = true
+features = "trillium-testing/async-std trillium-static/async-std"
+packages = ["trillium", "trillium-client", "trillium-static"]
 
 [report]
 out = ["Html", "Xml"]

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -1,0 +1,27 @@
+[base]
+workspace = true
+
+[http_serde]
+features = "trillium-http/serde"
+packages = ["trillium-http"]
+
+[http_parse]
+features = "trillium-http/parse trillium-client/parse"
+packages = ["trillium-http", "trillium-client"]
+
+[smol]
+features = "trillium-testing/smol,trillium-static/smol"
+workspace = true
+
+[tokio]
+features = "trillium-testing/tokio,trillium-static/tokio"
+workspace = true
+
+[async-std]
+features = "trillium-testing/async-std,trillium-static/async-std"
+workspace = true
+
+[report]
+out = ["Html", "Xml"]
+engine = "Llvm"
+timeout = "120 seconds"


### PR DESCRIPTION
implemented as an opt-in feature, with the intent to make the feature flagged behavior default in a patch release after it's been sufficiently tested