### PR TITLE
feat: deprecate set_state for insert_state

### DIFF
--- a/channels/src/channel_central.rs
+++ b/channels/src/channel_central.rs
@@ -86,7 +86,7 @@ where
 
         let (client, receiver) = self.build_client(vsn);
 
-        conn.set_state(client);
+        conn.insert_state(client);
 
         // this is always ok because we just set the client in state
         self.handler.connect(ChannelConn { conn: &mut conn }).await;

--- a/compression/src/lib.rs
+++ b/compression/src/lib.rs
@@ -172,7 +172,7 @@ impl Handler for Compression {
             .get_str(AcceptEncoding)
             .and_then(|h| self.negotiate(h))
         {
-            conn.set_state(header);
+            conn.insert_state(header);
         }
         conn
     }

--- a/head/src/lib.rs
+++ b/head/src/lib.rs
@@ -43,7 +43,7 @@ impl Handler for Head {
     async fn run(&self, mut conn: Conn) -> Conn {
         if conn.method() == Method::Head {
             conn.inner_mut().set_method(Method::Get);
-            conn.set_state(RequestWasHead);
+            conn.insert_state(RequestWasHead);
         }
 
         conn

--- a/proxy/src/upstream/connection_counting.rs
+++ b/proxy/src/upstream/connection_counting.rs
@@ -59,7 +59,7 @@ where
         }
 
         fastrand::choice(current_selection).and_then(|(u, cc)| {
-            conn.set_state(ConnectionCount(cc.counter()));
+            conn.insert_state(ConnectionCount(cc.counter()));
             u.determine_upstream(conn)
         })
     }

--- a/testing/src/test_conn.rs
+++ b/testing/src/test_conn.rs
@@ -96,7 +96,7 @@ impl TestConn {
     where
         S: Send + Sync + 'static,
     {
-        self.0.set_state(state);
+        self.0.insert_state(state);
         self
     }
 

--- a/trillium/src/conn.rs
+++ b/trillium/src/conn.rs
@@ -231,7 +231,7 @@ impl Conn {
     struct Hello;
     let mut conn = get("/").on(&());
     assert!(conn.state::<Hello>().is_none());
-    conn.set_state(Hello);
+    conn.insert_state(Hello);
     assert!(conn.state::<Hello>().is_some());
     ```
     */
@@ -244,18 +244,26 @@ impl Conn {
         self.inner.state_mut().get_mut()
     }
 
-    /// Puts a new type into the state set. see [`Conn::state`]
-    /// for an example. returns the previous instance of this type, if
+    #[deprecated = "use Conn::insert_state"]
+    /// see [`insert_state`]
+    pub fn set_state<T: Send + Sync + 'static>(&mut self, state: T) -> Option<T> {
+        self.insert_state(state)
+    }
+
+    /// Inserts a new type into the state set. See [`Conn::state`]
+    /// for an example.
+    ///
+    /// Returns the previously-set instance of this type, if
     /// any
-    pub fn set_state<T: Send + Sync + 'static>(&mut self, val: T) -> Option<T> {
-        self.inner.state_mut().insert(val)
+    pub fn insert_state<T: Send + Sync + 'static>(&mut self, state: T) -> Option<T> {
+        self.inner.state_mut().insert(state)
     }
 
     /// Puts a new type into the state set and returns the
     /// `Conn`. this is useful for fluent chaining
     #[must_use]
-    pub fn with_state<T: Send + Sync + 'static>(mut self, val: T) -> Self {
-        self.set_state(val);
+    pub fn with_state<T: Send + Sync + 'static>(mut self, state: T) -> Self {
+        self.insert_state(state);
         self
     }
 

--- a/trillium/src/state.rs
+++ b/trillium/src/state.rs
@@ -102,7 +102,7 @@ pub fn state<T: Clone + Send + Sync + 'static>(t: T) -> State<T> {
 #[async_trait]
 impl<T: Clone + Send + Sync + 'static> Handler for State<T> {
     async fn run(&self, mut conn: Conn) -> Conn {
-        conn.set_state(self.0.clone());
+        conn.insert_state(self.0.clone());
         conn
     }
 }

--- a/websockets/examples/json_broadcast_websocket.rs
+++ b/websockets/examples/json_broadcast_websocket.rs
@@ -39,7 +39,7 @@ fn main() {
         trillium_logger::logger(),
         |mut conn: Conn| async move {
             if let Some(ip) = conn.peer_ip() {
-                conn.set_state(ip);
+                conn.insert_state(ip);
             };
             conn
         },

--- a/websockets/examples/json_websocket.rs
+++ b/websockets/examples/json_websocket.rs
@@ -25,7 +25,7 @@ impl JsonWebSocketHandler for SomeJsonChannel {
 
     async fn connect(&self, conn: &mut WebSocketConn) -> Self::StreamType {
         let (s, r) = unbounded();
-        conn.set_state(s);
+        conn.insert_state(s);
         r
     }
 

--- a/websockets/src/json.rs
+++ b/websockets/src/json.rs
@@ -52,7 +52,7 @@ impl JsonWebSocketHandler for SomeJsonChannel {
 
     async fn connect(&self, conn: &mut WebSocketConn) -> Self::StreamType {
         let (s, r) = unbounded();
-        conn.set_state(s);
+        conn.insert_state(s);
         Box::pin(r)
     }
 

--- a/websockets/src/websocket_connection.rs
+++ b/websockets/src/websocket_connection.rs
@@ -141,10 +141,10 @@ impl WebSocketConn {
     an empty string if there is no query component.
      */
     pub fn querystring(&self) -> &str {
-        match self.path.split_once('?') {
-            Some((_, query)) => query,
-            None => "",
-        }
+        self.path
+            .split_once('?')
+            .map(|(_, q)| q)
+            .unwrap_or_default()
     }
 
     /// retrieve the request method for this conn
@@ -169,11 +169,17 @@ impl WebSocketConn {
         self.state.get_mut()
     }
 
-    /**
-    set state on this connection
-    */
-    pub fn set_state<T: Send + Sync + 'static>(&mut self, val: T) {
-        self.state.insert(val);
+    /// see [`insert_state`]
+    #[deprecated = "use WebsocketConn::insert_state"]
+    pub fn set_state<T: Send + Sync + 'static>(&mut self, state: T) {
+        self.insert_state(state);
+    }
+
+    /// inserts new state
+    ///
+    /// returns the previously set state of the same type, if any existed
+    pub fn insert_state<T: Send + Sync + 'static>(&mut self, state: T) -> Option<T> {
+        self.state.insert(state)
     }
 
     /**

--- a/websockets/tests/json.rs
+++ b/websockets/tests/json.rs
@@ -34,7 +34,7 @@ impl JsonWebSocketHandler for SomeJsonChannel {
 
     async fn connect(&self, conn: &mut WebSocketConn) -> Self::StreamType {
         let (s, r) = unbounded();
-        conn.set_state(s);
+        conn.insert_state(s);
         Box::pin(r)
     }
 

--- a/websockets/tests/test.rs
+++ b/websockets/tests/test.rs
@@ -34,7 +34,7 @@ fn with_channel() {
             mut conn: WebSocketConn,
         ) -> Option<(WebSocketConn, Self::OutboundStream)> {
             let (send, receive) = async_channel::unbounded();
-            conn.set_state(send);
+            conn.insert_state(send);
             Some((conn, Box::pin(receive)))
         }
 


### PR DESCRIPTION
I'm on the fence about this api churn, but this was a mistake that has been bothering me for a while, and trillium hasn't had intentional breaking changes since August 2021.

I'm going to hold off on releasing this until #611 is ready, just in case there are other easily-deprecatable changes, and then I'll stagger the releases by a week or so.