### PR TITLE
api: implement TryFromConn for `Vec<u8>` and `String`

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -38,3 +38,5 @@ trillium-router = { path = "../router" }
 trillium-smol = { path = "../smol" }
 trillium-testing = { path = "../testing" }
 trillium-api = { path = ".", features = ["url"] }
+test-harness = "0.2.0"
+async-channel = "2.3.1"

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -126,6 +126,7 @@ impl From<&Error> for Status {
                 Status::UnsupportedMediaType
             }
             Error::FailureToNegotiateContent => Status::NotAcceptable,
+            Error::IoError { .. } => Status::BadRequest,
             _ => Status::InternalServerError,
         }
     }

--- a/api/src/from_conn.rs
+++ b/api/src/from_conn.rs
@@ -1,6 +1,5 @@
-use trillium::{async_trait, Conn};
-
 use crate::TryFromConn;
+use trillium::{async_trait, Conn};
 
 /// A trait to extract content from [`Conn`]s to be used as the second
 /// argument to an api handler. Implement this for your types.
@@ -15,20 +14,6 @@ pub trait FromConn: Send + Sync + Sized + 'static {
 impl FromConn for () {
     async fn from_conn(_: &mut Conn) -> Option<Self> {
         Some(())
-    }
-}
-
-#[async_trait]
-impl FromConn for String {
-    async fn from_conn(conn: &mut Conn) -> Option<Self> {
-        conn.request_body_string().await.ok()
-    }
-}
-
-#[async_trait]
-impl FromConn for Vec<u8> {
-    async fn from_conn(conn: &mut Conn) -> Option<Self> {
-        conn.request_body().await.read_bytes().await.ok()
     }
 }
 

--- a/api/src/try_from_conn.rs
+++ b/api/src/try_from_conn.rs
@@ -34,6 +34,26 @@ impl<T: FromConn> TryFromConn for T {
     }
 }
 
+#[async_trait]
+impl TryFromConn for Vec<u8> {
+    type Error = crate::Error;
+    async fn try_from_conn(conn: &mut Conn) -> Result<Self, Self::Error> {
+        conn.request_body()
+            .await
+            .read_bytes()
+            .await
+            .map_err(Into::into)
+    }
+}
+
+#[async_trait]
+impl TryFromConn for String {
+    type Error = crate::Error;
+    async fn try_from_conn(conn: &mut Conn) -> Result<Self, Self::Error> {
+        conn.request_body_string().await.map_err(Into::into)
+    }
+}
+
 #[cfg(feature = "url")]
 #[async_trait]
 impl TryFromConn for url::Url {

--- a/api/tests/disconnect-body.rs
+++ b/api/tests/disconnect-body.rs
@@ -1,0 +1,122 @@
+use async_channel::Sender;
+use test_harness::test;
+use trillium::{async_trait, Conn, Handler, Status};
+use trillium_testing::{
+    futures_lite::AsyncWriteExt, harness, AsyncWrite, ClientConfig, Connector, ObjectSafeConnector,
+    ServerHandle,
+};
+
+struct LastStatus(Sender<Option<Status>>);
+
+#[async_trait]
+impl Handler for LastStatus {
+    async fn run(&self, conn: Conn) -> Conn {
+        conn
+    }
+    async fn before_send(&self, conn: Conn) -> Conn {
+        self.0.send(conn.status()).await.unwrap();
+        conn
+    }
+}
+
+#[test(harness)]
+async fn disconnect_on_string_body() {
+    async fn api_handler(conn: &mut Conn, body: String) {
+        conn.set_body(body);
+    }
+    let (sender, receiver) = async_channel::bounded(1);
+    let handler = (LastStatus(sender), trillium_api::api(api_handler));
+    let (handle, mut client) = establish_server(handler).await;
+
+    client
+        .write_all(b"POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 10\r\n\r\nnot ten")
+        .await
+        .unwrap();
+
+    drop(client);
+    assert_eq!(Some(Status::BadRequest), receiver.recv().await.unwrap());
+    handle.stop().await;
+}
+
+/// this test exists to confirm that the 400 response tested above is in fact due to the disconnect
+#[test(harness)]
+async fn normal_string_body() {
+    async fn api_handler(conn: &mut Conn, body: String) {
+        conn.set_body(body);
+    }
+    let (sender, receiver) = async_channel::bounded(1);
+    let handler = (LastStatus(sender), trillium_api::api(api_handler));
+    let (handle, mut client) = establish_server(handler).await;
+    client
+        .write_all(b"POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 10\r\n\r\nexactlyten")
+        .await
+        .unwrap();
+
+    drop(client);
+    assert_eq!(Some(Status::Ok), receiver.recv().await.unwrap());
+    handle.stop().await;
+}
+
+#[test(harness)]
+async fn disconnect_on_vec_body() {
+    async fn api_handler(conn: &mut Conn, body: Vec<u8>) {
+        conn.set_body(body);
+    }
+    let (sender, receiver) = async_channel::bounded(1);
+    let handler = (LastStatus(sender), trillium_api::api(api_handler));
+    let (handle, mut client) = establish_server(handler).await;
+
+    client
+        .write_all(b"POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 10\r\n\r\nnot ten")
+        .await
+        .unwrap();
+
+    drop(client);
+    assert_eq!(Some(Status::BadRequest), receiver.recv().await.unwrap());
+    handle.stop().await;
+}
+
+/// this test exists to confirm that the 400 response tested above is in fact due to the disconnect
+#[test(harness)]
+async fn normal_vec_body() {
+    async fn api_handler(conn: &mut Conn, body: Vec<u8>) {
+        conn.set_body(body);
+    }
+    let (sender, receiver) = async_channel::bounded(1);
+    let handler = (LastStatus(sender), trillium_api::api(api_handler));
+    let (handle, mut client) = establish_server(handler).await;
+    client
+        .write_all(b"POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 10\r\n\r\nexactlyten")
+        .await
+        .unwrap();
+
+    drop(client);
+    assert_eq!(Some(Status::Ok), receiver.recv().await.unwrap());
+    handle.stop().await;
+}
+
+async fn establish_server(handler: impl Handler) -> (ServerHandle, impl AsyncWrite) {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let handle = trillium_testing::config().with_port(0).spawn(handler);
+    let info = handle.info().await;
+    let port = info.tcp_socket_addr().map_or_else(
+        || {
+            info.listener_description()
+                .split(":")
+                .nth(1)
+                .unwrap()
+                .parse()
+                .unwrap()
+        },
+        |x| x.port(),
+    );
+
+    let client = Connector::connect(
+        &ClientConfig::default().boxed(),
+        &format!("http://localhost:{port}").parse().unwrap(),
+    )
+    .await
+    .unwrap();
+    (handle, client)
+}

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -104,7 +104,7 @@ mod server_connector;
 pub use server_connector::{connector, ServerConnector};
 
 use trillium_server_common::Config;
-pub use trillium_server_common::{Connector, ObjectSafeConnector, Server};
+pub use trillium_server_common::{Connector, ObjectSafeConnector, Server, ServerHandle};
 
 #[derive(Debug)]
 /// A droppable future


### PR DESCRIPTION
Instead of using the FromConn blanket impl with Error = ()

Closes #647 