### PR TITLE
chore: switch over to `///` from `/** */` comments

### DIFF
--- a/api/src/api_conn_ext.rs
+++ b/api/src/api_conn_ext.rs
@@ -10,140 +10,134 @@ use trillium::{
 
 /// Extension trait that adds api methods to [`trillium::Conn`]
 pub trait ApiConnExt {
-    /**
-    Sends a json response body. This sets a status code of 200,
-    serializes the body with serde_json, sets the content-type to
-    application/json, and [halts](trillium::Conn::halt) the
-    conn. If serialization fails, a 500 status code is sent as per
-    [`trillium::conn_try`]
-
-
-    ## Examples
-
-    ```
-    use trillium_api::{json, ApiConnExt};
-    async fn handler(conn: trillium::Conn) -> trillium::Conn {
-        conn.with_json(&json!({ "json macro": "is reexported" }))
-    }
-
-    # use trillium_testing::prelude::*;
-    assert_ok!(
-        get("/").on(&handler),
-        r#"{"json macro":"is reexported"}"#,
-        "content-type" => "application/json"
-    );
-    ```
-
-    ### overriding status code
-    ```
-    use trillium_api::ApiConnExt;
-    use serde::Serialize;
-
-    #[derive(Serialize)]
-    struct ApiResponse {
-       string: &'static str,
-       number: usize
-    }
-
-    async fn handler(conn: trillium::Conn) -> trillium::Conn {
-        conn.with_json(&ApiResponse { string: "not the most creative example", number: 100 })
-            .with_status(201)
-    }
-
-    # use trillium_testing::prelude::*;
-    assert_response!(
-        get("/").on(&handler),
-        Status::Created,
-        r#"{"string":"not the most creative example","number":100}"#,
-        "content-type" => "application/json"
-    );
-    ```
-    */
+    /// Sends a json response body. This sets a status code of 200,
+    /// serializes the body with serde_json, sets the content-type to
+    /// application/json, and [halts](trillium::Conn::halt) the
+    /// conn. If serialization fails, a 500 status code is sent as per
+    /// [`trillium::conn_try`]
+    ///
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use trillium_api::{json, ApiConnExt};
+    /// async fn handler(conn: trillium::Conn) -> trillium::Conn {
+    /// conn.with_json(&json!({ "json macro": "is reexported" }))
+    /// }
+    ///
+    /// # use trillium_testing::prelude::*;
+    /// assert_ok!(
+    /// get("/").on(&handler),
+    /// r#"{"json macro":"is reexported"}"#,
+    /// "content-type" => "application/json"
+    /// );
+    /// ```
+    ///
+    /// ### overriding status code
+    /// ```
+    /// use trillium_api::ApiConnExt;
+    /// use serde::Serialize;
+    ///
+    /// #[derive(Serialize)]
+    /// struct ApiResponse {
+    /// string: &'static str,
+    /// number: usize
+    /// }
+    ///
+    /// async fn handler(conn: trillium::Conn) -> trillium::Conn {
+    /// conn.with_json(&ApiResponse { string: "not the most creative example", number: 100 })
+    /// .with_status(201)
+    /// }
+    ///
+    /// # use trillium_testing::prelude::*;
+    /// assert_response!(
+    /// get("/").on(&handler),
+    /// Status::Created,
+    /// r#"{"string":"not the most creative example","number":100}"#,
+    /// "content-type" => "application/json"
+    /// );
+    /// ```
     fn with_json(self, response: &impl Serialize) -> Self;
 
-    /**
-    Attempts to deserialize a type from the request body, based on the
-    request content type.
-
-    By default, both application/json and
-    application/x-www-form-urlencoded are supported, and future
-    versions may add accepted request content types. Please open an
-    issue if you need to accept another content type.
-
-
-    To exclusively accept application/json, disable default features
-    on this crate.
-
-    This sets a status code of Status::Ok if and only if no status
-    code has been explicitly set.
-
-    ## Examples
-
-    ### Deserializing to [`Value`]
-
-    ```
-    use trillium_api::{ApiConnExt, Value};
-
-    async fn handler(mut conn: trillium::Conn) -> trillium::Conn {
-        let value: Value = trillium::conn_try!(conn.deserialize().await, conn);
-        conn.with_json(&value)
-    }
-
-    # use trillium_testing::prelude::*;
-    assert_ok!(
-        post("/")
-            .with_request_body(r#"key=value"#)
-            .with_request_header("content-type", "application/x-www-form-urlencoded")
-            .on(&handler),
-        r#"{"key":"value"}"#,
-        "content-type" => "application/json"
-    );
-
-    ```
-
-    ### Deserializing a concrete type
-
-    ```
-    use trillium_api::ApiConnExt;
-
-    #[derive(serde::Deserialize)]
-    struct KvPair { key: String, value: String }
-
-    async fn handler(mut conn: trillium::Conn) -> trillium::Conn {
-        match conn.deserialize().await {
-            Ok(KvPair { key, value }) => {
-                conn.with_status(201)
-                    .with_body(format!("{} is {}", key, value))
-                    .halt()
-            }
-
-            Err(_) => conn.with_status(422).with_body("nope").halt()
-        }
-    }
-
-    # use trillium_testing::prelude::*;
-    assert_response!(
-        post("/")
-            .with_request_body(r#"key=name&value=trillium"#)
-            .with_request_header("content-type", "application/x-www-form-urlencoded")
-            .on(&handler),
-        Status::Created,
-        r#"name is trillium"#,
-    );
-
-    assert_response!(
-        post("/")
-            .with_request_body(r#"name=trillium"#)
-            .with_request_header("content-type", "application/x-www-form-urlencoded")
-            .on(&handler),
-        Status::UnprocessableEntity,
-        r#"nope"#,
-    );
-
-
-    ```
-
-    */
+    /// Attempts to deserialize a type from the request body, based on the
+    /// request content type.
+    ///
+    /// By default, both application/json and
+    /// application/x-www-form-urlencoded are supported, and future
+    /// versions may add accepted request content types. Please open an
+    /// issue if you need to accept another content type.
+    ///
+    ///
+    /// To exclusively accept application/json, disable default features
+    /// on this crate.
+    ///
+    /// This sets a status code of Status::Ok if and only if no status
+    /// code has been explicitly set.
+    ///
+    /// ## Examples
+    ///
+    /// ### Deserializing to [`Value`]
+    ///
+    /// ```
+    /// use trillium_api::{ApiConnExt, Value};
+    ///
+    /// async fn handler(mut conn: trillium::Conn) -> trillium::Conn {
+    /// let value: Value = trillium::conn_try!(conn.deserialize().await, conn);
+    /// conn.with_json(&value)
+    /// }
+    ///
+    /// # use trillium_testing::prelude::*;
+    /// assert_ok!(
+    /// post("/")
+    /// .with_request_body(r#"key=value"#)
+    /// .with_request_header("content-type", "application/x-www-form-urlencoded")
+    /// .on(&handler),
+    /// r#"{"key":"value"}"#,
+    /// "content-type" => "application/json"
+    /// );
+    /// ```
+    ///
+    /// ### Deserializing a concrete type
+    ///
+    /// ```
+    /// use trillium_api::ApiConnExt;
+    ///
+    /// #[derive(serde::Deserialize)]
+    /// struct KvPair {
+    ///     key: String,
+    ///     value: String,
+    /// }
+    ///
+    /// async fn handler(mut conn: trillium::Conn) -> trillium::Conn {
+    ///     match conn.deserialize().await {
+    ///         Ok(KvPair { key, value }) => conn
+    ///             .with_status(201)
+    ///             .with_body(format!("{} is {}", key, value))
+    ///             .halt(),
+    ///
+    ///         Err(_) => conn.with_status(422).with_body("nope").halt(),
+    ///     }
+    /// }
+    ///
+    /// # use trillium_testing::prelude::*;
+    /// assert_response!(
+    ///     post("/")
+    ///         .with_request_body(r#"key=name&value=trillium"#)
+    ///         .with_request_header("content-type", "application/x-www-form-urlencoded")
+    ///         .on(&handler),
+    ///     Status::Created,
+    ///     r#"name is trillium"#,
+    /// );
+    ///
+    /// assert_response!(
+    ///     post("/")
+    ///         .with_request_body(r#"name=trillium"#)
+    ///         .with_request_header("content-type", "application/x-www-form-urlencoded")
+    ///         .on(&handler),
+    ///     Status::UnprocessableEntity,
+    ///     r#"nope"#,
+    /// );
+    /// ```
     fn deserialize<T>(&mut self) -> impl Future<Output = Result<T>> + Send
     where
         T: DeserializeOwned;

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,27 +1,25 @@
-/*!
-This crate provides handlers for common http api behavior.
-
-Eventually, some of this crate may move into the trillium crate, but
-for now it exists separately for ease of iteration. Expect more
-breaking changes in this crate then in the trillium crate.
-
-## Formats supported:
-
-Currently, this crate supports *receiving* `application/json` and
-`application/x-form-www-urlencoded` by default. To disable
-`application/x-form-www-urlencoded` support, use `default-features =
-false`.
-
-This crate currently only supports sending json responses, but may
-eventually add `Accepts` negotiation and further outbound response
-content types.
-
-The [`ApiConnExt`] extension trait and [`ApiHandler`] can be used
-independently or in combination.
-
-[`ApiHandler`] provides a different and more experimental interface to writing trillium handlers,
-with different performance and ergonomic considerations.
-*/
+//! This crate provides handlers for common http api behavior.
+//!
+//! Eventually, some of this crate may move into the trillium crate, but
+//! for now it exists separately for ease of iteration. Expect more
+//! breaking changes in this crate then in the trillium crate.
+//!
+//! ## Formats supported:
+//!
+//! Currently, this crate supports *receiving* `application/json` and
+//! `application/x-form-www-urlencoded` by default. To disable
+//! `application/x-form-www-urlencoded` support, use `default-features =
+//! false`.
+//!
+//! This crate currently only supports sending json responses, but may
+//! eventually add `Accepts` negotiation and further outbound response
+//! content types.
+//!
+//! The [`ApiConnExt`] extension trait and [`ApiHandler`] can be used
+//! independently or in combination.
+//!
+//! [`ApiHandler`] provides a different and more experimental interface to writing trillium
+//! handlers, with different performance and ergonomic considerations.
 #![forbid(unsafe_code)]
 #![deny(
     missing_copy_implementations,

--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -9,34 +9,32 @@
     unused_qualifications
 )]
 
-/*!
-provides support for using the askama compile-time template library
-with trillium.  see
-[https://github.com/djc/askama](https://github.com/djc/askama) for
-more information about using askama.
-
-```
-use trillium::Conn;
-use trillium_askama::{AskamaConnExt, Template};
-
-#[derive(Template)]
-#[template(path = "examples/hello.html")]
-struct HelloTemplate<'a> {
-    name: &'a str,
-}
-
-async fn handler(conn: Conn) -> Conn {
-    conn.render(HelloTemplate { name: "trillium" })
-}
-
-use trillium_testing::prelude::*;
-assert_ok!(
-    get("/").on(&handler),
-    "Hello, trillium!",
-    "content-type" => "text/html"
-);
-```
-*/
+//! provides support for using the askama compile-time template library
+//! with trillium.  see
+//! [https://github.com/djc/askama](https://github.com/djc/askama) for
+//! more information about using askama.
+//!
+//! ```
+//! use trillium::Conn;
+//! use trillium_askama::{AskamaConnExt, Template};
+//!
+//! #[derive(Template)]
+//! #[template(path = "examples/hello.html")]
+//! struct HelloTemplate<'a> {
+//! name: &'a str,
+//! }
+//!
+//! async fn handler(conn: Conn) -> Conn {
+//! conn.render(HelloTemplate { name: "trillium" })
+//! }
+//!
+//! use trillium_testing::prelude::*;
+//! assert_ok!(
+//! get("/").on(&handler),
+//! "Hello, trillium!",
+//! "content-type" => "text/html"
+//! );
+//! ```
 
 pub use askama::{self, Template};
 use trillium::KnownHeaderName::ContentType;

--- a/async-std/src/client.rs
+++ b/async-std/src/client.rs
@@ -6,9 +6,7 @@ use trillium_server_common::{
     Connector, Transport,
 };
 
-/**
-configuration for the tcp Connector
-*/
+/// configuration for the tcp Connector
 #[derive(Default, Debug, Clone, Copy)]
 pub struct ClientConfig {
     /// disable [nagle's algorithm](https://en.wikipedia.org/wiki/Nagle%27s_algorithm)

--- a/async-std/src/lib.rs
+++ b/async-std/src/lib.rs
@@ -9,28 +9,25 @@
     unused_qualifications
 )]
 
-/*!
-# Trillium server adapter for async-std
-
-```rust,no_run
-# #[allow(clippy::needless_doctest_main)]
-fn main() {
-    trillium_async_std::run(|conn: trillium::Conn| async move {
-        conn.ok("hello async-std")
-    });
-}
-```
-
-```rust,no_run
-# #[allow(clippy::needless_doctest_main)]
-#[async_std::main]
-async fn main() {
-    trillium_async_std::run_async(|conn: trillium::Conn| async move {
-        conn.ok("hello async-std")
-    }).await;
-}
-```
-*/
+//! # Trillium server adapter for async-std
+//!
+//! ```rust,no_run
+//! # #[allow(clippy::needless_doctest_main)]
+//! fn main() {
+//!     trillium_async_std::run(|conn: trillium::Conn| async move { conn.ok("hello async-std") });
+//! }
+//! ```
+//!
+//! ```rust,no_run
+//! # #[allow(clippy::needless_doctest_main)]
+//! #[async_std::main]
+//! async fn main() {
+//!     trillium_async_std::run_async(
+//!         |conn: trillium::Conn| async move { conn.ok("hello async-std") },
+//!     )
+//!     .await;
+//! }
+//! ```
 
 use trillium::Handler;
 pub use trillium_server_common::{Binding, Swansong};
@@ -45,67 +42,58 @@ use server::Config;
 mod transport;
 pub use transport::AsyncStdTransport;
 
-/**
-# Runs a trillium handler in a sync context with default config
-
-Runs a trillium handler on the async-std runtime with default
-configuration. See [`crate::config`] for what the defaults are and how
-to override them
-
-
-This function will block the current thread until the server shuts
-down
-*/
+/// # Runs a trillium handler in a sync context with default config
+///
+/// Runs a trillium handler on the async-std runtime with default
+/// configuration. See [`crate::config`] for what the defaults are and how
+/// to override them
+///
+///
+/// This function will block the current thread until the server shuts
+/// down
 
 pub fn run(handler: impl Handler) {
     config().run(handler)
 }
 
-/**
-# Runs a trillium handler in an async context with default config
-
-Run the provided trillium handler on an already-running async-std
-runtime with default settings. the defaults are the same as
-[`crate::run`]. To customize these settings, see [`crate::config`].
-
-This function will poll pending until the server shuts down.
-*/
+/// # Runs a trillium handler in an async context with default config
+///
+/// Run the provided trillium handler on an already-running async-std
+/// runtime with default settings. the defaults are the same as
+/// [`crate::run`]. To customize these settings, see [`crate::config`].
+///
+/// This function will poll pending until the server shuts down.
 pub async fn run_async(handler: impl Handler) {
     config().run_async(handler).await
 }
-/**
-# Configures a server before running it
-
-## Defaults
-
-The default configuration is as follows:
-
-* port: the contents of the `PORT` env var or else 8080
-* host: the contents of the `HOST` env var or else "localhost"
-* signals handling and graceful shutdown: enabled on cfg(unix) systems
-* tcp nodelay: disabled
-* tls acceptor: none
-
-## Usage
-
-```rust
-let swansong = trillium_async_std::Swansong::new();
-# swansong.shut_down(); // stoppping the server immediately for the test
-trillium_async_std::config()
-    .with_port(0)
-    .with_host("127.0.0.1")
-    .without_signals()
-    .with_nodelay()
-    .with_acceptor(()) // see [`trillium_rustls`] and [`trillium_native_tls`]
-    .with_swansong(swansong)
-    .run(|conn: trillium::Conn| async move {
-        conn.ok("hello async-std")
-    });
-```
-
-See [`trillium_server_common::Config`] for more details
-
-*/
+/// # Configures a server before running it
+///
+/// ## Defaults
+///
+/// The default configuration is as follows:
+///
+/// port: the contents of the `PORT` env var or else 8080
+/// host: the contents of the `HOST` env var or else "localhost"
+/// signals handling and graceful shutdown: enabled on cfg(unix) systems
+/// tcp nodelay: disabled
+/// tls acceptor: none
+///
+/// ## Usage
+///
+/// ```rust
+/// let swansong = trillium_async_std::Swansong::new();
+/// # swansong.shut_down(); // stoppping the server immediately for the test
+/// trillium_async_std::config()
+///     .with_port(0)
+///     .with_host("127.0.0.1")
+///     .without_signals()
+///     .with_nodelay()
+///     .with_acceptor(()) // see [`trillium_rustls`] and [`trillium_native_tls`]
+///     .with_swansong(swansong)
+///     .run(|conn: trillium::Conn| async move { conn.ok("hello async-std") });
+/// ```
+///
+/// See [`trillium_server_common::Config`] for more details
 pub fn config() -> Config<()> {
     Config::new()
 }

--- a/aws-lambda/src/context.rs
+++ b/aws-lambda/src/context.rs
@@ -16,12 +16,10 @@ impl Deref for LambdaContext {
     }
 }
 
-/**
-Provides access to the aws lambda context for [`trillium::Conn`].
-
-See [`lamedh_runtime::Context`] for more details on the data available
-on this struct.
-*/
+/// Provides access to the aws lambda context for [`trillium::Conn`].
+///
+/// See [`lamedh_runtime::Context`] for more details on the data available
+/// on this struct.
 pub trait LambdaConnExt {
     /// returns the [`lamedh_runtime::Context`] for this conn
     fn lambda_context(&self) -> &Context;

--- a/aws-lambda/src/lib.rs
+++ b/aws-lambda/src/lib.rs
@@ -9,15 +9,11 @@
     unused_qualifications
 )]
 
-/*!
-# Trillium server adapter for aws lambda
-
-```rust,no_run
-trillium_aws_lambda::run(|conn: trillium::Conn| async move {
-    conn.ok("hello lambda")
-});
-```
-*/
+//! # Trillium server adapter for aws lambda
+//!
+//! ```rust,no_run
+//! trillium_aws_lambda::run(|conn: trillium::Conn| async move { conn.ok("hello lambda") });
+//! ```
 
 use lamedh_runtime::{Context, Handler as AwsHandler};
 use std::{future::Future, pin::Pin, sync::Arc};
@@ -75,11 +71,9 @@ async fn handler_fn(
         }
     }
 }
-/**
-# Runs a trillium handler on an already-running tokio runtime
-
-This function will poll pending until the server shuts down.
-*/
+/// # Runs a trillium handler on an already-running tokio runtime
+///
+/// This function will poll pending until the server shuts down.
 pub async fn run_async(mut handler: impl Handler) {
     let mut info = "aws lambda".into();
     handler.init(&mut info).await;
@@ -88,15 +82,13 @@ pub async fn run_async(mut handler: impl Handler) {
         .unwrap()
 }
 
-/**
-# Runs a trillium handler in a sync context
-
-This function creates a new tokio runtime and executes the handler on
-it for aws lambda.
-
-This function will block the current thread until the server shuts
-down
-*/
+/// # Runs a trillium handler in a sync context
+///
+/// This function creates a new tokio runtime and executes the handler on
+/// it for aws lambda.
+///
+/// This function will block the current thread until the server shuts
+/// down
 
 pub fn run(handler: impl Handler) {
     runtime::Builder::new_current_thread()

--- a/aws-lambda/src/request.rs
+++ b/aws-lambda/src/request.rs
@@ -85,9 +85,9 @@ impl AlbMultiHeadersRequest {
         let Self {
             http_method,
             path,
-            //multi_value_query_string_parameters,
+            // multi_value_query_string_parameters,
             multi_value_headers,
-            //request_context,
+            // request_context,
             is_base64_encoded,
             body,
             ..

--- a/basic-auth/src/lib.rs
+++ b/basic-auth/src/lib.rs
@@ -8,17 +8,15 @@
     nonstandard_style,
     unused_qualifications
 )]
-/*!
-Basic authentication for trillium.rs
-
-```rust,no_run
-use trillium_basic_auth::BasicAuth;
-trillium_smol::run((
-    BasicAuth::new("trillium", "7r1ll1um").with_realm("rust"),
-    |conn: trillium::Conn| async move { conn.ok("authenticated") },
-));
-```
-*/
+//! Basic authentication for trillium.rs
+//!
+//! ```rust,no_run
+//! use trillium_basic_auth::BasicAuth;
+//! trillium_smol::run((
+//!     BasicAuth::new("trillium", "7r1ll1um").with_realm("rust"),
+//!     |conn: trillium::Conn| async move { conn.ok("authenticated") },
+//! ));
+//! ```
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use trillium::{
     Conn, Handler,

--- a/caching-headers/src/cache_control.rs
+++ b/caching-headers/src/cache_control.rs
@@ -6,11 +6,9 @@ use std::{
 };
 use trillium::{Conn, Handler, HeaderValues, KnownHeaderName};
 use CacheControlDirective::*;
-/**
-An enum representation of the
-[`Cache-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
-directives.
-*/
+/// An enum representation of the
+/// [`Cache-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
+/// directives.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CacheControlDirective {
@@ -75,11 +73,9 @@ impl Handler for CacheControlHeader {
     }
 }
 
-/**
-A representation of the
-[`Cache-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
-header.
-*/
+/// A representation of the
+/// [`Cache-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
+/// header.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CacheControlHeader(Vec<CacheControlDirective>);
 

--- a/caching-headers/src/etag.rs
+++ b/caching-headers/src/etag.rs
@@ -2,30 +2,28 @@ use crate::CachingHeadersExt;
 use etag::EntityTag;
 use trillium::{Conn, Handler, Status};
 
-/**
-# Etag and If-None-Match header handler
-
-Trillium handler that provides an outbound [`etag
-header`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag)
-after other handlers have been run, and if the request includes an
-[`if-none-match`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)
-header, compares these values and sends a
-[`304 not modified`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/304) status,
-omitting the response body.
-
-## Streamed bodies
-
-Note that this handler does not currently provide an etag trailer for
-streamed bodies, but may do so in the future.
-
-## Strong vs weak comparison
-
-Etags can be compared using a strong method or a weak
-method. By default, this handler allows weak comparison. To change
-this setting, construct your handler with `Etag::new().strong()`.
-See [`etag::EntityTag`](https://docs.rs/etag/3.0.0/etag/struct.EntityTag.html#comparison)
-for further documentation.
-*/
+/// # Etag and If-None-Match header handler
+///
+/// Trillium handler that provides an outbound [`etag
+/// header`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag)
+/// after other handlers have been run, and if the request includes an
+/// [`if-none-match`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)
+/// header, compares these values and sends a
+/// [`304 not modified`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/304) status,
+/// omitting the response body.
+///
+/// ## Streamed bodies
+///
+/// Note that this handler does not currently provide an etag trailer for
+/// streamed bodies, but may do so in the future.
+///
+/// ## Strong vs weak comparison
+///
+/// Etags can be compared using a strong method or a weak
+/// method. By default, this handler allows weak comparison. To change
+/// this setting, construct your handler with `Etag::new().strong()`.
+/// See [`etag::EntityTag`](https://docs.rs/etag/3.0.0/etag/struct.EntityTag.html#comparison)
+/// for further documentation.
 #[derive(Default, Clone, Copy, Debug)]
 pub struct Etag {
     strong: bool,

--- a/caching-headers/src/lib.rs
+++ b/caching-headers/src/lib.rs
@@ -1,14 +1,11 @@
-/*!
-# Trillium handlers for etag and last-modified-since headers.
-
-This crate provides three handlers: [`Etag`], [`Modified`], and
-[`CachingHeaders`], as well as a [`CachingHeadersExt`] that extends
-[`trillium::Headers`] with some accessors.
-
-Unless you are sure that you _don't_ want either etag or last-modified
-behavior, please use the combined [`CachingHeaders`] handler.
-
- */
+//! # Trillium handlers for etag and last-modified-since headers.
+//!
+//! This crate provides three handlers: [`Etag`], [`Modified`], and
+//! [`CachingHeaders`], as well as a [`CachingHeadersExt`] that extends
+//! [`trillium::Headers`] with some accessors.
+//!
+//! Unless you are sure that you _don't_ want either etag or last-modified
+//! behavior, please use the combined [`CachingHeaders`] handler.
 #![forbid(unsafe_code)]
 #![deny(
     missing_copy_implementations,
@@ -32,10 +29,8 @@ pub use caching_conn_ext::CachingHeadersExt;
 mod cache_control;
 pub use cache_control::{cache_control, CacheControlDirective, CacheControlHeader};
 
-/**
-A combined handler that provides both [`Etag`] and [`Modified`]
-behavior.
-*/
+/// A combined handler that provides both [`Etag`] and [`Modified`]
+/// behavior.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct CachingHeaders {
     inner: (Modified, Etag),

--- a/caching-headers/src/modified.rs
+++ b/caching-headers/src/modified.rs
@@ -1,12 +1,10 @@
 use crate::CachingHeadersExt;
 use trillium::{Conn, Handler, Status};
 
-/**
-# A handler for the `Last-Modified` and `If-Modified-Since` header interaction.
-
-This handler does not set a `Last-Modified` header on its own, but
-relies on other handlers doing so.
-*/
+/// # A handler for the `Last-Modified` and `If-Modified-Since` header interaction.
+///
+/// This handler does not set a `Last-Modified` header on its own, but
+/// relies on other handlers doing so.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Modified {
     _private: (),

--- a/channels/src/channel.rs
+++ b/channels/src/channel.rs
@@ -3,12 +3,10 @@ use std::ops::{Deref, DerefMut};
 use trillium::{Conn, Handler, Upgrade};
 use trillium_websockets::WebSocket;
 
-/**
-Trillium handler containing a [`ChannelHandler`]
-
-This is constructed from a [`ChannelHandler`] using [`Channel::new`]
-and dereferences to that type.
-*/
+/// Trillium handler containing a [`ChannelHandler`]
+///
+/// This is constructed from a [`ChannelHandler`] using [`Channel::new`]
+/// and dereferences to that type.
 #[derive(Debug)]
 pub struct Channel<CH>(WebSocket<ChannelCentral<CH>>);
 
@@ -38,25 +36,19 @@ where
 }
 
 impl<CH: ChannelHandler> Channel<CH> {
-    /**
-    Constructs a new trillium Channel handler from the provided
-    [`ChannelHandler`] implementation
-     */
+    /// Constructs a new trillium Channel handler from the provided
+    /// [`ChannelHandler`] implementation
     pub fn new(channel_handler: CH) -> Self {
         Self(WebSocket::new(ChannelCentral::new(channel_handler)))
     }
 
-    /**
-    Retrieve a ChannelBroadcaster that can be moved elsewhere or cloned
-    in order to trigger channel events and listen for global events.
-     */
+    /// Retrieve a ChannelBroadcaster that can be moved elsewhere or cloned
+    /// in order to trigger channel events and listen for global events.
     pub fn broadcaster(&self) -> ChannelBroadcaster {
         self.0.channel_broadcaster()
     }
 
-    /**
-    Send a ChannelEvent to all connected clients that subscribe to the topic
-     */
+    /// Send a ChannelEvent to all connected clients that subscribe to the topic
     pub fn broadcast(&self, event: impl Into<ChannelEvent>) {
         self.0.broadcast(event);
     }

--- a/channels/src/channel_broadcaster.rs
+++ b/channels/src/channel_broadcaster.rs
@@ -7,20 +7,17 @@ use std::{
     task::{Context, Poll},
 };
 
-/**
-Channel-wide event broadcaster and subscriber
-
-This can be cloned and stored elsewhere in an application in order to
-send events to connected channel clients. Retrieve a [`ChannelBroadcaster`] from a
-[`Channel`](crate::Channel) by calling
-[`Channel::broadcaster`](crate::Channel::broadcaster)
-
-ChannelBroadcaster also implements [`Stream`] so that your application
-can listen in on ChannelEvents happening elsewhere. This might be used
-for spawning a task to log events, or synchronizing events between
-servers.
-
-*/
+/// Channel-wide event broadcaster and subscriber
+///
+/// This can be cloned and stored elsewhere in an application in order to
+/// send events to connected channel clients. Retrieve a [`ChannelBroadcaster`] from a
+/// [`Channel`](crate::Channel) by calling
+/// [`Channel::broadcaster`](crate::Channel::broadcaster)
+///
+/// ChannelBroadcaster also implements [`Stream`] so that your application
+/// can listen in on ChannelEvents happening elsewhere. This might be used
+/// for spawning a task to log events, or synchronizing events between
+/// servers.
 #[derive(Clone, Debug)]
 pub struct ChannelBroadcaster {
     sender: Sender<ChannelEvent>,
@@ -84,20 +81,16 @@ impl ChannelBroadcaster {
         }
     }
 
-    /**
-    Send this ChannelEvent to all subscribed channel clients
-    */
+    /// Send this ChannelEvent to all subscribed channel clients
     pub fn broadcast(&self, event: impl Into<ChannelEvent>) {
         // we don't care about whether there are any connected clients
         // here, so we ignore error results.
         self.sender.try_broadcast(event.into()).ok();
     }
 
-    /**
-    Returns the number of connected clients. Note that the number of
-    clients listening on any given channel will likely be smaller than
-    this, and currently that number is not available.
-    */
+    /// Returns the number of connected clients. Note that the number of
+    /// clients listening on any given channel will likely be smaller than
+    /// this, and currently that number is not available.
     pub fn connected_clients(&self) -> usize {
         self.sender.receiver_count()
     }

--- a/channels/src/channel_client.rs
+++ b/channels/src/channel_client.rs
@@ -5,14 +5,12 @@ use serde::Serialize;
 use trillium::log_error;
 use trillium_websockets::Message;
 
-/**
-# Communicate with the connected client.
-
-Note that although each client is unique and represents a specific
-websocket connection, the ChannelClient can be cloned and moved
-elsewhere if needed and any updates to the topic subscriptions
-will be kept synchronized across clones.
-*/
+/// # Communicate with the connected client.
+///
+/// Note that although each client is unique and represents a specific
+/// websocket connection, the ChannelClient can be cloned and moved
+/// elsewhere if needed and any updates to the topic subscriptions
+/// will be kept synchronized across clones.
 #[derive(Debug, Clone)]
 pub struct ChannelClient {
     subscriptions: Subscriptions,
@@ -40,34 +38,28 @@ impl ChannelClient {
         )
     }
 
-    /**
-    Send a [`ChannelEvent`] to all connected clients. Note that
-    these messages will only reach clients that subscribe to the
-    event's topic.
-    */
+    /// Send a [`ChannelEvent`] to all connected clients. Note that
+    /// these messages will only reach clients that subscribe to the
+    /// event's topic.
     pub fn broadcast(&self, event: impl Into<ChannelEvent>) {
         let mut event = event.into();
         event.reference = None;
         log_error!(self.broadcast_sender.try_broadcast(event));
     }
 
-    /**
-    Send a [`ChannelEvent`] to this specific client. Note that
-    this message will only be received if the client subscribes to
-    the event's topic.
-    */
+    /// Send a [`ChannelEvent`] to this specific client. Note that
+    /// this message will only be received if the client subscribes to
+    /// the event's topic.
     pub async fn send_event(&self, event: impl Into<ChannelEvent>) {
         log_error!(self.sender.send(event.into()).await);
     }
 
-    /**
-    Send an ok reply in reference to the provided ChannelEvent
-    with the provided response payload.
-
-    Note that this sets the event as `"phx_reply"` and the payload as
-    `{"status": "ok", "response": response }`, as well as setting the
-    reference field.
-    */
+    /// Send an ok reply in reference to the provided ChannelEvent
+    /// with the provided response payload.
+    ///
+    /// Note that this sets the event as `"phx_reply"` and the payload as
+    /// `{"status": "ok", "response": response }`, as well as setting the
+    /// reference field.
     pub async fn reply_ok(&self, event: &ChannelEvent, payload: &impl Serialize) {
         #[derive(serde::Serialize)]
         struct Reply<'a, S> {
@@ -85,26 +77,21 @@ impl ChannelClient {
         .await
     }
 
-    /**
-    Send an error reply in reference to the provided ChannelEvent
-    with the provided response payload.
-
-    Note that this sets the event as `"phx_error"` as well as setting
-    the reference field.
-    */
+    /// Send an error reply in reference to the provided ChannelEvent
+    /// with the provided response payload.
+    ///
+    /// Note that this sets the event as `"phx_error"` as well as setting
+    /// the reference field.
     pub async fn reply_error(&self, event: &ChannelEvent, error: &impl Serialize) {
         self.send_event(event.build_reply("phx_error", &error))
             .await
     }
 
-    /**
-    Join a topic, sending an ok reply with the provided optional
-    value. This sends an ok reply to the client as well as adding the
-    topic to the client's subscriptions.
-
-    Use `&()` as the payload if no payload is needed.
-
-    */
+    /// Join a topic, sending an ok reply with the provided optional
+    /// value. This sends an ok reply to the client as well as adding the
+    /// topic to the client's subscriptions.
+    ///
+    /// Use `&()` as the payload if no payload is needed.
     pub async fn allow_join(&self, event: &ChannelEvent, payload: &impl Serialize) {
         if event.event() != "phx_join" {
             log::error!(
@@ -117,14 +104,12 @@ impl ChannelClient {
         self.reply_ok(event, payload).await;
     }
 
-    /**
-    Leave a topic as requested by the provided channel event,
-    including the optional payload. This sends an ok reply to the
-    client as well as removing the channel from the client's
-    subscriptions.
-
-    Use `&()` as the payload if no payload is needed.
-    */
+    /// Leave a topic as requested by the provided channel event,
+    /// including the optional payload. This sends an ok reply to the
+    /// client as well as removing the channel from the client's
+    /// subscriptions.
+    ///
+    /// Use `&()` as the payload if no payload is needed.
     pub async fn allow_leave(&self, event: &ChannelEvent, payload: &impl Serialize) {
         if event.event() != "phx_leave" {
             log::error!(
@@ -137,9 +122,7 @@ impl ChannelClient {
         self.reply_ok(event, payload).await;
     }
 
-    /**
-    Borrow this client's subscriptions
-     */
+    /// Borrow this client's subscriptions
     pub fn subscriptions(&self) -> &Subscriptions {
         &self.subscriptions
     }

--- a/channels/src/channel_conn.rs
+++ b/channels/src/channel_conn.rs
@@ -3,14 +3,12 @@ use serde::Serialize;
 use std::ops::{Deref, DerefMut};
 use trillium_websockets::WebSocketConn;
 
-/**
-A ChannelConn is a wrapper around a [`WebSocketConn`] that also
-contains a [`ChannelClient`]
-
-It that provides convenient access to functions from the ChannelClient
-held in the WebSocketConn's TypeSet, and dereferences to the
-`WebSocketConn` for other functionality.
-*/
+/// A ChannelConn is a wrapper around a [`WebSocketConn`] that also
+/// contains a [`ChannelClient`]
+///
+/// It that provides convenient access to functions from the ChannelClient
+/// held in the WebSocketConn's TypeSet, and dereferences to the
+/// `WebSocketConn` for other functionality.
 #[derive(Debug)]
 pub struct ChannelConn<'a> {
     pub(crate) conn: &'a mut WebSocketConn,
@@ -29,76 +27,60 @@ macro_rules! channel_client {
 }
 
 impl ChannelConn<'_> {
-    /**
-    Borrow the channel client
-    */
+    /// Borrow the channel client
     pub fn client(&self) -> Option<&ChannelClient> {
         self.state()
     }
 
-    /**
-    Borrow the websocket conn
-    */
+    /// Borrow the websocket conn
     pub fn conn(&self) -> &WebSocketConn {
         self
     }
 
-    /**
-    Send a [`ChannelEvent`] to all connected clients. Note that
-    these messages will only reach clients that subscribe to the
-    event's topic.
-    */
+    /// Send a [`ChannelEvent`] to all connected clients. Note that
+    /// these messages will only reach clients that subscribe to the
+    /// event's topic.
     pub fn broadcast(&self, event: impl Into<ChannelEvent>) {
         channel_client!(self).broadcast(event);
     }
 
-    /**
-    Send a [`ChannelEvent`] to this specific client. Note that
-    this message will only be received if the client subscribes to
-    the event's topic.
-    */
+    /// Send a [`ChannelEvent`] to this specific client. Note that
+    /// this message will only be received if the client subscribes to
+    /// the event's topic.
     pub async fn send_event(&self, event: impl Into<ChannelEvent>) {
         channel_client!(self).send_event(event).await;
     }
 
-    /**
-    Send an ok reply in reference to the provided ChannelEvent
-    with the provided response payload.
-
-    Note that this sets the event as `"phx_reply"` and the payload as
-    `{"status": "ok", "response": response }`, as well as setting the
-    reference field.
-    */
+    /// Send an ok reply in reference to the provided ChannelEvent
+    /// with the provided response payload.
+    ///
+    /// Note that this sets the event as `"phx_reply"` and the payload as
+    /// `{"status": "ok", "response": response }`, as well as setting the
+    /// reference field.
     pub async fn reply_ok(&self, event: &ChannelEvent, response: &impl Serialize) {
         channel_client!(self).reply_ok(event, response).await;
     }
 
-    /**
-    Send an error reply in reference to the provided ChannelEvent
-    with the provided response payload.
-
-    Note that this sets the event as `"phx_error"` as well as setting
-    the reference field.
-    */
+    /// Send an error reply in reference to the provided ChannelEvent
+    /// with the provided response payload.
+    ///
+    /// Note that this sets the event as `"phx_error"` as well as setting
+    /// the reference field.
     pub async fn reply_error(&self, event: &ChannelEvent, error: &impl Serialize) {
         channel_client!(self).reply_error(event, error).await;
     }
 
-    /**
-    Join a topic, sending an ok reply with the provided optional
-    value. This sends an ok reply to the client as well as adding the
-    topic to the client's subscriptions.
-    */
+    /// Join a topic, sending an ok reply with the provided optional
+    /// value. This sends an ok reply to the client as well as adding the
+    /// topic to the client's subscriptions.
     pub async fn allow_join(&self, event: &ChannelEvent, value: &impl Serialize) {
         channel_client!(self).allow_join(event, value).await;
     }
 
-    /**
-    Leave a topic as requested by the provided channel event,
-    including the optional payload. This sends an ok reply to the
-    client as well as removing the channel from the client's
-    subscriptions.
-    */
+    /// Leave a topic as requested by the provided channel event,
+    /// including the optional payload. This sends an ok reply to the
+    /// client as well as removing the channel from the client's
+    /// subscriptions.
     pub async fn allow_leave(&self, event: &ChannelEvent, payload: &impl Serialize) {
         channel_client!(self).allow_leave(event, payload).await;
     }

--- a/channels/src/channel_event.rs
+++ b/channels/src/channel_event.rs
@@ -3,35 +3,33 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::borrow::Cow;
 
-/**
-# The messages passed between server and connected clients.
-
-ChannelEvents contain a topic, event, payload, and if sent from a
-client, a unique reference identifier that can be used to respond to
-this event.
-
-Most interfaces in this crate take an `Into<ChannelEvent>` instead of a ChannelEvent directly, so that you can either implement Into<ChannelEvent> for relevant types, or use these tuple From implementations:
-```
-use trillium_channels::ChannelEvent;
-use serde_json::{json, Value, to_string};
-let event: ChannelEvent = ("topic", "event").into();
-assert_eq!(event.topic(), "topic");
-assert_eq!(event.event(), "event");
-assert_eq!(event.payload(), &json!({}));
-
-let event: ChannelEvent = ("topic", "event", &json!({"some": "payload"})).into();
-assert_eq!(event.topic(), "topic");
-assert_eq!(event.event(), "event");
-assert_eq!(to_string(event.payload()).unwrap(), r#"{"some":"payload"}"#);
-
-#[derive(serde::Serialize)]
-struct SomePayload { payload: &'static str };
-let event: ChannelEvent = ("topic", "event", &SomePayload { payload: "anything" }).into();
-assert_eq!(event.topic(), "topic");
-assert_eq!(event.event(), "event");
-assert_eq!(to_string(event.payload()).unwrap(), r#"{"payload":"anything"}"#);
-
-*/
+/// # The messages passed between server and connected clients.
+///
+/// ChannelEvents contain a topic, event, payload, and if sent from a
+/// client, a unique reference identifier that can be used to respond to
+/// this event.
+///
+/// Most interfaces in this crate take an `Into<ChannelEvent>` instead of a ChannelEvent directly,
+/// so that you can either implement Into<ChannelEvent> for relevant types, or use these tuple From
+/// implementations: ```
+/// use trillium_channels::ChannelEvent;
+/// use serde_json::{json, Value, to_string};
+/// let event: ChannelEvent = ("topic", "event").into();
+/// assert_eq!(event.topic(), "topic");
+/// assert_eq!(event.event(), "event");
+/// assert_eq!(event.payload(), &json!({}));
+///
+/// let event: ChannelEvent = ("topic", "event", &json!({"some": "payload"})).into();
+/// assert_eq!(event.topic(), "topic");
+/// assert_eq!(event.event(), "event");
+/// assert_eq!(to_string(event.payload()).unwrap(), r#"{"some":"payload"}"#);
+///
+/// #[derive(serde::Serialize)]
+/// struct SomePayload { payload: &'static str };
+/// let event: ChannelEvent = ("topic", "event", &SomePayload { payload: "anything" }).into();
+/// assert_eq!(event.topic(), "topic");
+/// assert_eq!(event.event(), "event");
+/// assert_eq!(to_string(event.payload()).unwrap(), r#"{"payload":"anything"}"#);
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ChannelEvent {
@@ -47,15 +45,13 @@ pub struct ChannelEvent {
 }
 
 impl ChannelEvent {
-    /**
-    Construct a new ChannelEvent with the same reference as this
-    ChannelEvent. Note that this is the only way of setting the
-    reference on an event.
-
-    The `event` argument can be either a `String` or, more commonly, a `&'static str`.
-
-    The topic will always be the same as the source ChannelEvent's topic.
-     */
+    /// Construct a new ChannelEvent with the same reference as this
+    /// ChannelEvent. Note that this is the only way of setting the
+    /// reference on an event.
+    ///
+    /// The `event` argument can be either a `String` or, more commonly, a `&'static str`.
+    ///
+    /// The topic will always be the same as the source ChannelEvent's topic.
     pub fn build_reply(
         &self,
         event: impl Into<Cow<'static, str>>,
@@ -109,42 +105,32 @@ impl ChannelEvent {
         }
     }
 
-    /**
-    Returns this ChannelEvent's topic
-    */
+    /// Returns this ChannelEvent's topic
     pub fn topic(&self) -> &str {
         &self.topic
     }
 
-    /**
-    Returns this ChannelEvent's event
-    */
+    /// Returns this ChannelEvent's event
     pub fn event(&self) -> &str {
         &self.event
     }
 
-    /**
-    Returns this ChannelEvent's payload as a Value
-    */
+    /// Returns this ChannelEvent's payload as a Value
     pub fn payload(&self) -> &Value {
         &self.payload
     }
 
-    /**
-    Returns the reference field ("ref" in json) for this ChannelEvent,
-    if one was provided by the client
-     */
+    /// Returns the reference field ("ref" in json) for this ChannelEvent,
+    /// if one was provided by the client
     pub fn reference(&self) -> Option<&str> {
         self.reference.as_deref()
     }
 
-    /**
-    Constructs a new ChannelEvent from topic, event, and a
-    serializable payload. Use &() if no payload is needed.
-
-    Note that the reference cannot be set this way. To set a
-    reference, use [`ChannelEvent::build_reply`]
-     */
+    /// Constructs a new ChannelEvent from topic, event, and a
+    /// serializable payload. Use &() if no payload is needed.
+    ///
+    /// Note that the reference cannot be set this way. To set a
+    /// reference, use [`ChannelEvent::build_reply`]
     pub fn new(
         topic: impl Into<Cow<'static, str>>,
         event: impl Into<Cow<'static, str>>,
@@ -162,11 +148,9 @@ impl ChannelEvent {
         }
     }
 
-    /**
-    returns true if this ChannelEvent is used by the phoenix-channels compatability layer
-
-    currently that means the topic is `"phoenix"` or the event is `"phx_join"` or `"phx_leave"`
-    */
+    /// returns true if this ChannelEvent is used by the phoenix-channels compatability layer
+    ///
+    /// currently that means the topic is `"phoenix"` or the event is `"phx_join"` or `"phx_leave"`
     pub(crate) fn is_system_event(&self) -> bool {
         self.topic == "phoenix" || self.event == "phx_join" || self.event == "phx_leave"
     }

--- a/channels/src/channel_handler.rs
+++ b/channels/src/channel_handler.rs
@@ -1,89 +1,81 @@
 use crate::{ChannelConn, ChannelEvent};
 use std::future::Future;
 
-/**
-# Trait for you to implement in order to define a [`Channel`](crate::Channel).
-
-## Example
-
-This simple example represents a simple chat server that's
-compatible with the [phoenix chat
-example](https://github.com/chrismccord/phoenix_chat_example) -- see
-channels/examples/channels.rs in this repo for a runnable example.
-
-The only behavior we need to implement:
-
-* allow users to join the lobby channel
-* broadcast to all users when a new user has joined the lobby
-* broadcast all messages sent to the lobby channel to all users
-  subscribed to the lobby channel.
-
-```
-use trillium_channels::{channel, ChannelConn, ChannelEvent, ChannelHandler};
-
-struct ChatChannel;
-impl ChannelHandler for ChatChannel {
-    async fn join_channel(&self, conn: ChannelConn<'_>, event: ChannelEvent) {
-        match event.topic() {
-            "rooms:lobby" => {
-                conn.allow_join(&event, &()).await;
-                conn.broadcast(("rooms:lobby", "user:entered"));
-            }
-
-            _ => {}
-        }
-    }
-
-    async fn incoming_message(&self, conn: ChannelConn<'_>, event: ChannelEvent) {
-        match (event.topic(), event.event()) {
-            ("rooms:lobby", "new:msg") => conn.broadcast(event),
-            _ => {}
-        }
-    }
-}
-
-// fn main() {
-//     trillium_smol::run(channel(ChatChannel));
-// }
-```
-
-*/
+/// # Trait for you to implement in order to define a [`Channel`](crate::Channel).
+///
+/// ## Example
+///
+/// This simple example represents a simple chat server that's
+/// compatible with the [phoenix chat
+/// example](https://github.com/chrismccord/phoenix_chat_example) -- see
+/// channels/examples/channels.rs in this repo for a runnable example.
+///
+/// The only behavior we need to implement:
+///
+/// allow users to join the lobby channel
+/// broadcast to all users when a new user has joined the lobby
+/// broadcast all messages sent to the lobby channel to all users
+/// subscribed to the lobby channel.
+///
+/// ```
+/// use trillium_channels::{channel, ChannelConn, ChannelEvent, ChannelHandler};
+///
+/// struct ChatChannel;
+/// impl ChannelHandler for ChatChannel {
+///     async fn join_channel(&self, conn: ChannelConn<'_>, event: ChannelEvent) {
+///         match event.topic() {
+///             "rooms:lobby" => {
+///                 conn.allow_join(&event, &()).await;
+///                 conn.broadcast(("rooms:lobby", "user:entered"));
+///             }
+///
+///             _ => {}
+///         }
+///     }
+///
+///     async fn incoming_message(&self, conn: ChannelConn<'_>, event: ChannelEvent) {
+///         match (event.topic(), event.event()) {
+///             ("rooms:lobby", "new:msg") => conn.broadcast(event),
+///             _ => {}
+///         }
+///     }
+/// }
+///
+/// // fn main() {
+/// //    trillium_smol::run(channel(ChatChannel));
+/// // }
+/// ```
 #[allow(unused_variables)]
 pub trait ChannelHandler: Sized + Send + Sync + 'static {
-    /**
-    `connect` is called once when each websocket client is connected. The default implementation does nothing.
-     */
+    /// `connect` is called once when each websocket client is connected. The default implementation
+    /// does nothing.
     fn connect(&self, conn: ChannelConn<'_>) -> impl Future<Output = ()> + Send {
         async {}
     }
 
-    /**
-    `join_channel` is called when a websocket client sends a
-    `phx_join` event. There is no default implementation to ensure
-    that you implement the appropriate access control logic for your
-    application. If you want clients to be able to connect to any
-    channel they request, use this definition:
-
-    ```
-    # use trillium_channels::{ChannelEvent, ChannelConn, ChannelHandler};
-    # struct MyChannel; impl ChannelHandler for MyChannel {
-    async fn join_channel(&self, conn: ChannelConn<'_>, event: ChannelEvent) {
-        conn.allow_join(&event, &()).await;
-    }
-    # }
-    ```
-    */
+    /// `join_channel` is called when a websocket client sends a
+    /// `phx_join` event. There is no default implementation to ensure
+    /// that you implement the appropriate access control logic for your
+    /// application. If you want clients to be able to connect to any
+    /// channel they request, use this definition:
+    ///
+    /// ```
+    /// # use trillium_channels::{ChannelEvent, ChannelConn, ChannelHandler};
+    /// # struct MyChannel; impl ChannelHandler for MyChannel {
+    /// async fn join_channel(&self, conn: ChannelConn<'_>, event: ChannelEvent) {
+    ///     conn.allow_join(&event, &()).await;
+    /// }
+    /// # }
+    /// ```
     fn join_channel(
         &self,
         conn: ChannelConn<'_>,
         event: ChannelEvent,
     ) -> impl Future<Output = ()> + Send;
 
-    /**
-    `leave_channel` is called when a websocket client sends a
-    `phx_leave` event. The default implementation is to allow the user
-    to leave that channel.
-    */
+    /// `leave_channel` is called when a websocket client sends a
+    /// `phx_leave` event. The default implementation is to allow the user
+    /// to leave that channel.
     fn leave_channel(
         &self,
         conn: ChannelConn<'_>,
@@ -92,10 +84,8 @@ pub trait ChannelHandler: Sized + Send + Sync + 'static {
         async move { conn.allow_leave(&event, &()).await }
     }
 
-    /**
-    `incoming_message` is called once for each [`ChannelEvent`] sent
-    from a client. The default implementation does nothing.
-    */
+    /// `incoming_message` is called once for each [`ChannelEvent`] sent
+    /// from a client. The default implementation does nothing.
     fn incoming_message(
         &self,
         conn: ChannelConn<'_>,
@@ -104,10 +94,8 @@ pub trait ChannelHandler: Sized + Send + Sync + 'static {
         async {}
     }
 
-    /**
-    `disconnect` is called when the websocket client ceases to be
-    connected, either gracefully or abruptly.
-    */
+    /// `disconnect` is called when the websocket client ceases to be
+    /// connected, either gracefully or abruptly.
     fn disconnect(&self, conn: ChannelConn<'_>) -> impl Future<Output = ()> + Send {
         async {}
     }

--- a/channels/src/lib.rs
+++ b/channels/src/lib.rs
@@ -1,101 +1,98 @@
-/*!
-# An implementation of phoenix channels for trillium.rs
-
-Channels are a means of distributing events in soft-realtime to
-connected websocket clients, including topic-subscription-based
-fanout.
-
-From the [phoenix docs](https://hexdocs.pm/phoenix/channels.html),
-
-Some possible use cases include:
-
-* Chat rooms and APIs for messaging apps
-* Breaking news, like "a goal was scored" or "an earthquake is coming"
-* Tracking trains, trucks, or race participants on a map
-* Events in multiplayer games
-* Monitoring sensors and controlling lights
-* Notifying a browser that a page's CSS or JavaScript has changed
-  (this is handy in development)
-* Conceptually, Channels are pretty simple.
-
-First, clients connect to the server using WebSockets. Once connected,
-they join one or more topics. For example, to interact with a public
-chat room clients may join a topic called public_chat, and to receive
-updates from a product with ID 7, they may need to join a topic called
-product_updates:7.
-
-Clients can push messages to the topics they've joined, and can also
-receive messages from them. The other way around, Channel servers
-receive messages from their connected clients, and can push messages
-to them too.
-
-
-## Current known differences from phoenix channels:
-
-### No long-polling support
-
-Phoenix channels support long polling transports as well as
-websockets. As most modern browsers and http clients support
-websockets, as of the current version, trillium channels exclusively
-are built on them. The design should be flexible to support long
-polling if it is eventually needed.
-
-### No multi-server synchronization yet
-
-Phoenix channels support running several server nodes and distributing
-all broadcast messages between them. This will be straightforward to
-add to trillium channels in a future revision, but the current
-implementation does not synchronize messages across servers. However,
-in the mean time, you can use [`Channel::broadcaster`] to return a
-[`ChannelBroadcaster`] that can be used to publish and subscribe to
-messages between servers using whatever distribution mechanism is
-appropriate for your application and deployment. Open a discussion on
-the trillium repo for ideas on how this might work for you.
-
-
-### Event routing is handled in user code
-
-Phoenix channels has a notion of registering channel handlers for
-different topics, so an implementation might involve registering a
-RoomChannel for `rooms:*`. Trillium channels does not currently
-provide this routing/matching behavior, but will likely do so
-eventually.
-
-
-## Simple Example: Chat App
-
-```
-use trillium_channels::{channel, ChannelConn, ChannelEvent, ChannelHandler};
-
-struct ChatChannel;
-impl ChannelHandler for ChatChannel {
-    async fn join_channel(&self, conn: ChannelConn<'_>, event: ChannelEvent) {
-        match event.topic() {
-            "rooms:lobby" => {
-                conn.allow_join(&event, &()).await;
-                conn.broadcast(("rooms:lobby", "user:entered"));
-            }
-
-            _ => {}
-        }
-    }
-
-    async fn incoming_message(&self, conn: ChannelConn<'_>, event: ChannelEvent) {
-        match (event.topic(), event.event()) {
-            ("rooms:lobby", "new:msg") => conn.broadcast(event),
-            _ => {}
-        }
-    }
-}
-
-// fn main() {
-//     trillium_smol::run(channel(ChatChannel));
-// }
-```
-
-See channels/examples/channels.rs for a fully functional example that uses the front-end from [the phoenix chat example](https://github.com/chrismccord/phoenix_chat_example).
-
-*/
+//! # An implementation of phoenix channels for trillium.rs
+//!
+//! Channels are a means of distributing events in soft-realtime to
+//! connected websocket clients, including topic-subscription-based
+//! fanout.
+//!
+//! From the [phoenix docs](https://hexdocs.pm/phoenix/channels.html),
+//!
+//! Some possible use cases include:
+//!
+//! Chat rooms and APIs for messaging apps
+//! Breaking news, like "a goal was scored" or "an earthquake is coming"
+//! Tracking trains, trucks, or race participants on a map
+//! Events in multiplayer games
+//! Monitoring sensors and controlling lights
+//! Notifying a browser that a page's CSS or JavaScript has changed
+//! (this is handy in development)
+//! Conceptually, Channels are pretty simple.
+//!
+//! First, clients connect to the server using WebSockets. Once connected,
+//! they join one or more topics. For example, to interact with a public
+//! chat room clients may join a topic called public_chat, and to receive
+//! updates from a product with ID 7, they may need to join a topic called
+//! product_updates:7.
+//!
+//! Clients can push messages to the topics they've joined, and can also
+//! receive messages from them. The other way around, Channel servers
+//! receive messages from their connected clients, and can push messages
+//! to them too.
+//!
+//!
+//! ## Current known differences from phoenix channels:
+//!
+//! ### No long-polling support
+//!
+//! Phoenix channels support long polling transports as well as
+//! websockets. As most modern browsers and http clients support
+//! websockets, as of the current version, trillium channels exclusively
+//! are built on them. The design should be flexible to support long
+//! polling if it is eventually needed.
+//!
+//! ### No multi-server synchronization yet
+//!
+//! Phoenix channels support running several server nodes and distributing
+//! all broadcast messages between them. This will be straightforward to
+//! add to trillium channels in a future revision, but the current
+//! implementation does not synchronize messages across servers. However,
+//! in the mean time, you can use [`Channel::broadcaster`] to return a
+//! [`ChannelBroadcaster`] that can be used to publish and subscribe to
+//! messages between servers using whatever distribution mechanism is
+//! appropriate for your application and deployment. Open a discussion on
+//! the trillium repo for ideas on how this might work for you.
+//!
+//!
+//! ### Event routing is handled in user code
+//!
+//! Phoenix channels has a notion of registering channel handlers for
+//! different topics, so an implementation might involve registering a
+//! RoomChannel for `rooms:*`. Trillium channels does not currently
+//! provide this routing/matching behavior, but will likely do so
+//! eventually.
+//!
+//!
+//! ## Simple Example: Chat App
+//!
+//! ```
+//! use trillium_channels::{channel, ChannelConn, ChannelEvent, ChannelHandler};
+//!
+//! struct ChatChannel;
+//! impl ChannelHandler for ChatChannel {
+//!     async fn join_channel(&self, conn: ChannelConn<'_>, event: ChannelEvent) {
+//!         match event.topic() {
+//!             "rooms:lobby" => {
+//!                 conn.allow_join(&event, &()).await;
+//!                 conn.broadcast(("rooms:lobby", "user:entered"));
+//!             }
+//!
+//!             _ => {}
+//!         }
+//!     }
+//!
+//!     async fn incoming_message(&self, conn: ChannelConn<'_>, event: ChannelEvent) {
+//!         match (event.topic(), event.event()) {
+//!             ("rooms:lobby", "new:msg") => conn.broadcast(event),
+//!             _ => {}
+//!         }
+//!     }
+//! }
+//!
+//! // fn main() {
+//! //    trillium_smol::run(channel(ChatChannel));
+//! // }
+//! ```
+//!
+//! See channels/examples/channels.rs for a fully functional example that uses the front-end from [the phoenix chat example](https://github.com/chrismccord/phoenix_chat_example).
 
 #![forbid(unsafe_code)]
 #![deny(
@@ -135,25 +132,23 @@ pub use channel_conn::ChannelConn;
 mod version;
 pub use version::Version;
 
-/**
-This macro provides a convenient constructor for a
-[`ChannelEvent`]. It is called with a topic, an event, and an optional
-inline json payload.
-
-
-```
-let event = trillium_channels::event!("some:topic", "some:event");
-assert_eq!(event.topic(), "some:topic");
-assert_eq!(event.event(), "some:event");
-assert_eq!(serde_json::to_string(event.payload()).unwrap(), "{}");
-
-
-let event = trillium_channels::event!("some:topic", "some:event", { "payload": ["any", "json"] });
-assert_eq!(event.topic(), "some:topic");
-assert_eq!(event.event(), "some:event");
-assert_eq!(serde_json::to_string(event.payload()).unwrap(), r#"{"payload":["any","json"]}"#);
-```
-*/
+/// This macro provides a convenient constructor for a
+/// [`ChannelEvent`]. It is called with a topic, an event, and an optional
+/// inline json payload.
+///
+///
+/// ```
+/// let event = trillium_channels::event!("some:topic", "some:event");
+/// assert_eq!(event.topic(), "some:topic");
+/// assert_eq!(event.event(), "some:event");
+/// assert_eq!(serde_json::to_string(event.payload()).unwrap(), "{}");
+///
+///
+/// let event = trillium_channels::event!("some:topic", "some:event", { "payload": ["any", "json"] });
+/// assert_eq!(event.topic(), "some:topic");
+/// assert_eq!(event.event(), "some:event");
+/// assert_eq!(serde_json::to_string(event.payload()).unwrap(), r#"{"payload":["any","json"]}"#);
+/// ```
 #[macro_export]
 macro_rules! event {
     ($topic:expr, $event:expr) => {
@@ -167,10 +162,8 @@ macro_rules! event {
 
 pub use serde_json::json;
 
-/**
-Constructs a new [`Channel`] trillium handler from the provided
-[`ChannelHandler`]. This is an alias for [`Channel::new`]
-*/
+/// Constructs a new [`Channel`] trillium handler from the provided
+/// [`ChannelHandler`]. This is an alias for [`Channel::new`]
 pub fn channel<CH: ChannelHandler>(channel_handler: CH) -> Channel<CH> {
     Channel::new(channel_handler)
 }

--- a/channels/src/subscriptions.rs
+++ b/channels/src/subscriptions.rs
@@ -2,34 +2,26 @@ use crate::ChannelEvent;
 use dashmap::DashSet;
 use std::sync::Arc;
 
-/**
-A data structure that tracks what topics a given client is subscribed to.
-*/
+/// A data structure that tracks what topics a given client is subscribed to.
 #[derive(Clone, Default, Debug)]
 pub struct Subscriptions(Arc<DashSet<String>>);
 impl Subscriptions {
-    /**
-    adds the provided topic to the set of subscriptions. please note
-    that this is case sensitive .
-     */
+    /// adds the provided topic to the set of subscriptions. please note
+    /// that this is case sensitive .
     pub fn join(&self, topic: String) {
         self.0.insert(topic);
     }
 
-    /**
-    removes the provided topic to the set of subscriptions, if it was
-    previously subscribed. please note that this is case sensitive
-     */
+    /// removes the provided topic to the set of subscriptions, if it was
+    /// previously subscribed. please note that this is case sensitive
     pub fn leave(&self, topic: &str) {
         self.0.remove(topic);
     }
 
-    /**
-    predicate function to determine if a ChannelEvent is applicable to
-    a given user. `phx_join` and `phx_leave` are always applicable, as
-    are any topics that are subscribed to by this client (as an exact
-    match).
-     */
+    /// predicate function to determine if a ChannelEvent is applicable to
+    /// a given user. `phx_join` and `phx_leave` are always applicable, as
+    /// are any topics that are subscribed to by this client (as an exact
+    /// match).
     pub fn subscribes(&self, event: &ChannelEvent) -> bool {
         event.is_system_event() || self.0.contains(event.topic())
     }

--- a/channels/src/version.rs
+++ b/channels/src/version.rs
@@ -1,8 +1,6 @@
 use std::{convert::Infallible, str::FromStr};
 
-/**
-The phoenix channel "protocol" version
-*/
+/// The phoenix channel "protocol" version
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub enum Version {

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -9,11 +9,8 @@ use trillium_server_common::{
     ArcedConnector, Connector,
 };
 
-/**
-A client contains a Config and an optional connection pool and builds
-conns.
-
-*/
+/// A client contains a Config and an optional connection pool and builds
+/// conns.
 #[derive(Clone, Debug)]
 pub struct Client {
     config: ArcedConnector,
@@ -117,43 +114,38 @@ impl Client {
         Arc::make_mut(&mut self.default_headers)
     }
 
-    /**
-    chainable constructor to enable connection pooling. this can be
-    combined with [`Client::with_config`]
-
-
-    ```
-    use trillium_smol::ClientConfig;
-    use trillium_client::Client;
-
-    let client = Client::new(ClientConfig::default())
-        .with_default_pool(); //<-
-    ```
-    */
+    /// chainable constructor to enable connection pooling. this can be
+    /// combined with [`Client::with_config`]
+    ///
+    ///
+    /// ```
+    /// use trillium_client::Client;
+    /// use trillium_smol::ClientConfig;
+    ///
+    /// let client = Client::new(ClientConfig::default()).with_default_pool();
+    /// ```
     pub fn with_default_pool(mut self) -> Self {
         self.pool = Some(Pool::default());
         self
     }
 
-    /**
-    builds a new conn.
-
-    if the client has pooling enabled and there is
-    an available connection to the dns-resolved socket (ip and port),
-    the new conn will reuse that when it is sent.
-
-    ```
-    use trillium_smol::ClientConfig;
-    use trillium_client::Client;
-    use trillium_testing::prelude::*;
-    let client = Client::new(ClientConfig::default());
-
-    let conn = client.build_conn("get", "http://trillium.rs"); //<-
-
-    assert_eq!(conn.method(), Method::Get);
-    assert_eq!(conn.url().host_str().unwrap(), "trillium.rs");
-    ```
-    */
+    /// builds a new conn.
+    ///
+    /// if the client has pooling enabled and there is
+    /// an available connection to the dns-resolved socket (ip and port),
+    /// the new conn will reuse that when it is sent.
+    ///
+    /// ```
+    /// use trillium_client::Client;
+    /// use trillium_smol::ClientConfig;
+    /// use trillium_testing::prelude::*;
+    /// let client = Client::new(ClientConfig::default());
+    ///
+    /// let conn = client.build_conn("get", "http://trillium.rs"); //<-
+    ///
+    /// assert_eq!(conn.method(), Method::Get);
+    /// assert_eq!(conn.url().host_str().unwrap(), "trillium.rs");
+    /// ```
     pub fn build_conn<M>(&self, method: M, url: impl IntoUrl) -> Conn
     where
         M: TryInto<Method>,
@@ -183,12 +175,10 @@ impl Client {
         &self.config
     }
 
-    /**
-    The pool implementation currently accumulates a small memory
-    footprint for each new host. If your application is reusing a pool
-    against a large number of unique hosts, call this method
-    intermittently.
-    */
+    /// The pool implementation currently accumulates a small memory
+    /// footprint for each new host. If your application is reusing a pool
+    /// against a large number of unique hosts, call this method
+    /// intermittently.
     pub fn clean_up_pool(&self) {
         if let Some(pool) = &self.pool {
             pool.cleanup();

--- a/client/src/conn.rs
+++ b/client/src/conn.rs
@@ -22,11 +22,9 @@ use trillium_server_common::{
     ArcedConnector, Connector,
 };
 
-/**
-A wrapper error for [`trillium_http::Error`] or
-[`serde_json::Error`]. Only available when the `json` crate feature is
-enabled.
-*/
+/// A wrapper error for [`trillium_http::Error`] or
+/// [`serde_json::Error`]. Only available when the `json` crate feature is
+/// enabled.
 #[cfg(feature = "json")]
 #[derive(thiserror::Error, Debug)]
 pub enum ClientSerdeError {
@@ -39,10 +37,8 @@ pub enum ClientSerdeError {
     JsonError(#[from] serde_json::Error),
 }
 
-/**
-a client connection, representing both an outbound http request and a
-http response
-*/
+/// a client connection, representing both an outbound http request and a
+/// http response
 #[must_use]
 pub struct Conn {
     pub(crate) url: Url,
@@ -90,33 +86,34 @@ impl Conn {
         &self.request_headers
     }
 
-    /**
-    chainable setter for [`inserting`](Headers::insert) a request header
-
-    ```
-    use trillium_testing::client_config;
-
-
-    let handler = |conn: trillium::Conn| async move {
-        let header = conn.request_headers().get_str("some-request-header").unwrap_or_default();
-        let response = format!("some-request-header was {}", header);
-        conn.ok(response)
-    };
-
-    let client = trillium_client::Client::new(client_config());
-
-    trillium_testing::with_server(handler, |url| async move {
-        let mut conn = client.get(url)
-            .with_request_header("some-request-header", "header-value") // <--
-            .await?;
-        assert_eq!(
-            conn.response_body().read_string().await?,
-            "some-request-header was header-value"
-        );
-        Ok(())
-    })
-    ```
-    */
+    /// chainable setter for [`inserting`](Headers::insert) a request header
+    ///
+    /// ```
+    /// use trillium_testing::client_config;
+    ///
+    /// let handler = |conn: trillium::Conn| async move {
+    ///     let header = conn
+    ///         .request_headers()
+    ///         .get_str("some-request-header")
+    ///         .unwrap_or_default();
+    ///     let response = format!("some-request-header was {}", header);
+    ///     conn.ok(response)
+    /// };
+    ///
+    /// let client = trillium_client::Client::new(client_config());
+    ///
+    /// trillium_testing::with_server(handler, |url| async move {
+    ///     let mut conn = client
+    ///         .get(url)
+    ///         .with_request_header("some-request-header", "header-value") // <--
+    ///         .await?;
+    ///     assert_eq!(
+    ///         conn.response_body().read_string().await?,
+    ///         "some-request-header was header-value"
+    ///     );
+    ///     Ok(())
+    /// })
+    /// ```
 
     pub fn with_request_header(
         mut self,
@@ -127,34 +124,36 @@ impl Conn {
         self
     }
 
-    /**
-    chainable setter for `extending` request headers
-
-    ```
-    let handler = |conn: trillium::Conn| async move {
-        let header = conn.request_headers().get_str("some-request-header").unwrap_or_default();
-        let response = format!("some-request-header was {}", header);
-        conn.ok(response)
-    };
-
-    use trillium_testing::client_config;
-    let client = trillium_client::client(client_config());
-
-    trillium_testing::with_server(handler, move |url| async move {
-        let mut conn = client.get(url)
-            .with_request_headers([ // <--
-                ("some-request-header", "header-value"),
-                ("some-other-req-header", "other-header-value")
-            ])
-            .await?;
-        assert_eq!(
-            conn.response_body().read_string().await?,
-            "some-request-header was header-value"
-        );
-        Ok(())
-    })
-    ```
-    */
+    /// chainable setter for `extending` request headers
+    ///
+    /// ```
+    /// let handler = |conn: trillium::Conn| async move {
+    ///     let header = conn
+    ///         .request_headers()
+    ///         .get_str("some-request-header")
+    ///         .unwrap_or_default();
+    ///     let response = format!("some-request-header was {}", header);
+    ///     conn.ok(response)
+    /// };
+    ///
+    /// use trillium_testing::client_config;
+    /// let client = trillium_client::client(client_config());
+    ///
+    /// trillium_testing::with_server(handler, move |url| async move {
+    ///     let mut conn = client
+    ///         .get(url)
+    ///         .with_request_headers([
+    ///             ("some-request-header", "header-value"),
+    ///             ("some-other-req-header", "other-header-value"),
+    ///         ])
+    ///         .await?;
+    ///     assert_eq!(
+    ///         conn.response_body().read_string().await?,
+    ///         "some-request-header was header-value"
+    ///     );
+    ///     Ok(())
+    /// })
+    /// ```
     pub fn with_request_headers<HN, HV, I>(mut self, headers: I) -> Self
     where
         I: IntoIterator<Item = (HN, HV)> + Send,
@@ -171,64 +170,63 @@ impl Conn {
         self
     }
 
-    /**
-    ```
-    let handler = |conn: trillium::Conn| async move {
-        conn.with_response_header("some-header", "some-value")
-            .with_status(200)
-    };
-
-    use trillium_client::Client;
-    use trillium_testing::client_config;
-
-    trillium_testing::with_server(handler, move |url| async move {
-        let client = Client::new(client_config());
-        let conn = client.get(url).await?;
-
-        let headers = conn.response_headers(); //<-
-
-        assert_eq!(headers.get_str("some-header"), Some("some-value"));
-        Ok(())
-    })
-    ```
-    */
+    /// ```
+    /// let handler = |conn: trillium::Conn| async move {
+    ///     conn.with_response_header("some-header", "some-value")
+    ///         .with_status(200)
+    /// };
+    ///
+    /// use trillium_client::Client;
+    /// use trillium_testing::client_config;
+    ///
+    /// trillium_testing::with_server(handler, move |url| async move {
+    ///     let client = Client::new(client_config());
+    ///     let conn = client.get(url).await?;
+    ///
+    ///     let headers = conn.response_headers(); //<-
+    ///
+    ///     assert_eq!(headers.get_str("some-header"), Some("some-value"));
+    ///     Ok(())
+    /// })
+    /// ```
     pub fn response_headers(&self) -> &Headers {
         &self.response_headers
     }
 
-    /**
-    retrieves a mutable borrow of the request headers, suitable for
-    appending a header. generally, prefer using chainable methods on
-    Conn
-
-    ```
-    use trillium_testing::client_config;
-    use trillium_client::Client;
-
-    let handler = |conn: trillium::Conn| async move {
-        let header = conn.request_headers().get_str("some-request-header").unwrap_or_default();
-        let response = format!("some-request-header was {}", header);
-        conn.ok(response)
-    };
-
-    let client = Client::new(client_config());
-
-    trillium_testing::with_server(handler, move |url| async move {
-        let mut conn = client.get(url);
-
-        conn.request_headers_mut() //<-
-            .insert("some-request-header", "header-value");
-
-        let mut conn = conn.await?;
-
-        assert_eq!(
-            conn.response_body().read_string().await?,
-            "some-request-header was header-value"
-        );
-        Ok(())
-    })
-    ```
-    */
+    /// retrieves a mutable borrow of the request headers, suitable for
+    /// appending a header. generally, prefer using chainable methods on
+    /// Conn
+    ///
+    /// ```
+    /// use trillium_client::Client;
+    /// use trillium_testing::client_config;
+    ///
+    /// let handler = |conn: trillium::Conn| async move {
+    ///     let header = conn
+    ///         .request_headers()
+    ///         .get_str("some-request-header")
+    ///         .unwrap_or_default();
+    ///     let response = format!("some-request-header was {}", header);
+    ///     conn.ok(response)
+    /// };
+    ///
+    /// let client = Client::new(client_config());
+    ///
+    /// trillium_testing::with_server(handler, move |url| async move {
+    ///     let mut conn = client.get(url);
+    ///
+    ///     conn.request_headers_mut() //<-
+    ///         .insert("some-request-header", "header-value");
+    ///
+    ///     let mut conn = conn.await?;
+    ///
+    ///     assert_eq!(
+    ///         conn.response_body().read_string().await?,
+    ///         "some-request-header was header-value"
+    ///     );
+    ///     Ok(())
+    /// })
+    /// ```
     pub fn request_headers_mut(&mut self) -> &mut Headers {
         &mut self.request_headers
     }
@@ -238,74 +236,70 @@ impl Conn {
         &mut self.response_headers
     }
 
-    /**
-    sets the request body on a mutable reference. prefer the chainable
-    [`Conn::with_body`] wherever possible
-
-    ```
-    env_logger::init();
-    use trillium_client::Client;
-    use trillium_testing::client_config;
-
-
-    let handler = |mut conn: trillium::Conn| async move {
-        let body = conn.request_body_string().await.unwrap();
-        conn.ok(format!("request body was: {}", body))
-    };
-
-    trillium_testing::with_server(handler, move |url| async move {
-        let client = Client::new(client_config());
-        let mut conn = client.post(url);
-
-        conn.set_request_body("body"); //<-
-
-        (&mut conn).await?;
-
-        assert_eq!(conn.response_body().read_string().await?, "request body was: body");
-        Ok(())
-    });
-    ```
-     */
+    /// sets the request body on a mutable reference. prefer the chainable
+    /// [`Conn::with_body`] wherever possible
+    ///
+    /// ```
+    /// env_logger::init();
+    /// use trillium_client::Client;
+    /// use trillium_testing::client_config;
+    ///
+    /// let handler = |mut conn: trillium::Conn| async move {
+    ///     let body = conn.request_body_string().await.unwrap();
+    ///     conn.ok(format!("request body was: {}", body))
+    /// };
+    ///
+    /// trillium_testing::with_server(handler, move |url| async move {
+    ///     let client = Client::new(client_config());
+    ///     let mut conn = client.post(url);
+    ///
+    ///     conn.set_request_body("body"); //<-
+    ///
+    ///     (&mut conn).await?;
+    ///
+    ///     assert_eq!(
+    ///         conn.response_body().read_string().await?,
+    ///         "request body was: body"
+    ///     );
+    ///     Ok(())
+    /// });
+    /// ```
     pub fn set_request_body(&mut self, body: impl Into<Body>) {
         self.request_body = Some(body.into());
     }
 
-    /**
-    chainable setter for the request body
-
-    ```
-    env_logger::init();
-    use trillium_testing::client_config;
-    use trillium_client::Client;
-
-    let handler = |mut conn: trillium::Conn| async move {
-        let body = conn.request_body_string().await.unwrap();
-        conn.ok(format!("request body was: {}", body))
-    };
-
-
-    trillium_testing::with_server(handler, |url| async move {
-        let client = Client::from(client_config());
-        let mut conn = client.post(url)
-            .with_body("body") //<-
-            .await?;
-
-        assert_eq!(
-            conn.response_body().read_string().await?,
-            "request body was: body"
-        );
-        Ok(())
-    });
-    ```
-     */
+    /// chainable setter for the request body
+    ///
+    /// ```
+    /// env_logger::init();
+    /// use trillium_client::Client;
+    /// use trillium_testing::client_config;
+    ///
+    /// let handler = |mut conn: trillium::Conn| async move {
+    ///     let body = conn.request_body_string().await.unwrap();
+    ///     conn.ok(format!("request body was: {}", body))
+    /// };
+    ///
+    /// trillium_testing::with_server(handler, |url| async move {
+    ///     let client = Client::from(client_config());
+    ///     let mut conn = client
+    ///         .post(url)
+    ///         .with_body("body") //<-
+    ///         .await?;
+    ///
+    ///     assert_eq!(
+    ///         conn.response_body().read_string().await?,
+    ///         "request body was: body"
+    ///     );
+    ///     Ok(())
+    /// });
+    /// ```
     pub fn with_body(mut self, body: impl Into<Body>) -> Self {
         self.set_request_body(body);
         self
     }
 
-    /**
-    chainable setter for json body. this requires the `json` crate feature to be enabled.
-     */
+    /// chainable setter for json body. this requires the `json` crate feature to be enabled.
     #[cfg(feature = "json")]
     pub fn with_json_body(self, body: &impl serde::Serialize) -> serde_json::Result<Self> {
         use trillium_http::KnownHeaderName;
@@ -319,69 +313,57 @@ impl Conn {
         encoding(&self.response_headers)
     }
 
-    /**
-    retrieves the url for this conn.
-    ```
-    use trillium_testing::client_config;
-    use trillium_client::Client;
-    let client = Client::from(client_config());
-    let conn = client.get("http://localhost:9080");
-
-    let url = conn.url(); //<-
-
-    assert_eq!(url.host_str().unwrap(), "localhost");
-    ```
-     */
+    /// retrieves the url for this conn.
+    /// ```
+    /// use trillium_client::Client;
+    /// use trillium_testing::client_config;
+    /// let client = Client::from(client_config());
+    /// let conn = client.get("http://localhost:9080");
+    ///
+    /// let url = conn.url(); //<-
+    ///
+    /// assert_eq!(url.host_str().unwrap(), "localhost");
+    /// ```
     pub fn url(&self) -> &Url {
         &self.url
     }
 
-    /**
-    retrieves the url for this conn.
-    ```
-    use trillium_testing::client_config;
-    use trillium_client::Client;
-
-    use trillium_testing::prelude::*;
-
-    let client = Client::from(client_config());
-    let conn = client.get("http://localhost:9080");
-
-    let method = conn.method(); //<-
-
-    assert_eq!(method, Method::Get);
-    ```
-     */
+    /// retrieves the url for this conn.
+    /// ```
+    /// use trillium_client::Client;
+    /// use trillium_testing::{client_config, prelude::*};
+    ///
+    /// let client = Client::from(client_config());
+    /// let conn = client.get("http://localhost:9080");
+    ///
+    /// let method = conn.method(); //<-
+    ///
+    /// assert_eq!(method, Method::Get);
+    /// ```
     pub fn method(&self) -> Method {
         self.method
     }
 
-    /**
-    returns a [`ReceivedBody`] that borrows the connection inside this conn.
-    ```
-    env_logger::init();
-    use trillium_testing::client_config;
-    use trillium_client::Client;
-
-
-
-    let handler = |mut conn: trillium::Conn| async move {
-        conn.ok("hello from trillium")
-    };
-
-    trillium_testing::with_server(handler, |url| async move {
-        let client = Client::from(client_config());
-        let mut conn = client.get(url).await?;
-
-        let response_body = conn.response_body(); //<-
-
-        assert_eq!(19, response_body.content_length().unwrap());
-        let string = response_body.read_string().await?;
-        assert_eq!("hello from trillium", string);
-        Ok(())
-    });
-    ```
-     */
+    /// returns a [`ReceivedBody`] that borrows the connection inside this conn.
+    /// ```
+    /// env_logger::init();
+    /// use trillium_client::Client;
+    /// use trillium_testing::client_config;
+    ///
+    /// let handler = |mut conn: trillium::Conn| async move { conn.ok("hello from trillium") };
+    ///
+    /// trillium_testing::with_server(handler, |url| async move {
+    ///     let client = Client::from(client_config());
+    ///     let mut conn = client.get(url).await?;
+    ///
+    ///     let response_body = conn.response_body(); //<-
+    ///
+    ///     assert_eq!(19, response_body.content_length().unwrap());
+    ///     let string = response_body.read_string().await?;
+    ///     assert_eq!("hello from trillium", string);
+    ///     Ok(())
+    /// });
+    /// ```
 
     #[allow(clippy::needless_borrow, clippy::needless_borrows_for_generic_args)]
     pub fn response_body(&mut self) -> ReceivedBody<'_, BoxedTransport> {
@@ -395,9 +377,7 @@ impl Conn {
         )
     }
 
-    /**
-    Attempt to deserialize the response body. Note that this consumes the body content.
-     */
+    /// Attempt to deserialize the response body. Note that this consumes the body content.
     #[cfg(feature = "json")]
     pub async fn response_json<T>(&mut self) -> std::result::Result<T, ClientSerdeError>
     where
@@ -420,53 +400,48 @@ impl Conn {
         }
     }
 
-    /**
-    returns the status code for this conn. if the conn has not yet
-    been sent, this will be None.
-
-    ```
-    use trillium_testing::client_config;
-    use trillium_client::Client;
-    use trillium_testing::prelude::*;
-
-    async fn handler(conn: trillium::Conn) -> trillium::Conn {
-        conn.with_status(418)
-    }
-
-    trillium_testing::with_server(handler, |url| async move {
-        let client = Client::new(client_config());
-        let conn = client.get(url).await?;
-        assert_eq!(Status::ImATeapot, conn.status().unwrap());
-        Ok(())
-    });
-    ```
-     */
+    /// returns the status code for this conn. if the conn has not yet
+    /// been sent, this will be None.
+    ///
+    /// ```
+    /// use trillium_client::Client;
+    /// use trillium_testing::{client_config, prelude::*};
+    ///
+    /// async fn handler(conn: trillium::Conn) -> trillium::Conn {
+    ///     conn.with_status(418)
+    /// }
+    ///
+    /// trillium_testing::with_server(handler, |url| async move {
+    ///     let client = Client::new(client_config());
+    ///     let conn = client.get(url).await?;
+    ///     assert_eq!(Status::ImATeapot, conn.status().unwrap());
+    ///     Ok(())
+    /// });
+    /// ```
     pub fn status(&self) -> Option<Status> {
         self.status
     }
 
-    /**
-    Returns the conn or an [`UnexpectedStatusError`] that contains the conn
-
-    ```
-    use trillium_testing::client_config;
-
-    trillium_testing::with_server(trillium::Status::NotFound, |url| async move {
-        let client = trillium_client::Client::new(client_config());
-        assert_eq!(
-            client.get(url).await?.success().unwrap_err().to_string(),
-            "expected a success (2xx) status code, but got 404 Not Found"
-        );
-        Ok(())
-    });
-
-    trillium_testing::with_server(trillium::Status::Ok, |url| async move {
-        let client = trillium_client::Client::new(client_config());
-        assert!(client.get(url).await?.success().is_ok());
-        Ok(())
-    });
-    ```
-     */
+    /// Returns the conn or an [`UnexpectedStatusError`] that contains the conn
+    ///
+    /// ```
+    /// use trillium_testing::client_config;
+    ///
+    /// trillium_testing::with_server(trillium::Status::NotFound, |url| async move {
+    ///     let client = trillium_client::Client::new(client_config());
+    ///     assert_eq!(
+    ///         client.get(url).await?.success().unwrap_err().to_string(),
+    ///         "expected a success (2xx) status code, but got 404 Not Found"
+    ///     );
+    ///     Ok(())
+    /// });
+    ///
+    /// trillium_testing::with_server(trillium::Status::Ok, |url| async move {
+    ///     let client = trillium_client::Client::new(client_config());
+    ///     assert!(client.get(url).await?.success().is_ok());
+    ///     Ok(())
+    /// });
+    /// ```
     pub fn success(self) -> std::result::Result<Self, UnexpectedStatusError> {
         match self.status() {
             Some(status) if status.is_success() => Ok(self),
@@ -474,12 +449,10 @@ impl Conn {
         }
     }
 
-    /**
-    Returns this conn to the connection pool if it is keepalive, and
-    closes it otherwise. This will happen asynchronously as a spawned
-    task when the conn is dropped, but calling it explicitly allows
-    you to block on it and control where it happens.
-    */
+    /// Returns this conn to the connection pool if it is keepalive, and
+    /// closes it otherwise. This will happen asynchronously as a spawned
+    /// task when the conn is dropped, but calling it explicitly allows
+    /// you to block on it and control where it happens.
     pub async fn recycle(mut self) {
         if self.is_keep_alive() && self.transport.is_some() && self.pool.is_some() {
             self.finish_reading_body().await;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -9,26 +9,23 @@
     unused_qualifications
 )]
 
-/*!
-trillium client is a http client that uses the same `conn` approach as
-[`trillium`](https://trillium.rs) but which can be used
-independently for any http client application.
-
-## Connector
-
-[`trillium_client::Client`] is built with a Connector. Each runtime crate
-([`trillium_smol`](https://docs.trillium.rs/trillium_smol),
-[`trillium_tokio`](https://docs.trillium.rs/trillium_tokio),
-[`trillium_async_std`](https://docs.trillium.rs/trillium_tokio)) offers
-a Connector implementation, which can optionally be combined with a
-tls crate such as
-[`trillium_rustls`](https://docs.trillium.rs/trillium_rustls) or
-[`trillium_native_tls`](https://docs.trillium.rs/trillium_native_tls).
-
-See the documentation for [`Client`] and [`Conn`] for further usage
-examples.
-
-*/
+//! trillium client is a http client that uses the same `conn` approach as
+//! [`trillium`](https://trillium.rs) but which can be used
+//! independently for any http client application.
+//!
+//! ## Connector
+//!
+//! [`trillium_client::Client`] is built with a Connector. Each runtime crate
+//! ([`trillium_smol`](https://docs.trillium.rs/trillium_smol),
+//! [`trillium_tokio`](https://docs.trillium.rs/trillium_tokio),
+//! [`trillium_async_std`](https://docs.trillium.rs/trillium_tokio)) offers
+//! a Connector implementation, which can optionally be combined with a
+//! tls crate such as
+//! [`trillium_rustls`](https://docs.trillium.rs/trillium_rustls) or
+//! [`trillium_native_tls`](https://docs.trillium.rs/trillium_native_tls).
+//!
+//! See the documentation for [`Client`] and [`Conn`] for further usage
+//! examples.
 
 mod conn;
 #[cfg(feature = "json")]

--- a/compression/src/lib.rs
+++ b/compression/src/lib.rs
@@ -1,12 +1,10 @@
-/*!
-Body compression for trillium.rs
-
-Currently, this crate only supports compressing outbound bodies with
-the zstd, brotli, and gzip algorithms (in order of preference),
-although more algorithms may be added in the future. The correct
-algorithm will be selected based on the Accept-Encoding header sent by
-the client, if one exists.
-*/
+//! Body compression for trillium.rs
+//!
+//! Currently, this crate only supports compressing outbound bodies with
+//! the zstd, brotli, and gzip algorithms (in order of preference),
+//! although more algorithms may be added in the future. The correct
+//! algorithm will be selected based on the Accept-Encoding header sent by
+//! the client, if one exists.
 #![forbid(unsafe_code)]
 #![deny(
     missing_copy_implementations,
@@ -88,9 +86,7 @@ impl FromStr for CompressionAlgorithm {
     }
 }
 
-/**
-Trillium handler for compression
-*/
+/// Trillium handler for compression
 #[derive(Clone, Debug)]
 pub struct Compression {
     algorithms: BTreeSet<CompressionAlgorithm>,
@@ -115,11 +111,9 @@ impl Compression {
         self.algorithms = algos.iter().copied().collect();
     }
 
-    /**
-    sets the compression algorithms that this handler will
-    use. the default of Zstd, Brotli, Gzip is recommended. Note that the
-    order is ignored.
-    */
+    /// sets the compression algorithms that this handler will
+    /// use. the default of Zstd, Brotli, Gzip is recommended. Note that the
+    /// order is ignored.
     pub fn with_algorithms(mut self, algorithms: &[CompressionAlgorithm]) -> Self {
         self.set_algorithms(algorithms);
         self

--- a/conn-id/src/lib.rs
+++ b/conn-id/src/lib.rs
@@ -1,14 +1,11 @@
-/*!
-Trillium crate to add identifiers to conns.
-
-This crate provides the following utilities:
-* [`ConnId`] a handler which must be called for the rest of this crate to function
-* [`log_formatter::conn_id`] a formatter to use with trillium_logger
-  (note that this does not depend on the trillium_logger crate and is very lightweight
-  if you do not use that crate)
-* [`ConnIdExt`] an extension trait for retrieving the id from a conn
-
-*/
+//! Trillium crate to add identifiers to conns.
+//!
+//! This crate provides the following utilities:
+//! [`ConnId`] a handler which must be called for the rest of this crate to function
+//! [`log_formatter::conn_id`] a formatter to use with trillium_logger
+//! (note that this does not depend on the trillium_logger crate and is very lightweight
+//! if you do not use that crate)
+//! [`ConnIdExt`] an extension trait for retrieving the id from a conn
 #![forbid(unsafe_code)]
 #![deny(
     missing_copy_implementations,
@@ -46,15 +43,13 @@ impl IdGenerator {
     }
 }
 
-/**
-Trillium handler to set a identifier for every Conn.
-
-By default, it will use an inbound `x-request-id` request header or if
-that is missing, populate a ten character random id. This handler will
-set an outbound `x-request-id` header as well by default. All of this
-behavior can be customized with [`ConnId::with_request_header`],
-[`ConnId::with_response_header`] and [`ConnId::with_id_generator`]
-*/
+/// Trillium handler to set a identifier for every Conn.
+///
+/// By default, it will use an inbound `x-request-id` request header or if
+/// that is missing, populate a ten character random id. This handler will
+/// set an outbound `x-request-id` header as well by default. All of this
+/// behavior can be customized with [`ConnId::with_request_header`],
+/// [`ConnId::with_response_header`] and [`ConnId::with_id_generator`]
 pub struct ConnId {
     request_header: Option<HeaderName<'static>>,
     response_header: Option<HeaderName<'static>>,
@@ -82,121 +77,117 @@ impl Default for ConnId {
 }
 
 impl ConnId {
-    /**
-    Constructs a new ConnId handler
-    ```
-    # use trillium_testing::prelude::*;
-    # use trillium_conn_id::ConnId;
-    let app = (ConnId::new().with_seed(1000), "ok"); // seeded for testing
-    assert_ok!(
-        get("/").on(&app),
-        "ok",
-        "x-request-id" => "J4lzoPXcT5"
-    );
-
-    assert_headers!(
-        get("/")
-            .with_request_header("x-request-id", "inbound")
-            .on(&app),
-        "x-request-id" => "inbound"
-    );
-    ```
-    */
+    /// Constructs a new ConnId handler
+    /// ```
+    /// # use trillium_testing::prelude::*;
+    /// # use trillium_conn_id::ConnId;
+    /// let app = (ConnId::new().with_seed(1000), "ok"); // seeded for testing
+    /// assert_ok!(
+    /// get("/").on(&app),
+    /// "ok",
+    /// "x-request-id" => "J4lzoPXcT5"
+    /// );
+    ///
+    /// assert_headers!(
+    /// get("/")
+    /// .with_request_header("x-request-id", "inbound")
+    /// .on(&app),
+    /// "x-request-id" => "inbound"
+    /// );
+    /// ```
     pub fn new() -> Self {
         Self::default()
     }
 
-    /**
-    Specifies a request header to use. If this header is provided on
-    the inbound request, the id will be used unmodified. To disable
-    this behavior, see [`ConnId::without_request_header`]
-
-    ```
-    # use trillium_testing::prelude::*;
-    # use trillium_conn_id::ConnId;
-
-    let app = (
-        ConnId::new().with_request_header("x-custom-id"),
-        "ok"
-    );
-
-    assert_headers!(
-        get("/")
-            .with_request_header("x-custom-id", "inbound")
-            .on(&app),
-        "x-request-id" => "inbound"
-    );
-    ```
-
-    */
+    /// Specifies a request header to use. If this header is provided on
+    /// the inbound request, the id will be used unmodified. To disable
+    /// this behavior, see [`ConnId::without_request_header`]
+    ///
+    /// ```
+    /// # use trillium_testing::prelude::*;
+    /// # use trillium_conn_id::ConnId;
+    ///
+    /// let app = (
+    /// ConnId::new().with_request_header("x-custom-id"),
+    /// "ok"
+    /// );
+    ///
+    /// assert_headers!(
+    /// get("/")
+    /// .with_request_header("x-custom-id", "inbound")
+    /// .on(&app),
+    /// "x-request-id" => "inbound"
+    /// );
+    /// ```
     pub fn with_request_header(mut self, request_header: impl Into<HeaderName<'static>>) -> Self {
         self.request_header = Some(request_header.into());
         self
     }
 
-    /**
-    disables the default behavior of reusing an inbound header for
-    the request id. If a ConnId is configured
-    `without_request_header`, a new id will always be generated
-    */
+    /// disables the default behavior of reusing an inbound header for
+    /// the request id. If a ConnId is configured
+    /// `without_request_header`, a new id will always be generated
     pub fn without_request_header(mut self) -> Self {
         self.request_header = None;
         self
     }
 
-    /**
-    Specifies a response header to set. To disable this behavior, see
-    [`ConnId::without_response_header`]
-
-    ```
-    # use trillium_testing::prelude::*;
-    # use trillium_conn_id::ConnId;
-    let app = (
-        ConnId::new()
-            .with_seed(1000) // for testing
-            .with_response_header("x-custom-header"),
-        "ok"
-    );
-
-    assert_headers!(
-        get("/").on(&app),
-        "x-custom-header" => "J4lzoPXcT5"
-    );
-    ```
-    */
+    /// Specifies a response header to set. To disable this behavior, see
+    /// [`ConnId::without_response_header`]
+    ///
+    /// ```
+    /// # use trillium_testing::prelude::*;
+    /// # use trillium_conn_id::ConnId;
+    /// let app = (
+    ///   ConnId::new()
+    ///       .with_seed(1000) // for testing
+    ///       .with_response_header("x-custom-header"),
+    ///   "ok",
+    /// );
+    ///
+    /// assert_headers!(
+    ///     get("/").on(&app),
+    ///     "x-custom-header" => "J4lzoPXcT5"
+    /// );
+    /// ```
     pub fn with_response_header(mut self, response_header: impl Into<HeaderName<'static>>) -> Self {
         self.response_header = Some(response_header.into());
         self
     }
 
-    /**
-    Disables the default behavior of sending the conn id as a response
-    header. A request id will be available within the application
-    through use of [`ConnIdExt`] but will not be sent as part of the
-    response.
-    */
+    /// Disables the default behavior of sending the conn id as a response
+    /// header. A request id will be available within the application
+    /// through use of [`ConnIdExt`] but will not be sent as part of the
+    /// response.
     pub fn without_response_header(mut self) -> Self {
         self.response_header = None;
         self
     }
 
-    /**
-    Provide an alternative generator function for ids. The default
-    is a ten-character alphanumeric random sequence.
-
-    ```
-    # use trillium_testing::prelude::*;
-    # use trillium_conn_id::ConnId;
-    # use uuid::Uuid;
-    let app = (
-        ConnId::new().with_id_generator(|| Uuid::new_v4().to_string()),
-        "ok"
-    );
-
-    // assert that the id is a valid uuid, even if we can't assert a specific value
-    assert!(Uuid::parse_str(get("/").on(&app).response_headers().get_str("x-request-id").unwrap()).is_ok());
-    ```
-    */
+    /// Provide an alternative generator function for ids. The default
+    /// is a ten-character alphanumeric random sequence.
+    ///
+    /// ```
+    /// # use trillium_testing::prelude::*;
+    /// # use trillium_conn_id::ConnId;
+    /// # use uuid::Uuid;
+    /// let app = (
+    ///     ConnId::new().with_id_generator(|| Uuid::new_v4().to_string()),
+    ///     "ok",
+    /// );
+    ///
+    /// // assert that the id is a valid uuid, even if we can't assert a specific value
+    /// assert!(
+    ///     Uuid::parse_str(
+    ///         get("/")
+    ///             .on(&app)
+    ///             .response_headers()
+    ///             .get_str("x-request-id")
+    ///             .unwrap()
+    ///     )
+    ///     .is_ok()
+    /// );
+    /// ```
     pub fn with_id_generator<F>(mut self, id_generator: F) -> Self
     where
         F: Fn() -> String + Send + Sync + 'static,

--- a/cookies/src/cookies_conn_ext.rs
+++ b/cookies/src/cookies_conn_ext.rs
@@ -1,12 +1,10 @@
 use cookie::{Cookie, CookieJar};
 use trillium::Conn;
 
-/**
-Extension trait adding cookie capacities to [`Conn`].
-
-Important: The [`CookiesHandler`](crate::CookiesHandler) must be
-called before any of these functions can be called on a conn.
-*/
+/// Extension trait adding cookie capacities to [`Conn`].
+///
+/// Important: The [`CookiesHandler`](crate::CookiesHandler) must be
+/// called before any of these functions can be called on a conn.
 pub trait CookiesConnExt {
     /// adds a cookie to the cookie jar and returns the conn
     fn with_cookie<'a>(self, cookie: impl Into<Cookie<'a>>) -> Self;

--- a/cookies/src/cookies_handler.rs
+++ b/cookies/src/cookies_handler.rs
@@ -1,10 +1,8 @@
 use cookie::{Cookie, CookieJar};
 use trillium::{Conn, Handler, HeaderValue, HeaderValues, KnownHeaderName};
 
-/**
-The trillium cookie handler. See crate level docs for an example. This
-must run before any handlers access the cookie jar.
-*/
+/// The trillium cookie handler. See crate level docs for an example. This
+/// must run before any handlers access the cookie jar.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct CookiesHandler {
     // this is in order to force users to call CookiesHandler::new or

--- a/cookies/src/lib.rs
+++ b/cookies/src/lib.rs
@@ -9,42 +9,38 @@
     unused_qualifications
 )]
 
-/*!
-
-# the trillium cookie handler
-
-## example
-```
-use trillium::Conn;
-use trillium_cookies::{cookie::Cookie, CookiesConnExt, CookiesHandler};
-async fn handler_that_uses_cookies(conn: Conn) -> Conn {
-    let content = if let Some(cookie_value) = conn.cookies().get("some_cookie") {
-        format!("current cookie value: {}", cookie_value.value())
-    } else {
-        String::from("no cookie value set")
-    };
-
-    conn.with_cookie(("some_cookie", "some-cookie-value")).ok(content)
-}
-
-let handler = (CookiesHandler::new(), handler_that_uses_cookies);
-
-use trillium_testing::prelude::*;
-
-assert_ok!(
-    get("/").on(&handler),
-    "no cookie value set",
-    "set-cookie" => "some_cookie=some-cookie-value"
-);
-
-assert_ok!(
-    get("/").with_request_header("cookie", "some_cookie=trillium").on(&handler),
-    "current cookie value: trillium",
-    "set-cookie" => "some_cookie=some-cookie-value"
-);
-
-```
-*/
+//! # the trillium cookie handler
+//!
+//! ## example
+//! ```
+//! use trillium::Conn;
+//! use trillium_cookies::{cookie::Cookie, CookiesConnExt, CookiesHandler};
+//! async fn handler_that_uses_cookies(conn: Conn) -> Conn {
+//! let content = if let Some(cookie_value) = conn.cookies().get("some_cookie") {
+//! format!("current cookie value: {}", cookie_value.value())
+//! } else {
+//! String::from("no cookie value set")
+//! };
+//!
+//! conn.with_cookie(("some_cookie", "some-cookie-value")).ok(content)
+//! }
+//!
+//! let handler = (CookiesHandler::new(), handler_that_uses_cookies);
+//!
+//! use trillium_testing::prelude::*;
+//!
+//! assert_ok!(
+//! get("/").on(&handler),
+//! "no cookie value set",
+//! "set-cookie" => "some_cookie=some-cookie-value"
+//! );
+//!
+//! assert_ok!(
+//! get("/").with_request_header("cookie", "some_cookie=trillium").on(&handler),
+//! "current cookie value: trillium",
+//! "set-cookie" => "some_cookie=some-cookie-value"
+//! );
+//! ```
 mod cookies_handler;
 pub use cookies_handler::{cookies, CookiesHandler};
 

--- a/handlebars/src/assigns.rs
+++ b/handlebars/src/assigns.rs
@@ -6,10 +6,8 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-/**
-A struct for accumulating key-value data for use in handlebars
-templates. The values can be any type that is serde serializable
-*/
+/// A struct for accumulating key-value data for use in handlebars
+/// templates. The values can be any type that is serde serializable
 #[derive(Default, Serialize, Debug)]
 pub struct Assigns(HashMap<Cow<'static, str>, Value>);
 

--- a/handlebars/src/handlebars_conn_ext.rs
+++ b/handlebars/src/handlebars_conn_ext.rs
@@ -4,59 +4,51 @@ use serde_json::json;
 use std::borrow::Cow;
 use trillium::Conn;
 
-/**
-Extension trait that provides handlebar rendering capabilities to
-[`trillium::Conn`]s.
-*/
+/// Extension trait that provides handlebar rendering capabilities to
+/// [`trillium::Conn`]s.
 pub trait HandlebarsConnExt {
-    /**
-    Registers an "assigns" value on this Conn for use in a template.
-    See example usage at [`Handlebars::new`](crate::Handlebars::new)
-    */
+    /// Registers an "assigns" value on this Conn for use in a template.
+    /// See example usage at [`Handlebars::new`](crate::Handlebars::new)
     fn assign(self, key: impl Into<Cow<'static, str>>, data: impl Serialize) -> Self;
 
-    /**
-    renders a registered template by name with the provided data as
-    assigns. note that this does not use any data accumulated by
-    [`HandlebarsConnExt::assign`]
-
-    ```
-    use trillium_handlebars::{HandlebarsHandler, Handlebars, HandlebarsConnExt};
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-
-    #[derive(serde::Serialize)]
-    struct User { name: &'static str };
-
-    let mut handlebars = Handlebars::new();
-    handlebars.register_template_string("greet-user", "Hello {{name}}")?;
-
-    let handler = (
-        HandlebarsHandler::new(handlebars),
-        |mut conn: trillium::Conn| async move {
-            conn.render_with("greet-user", &User { name: "handlebars" })
-        }
-    );
-
-    use trillium_testing::prelude::*;
-    assert_ok!(get("/").on(&handler), "Hello handlebars");
-    # Ok(()) }
-    ```
-    */
+    /// renders a registered template by name with the provided data as
+    /// assigns. note that this does not use any data accumulated by
+    /// [`HandlebarsConnExt::assign`]
+    ///
+    /// ```
+    /// use trillium_handlebars::{Handlebars, HandlebarsConnExt, HandlebarsHandler};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///
+    /// #[derive(serde::Serialize)]
+    /// struct User {
+    ///     name: &'static str,
+    /// };
+    ///
+    /// let mut handlebars = Handlebars::new();
+    /// handlebars.register_template_string("greet-user", "Hello {{name}}")?;
+    ///
+    /// let handler = (
+    ///     HandlebarsHandler::new(handlebars),
+    ///     |mut conn: trillium::Conn| async move {
+    ///         conn.render_with("greet-user", &User { name: "handlebars" })
+    ///     },
+    /// );
+    ///
+    /// use trillium_testing::prelude::*;
+    /// assert_ok!(get("/").on(&handler), "Hello handlebars");
+    /// # Ok(()) }
+    /// ```
     fn render_with(self, template: &str, data: &impl Serialize) -> Self;
 
-    /**
-    renders a registered template, passing any accumulated assigns to
-    the template. See example at [`Handlebars::new`](crate::Handlebars::new)
-     */
+    /// renders a registered template, passing any accumulated assigns to
+    /// the template. See example at [`Handlebars::new`](crate::Handlebars::new)
     fn render(self, template: &str) -> Self;
 
     /// retrieves a reference to any accumulated assigns on this conn
     fn assigns(&self) -> Option<&Assigns>;
 
-    /**
-    retrieves a mutable reference to any accumulated assigns on this
-    conn
-     */
+    /// retrieves a mutable reference to any accumulated assigns on this
+    /// conn
     fn assigns_mut(&mut self) -> &mut Assigns;
 }
 

--- a/handlebars/src/handlebars_handler.rs
+++ b/handlebars/src/handlebars_handler.rs
@@ -5,10 +5,8 @@ use std::{
     sync::{Arc, RwLock},
 };
 use trillium::{Conn, Handler};
-/**
-A trillium handler that provides registered templates to
-downsequence handlers
-*/
+/// A trillium handler that provides registered templates to
+/// downsequence handlers
 
 #[derive(Default, Clone, Debug)]
 pub struct HandlebarsHandler(Arc<RwLock<Handlebars<'static>>>);

--- a/head/src/lib.rs
+++ b/head/src/lib.rs
@@ -1,11 +1,9 @@
-/*!
-# Trillium handler for HEAD requests
-
-This simple handler rewrites HEAD requests to be GET requests, and
-then before sending the response, removes the outbound body but sets a
-content length header. Any handlers subsequent to this one see a GET
-request.
-*/
+//! # Trillium handler for HEAD requests
+//!
+//! This simple handler rewrites HEAD requests to be GET requests, and
+//! then before sending the response, removes the outbound body but sets a
+//! content length header. Any handlers subsequent to this one see a GET
+//! request.
 #![forbid(unsafe_code)]
 #![deny(
     missing_copy_implementations,
@@ -18,11 +16,9 @@ request.
 
 use trillium::{conn_unwrap, Conn, Handler, KnownHeaderName::ContentLength, Method};
 
-/**
-Trillium handler for HEAD requests
-
-See crate-level docs for an explanation
-*/
+/// Trillium handler for HEAD requests
+///
+/// See crate-level docs for an explanation
 #[derive(Default, Clone, Copy, Debug)]
 pub struct Head {
     _my_private_things: (),

--- a/http/src/body.rs
+++ b/http/src/body.rs
@@ -61,21 +61,18 @@ impl Body {
         }
     }
 
-    /**
-    Consume this body and return the full content. If the body was
-    constructed with `[Body::new_streaming`], this will read the
-    entire streaming body into memory, awaiting the streaming
-    source's completion. This function will return an error if a
-    streaming body has already been read to completion.
-
-    # Errors
-
-    This returns an error variant if either of the following conditions are met:
-
-    * there is an io error when reading from the underlying transport such as a disconnect
-    * the body has already been read to completion
-
-    */
+    /// Consume this body and return the full content. If the body was
+    /// constructed with `[Body::new_streaming`], this will read the
+    /// entire streaming body into memory, awaiting the streaming
+    /// source's completion. This function will return an error if a
+    /// streaming body has already been read to completion.
+    ///
+    /// # Errors
+    ///
+    /// This returns an error variant if either of the following conditions are met:
+    ///
+    /// there is an io error when reading from the underlying transport such as a disconnect
+    /// the body has already been read to completion
     #[allow(clippy::missing_errors_doc)] // false positive
     pub async fn into_bytes(self) -> Result<Cow<'static, [u8]>> {
         match self.0 {

--- a/http/src/conn.rs
+++ b/http/src/conn.rs
@@ -28,12 +28,11 @@ use std::{
 /// Default Server header
 pub const SERVER: &str = concat!("trillium/", env!("CARGO_PKG_VERSION"));
 
-/** A http connection
-
-Unlike in other rust http implementations, this struct represents both
-the request and the response, and holds the transport over which the
-response will be sent.
-*/
+/// A http connection
+///
+/// Unlike in other rust http implementations, this struct represents both
+/// the request and the response, and holds the transport over which the
+/// response will be sent.
 pub struct Conn<Transport> {
     pub(crate) request_headers: Headers,
     pub(crate) response_headers: Headers,
@@ -270,20 +269,19 @@ where
         &self.response_headers
     }
 
-    /** sets the http status code from any `TryInto<Status>`.
-
-    ```
-    # use trillium_http::{Conn, Method, Status};
-    # let mut conn = Conn::new_synthetic(Method::Get, "/", ());
-    assert!(conn.status().is_none());
-
-    conn.set_status(200); // a status can be set as a u16
-    assert_eq!(conn.status().unwrap(), Status::Ok);
-
-    conn.set_status(Status::ImATeapot); // or as a Status
-    assert_eq!(conn.status().unwrap(), Status::ImATeapot);
-    ```
-    */
+    /// sets the http status code from any `TryInto<Status>`.
+    ///
+    /// ```
+    /// # use trillium_http::{Conn, Method, Status};
+    /// # let mut conn = Conn::new_synthetic(Method::Get, "/", ());
+    /// assert!(conn.status().is_none());
+    ///
+    /// conn.set_status(200); // a status can be set as a u16
+    /// assert_eq!(conn.status().unwrap(), Status::Ok);
+    ///
+    /// conn.set_status(Status::ImATeapot); // or as a Status
+    /// assert_eq!(conn.status().unwrap(), Status::ImATeapot);
+    /// ```
     pub fn set_status(&mut self, status: impl TryInto<Status>) {
         self.status = Some(status.try_into().unwrap_or_else(|_| {
             log::error!("attempted to set an invalid status code");
@@ -297,14 +295,12 @@ where
         self.status
     }
 
-    /**
-    retrieves the path part of the request url, up to and excluding any query component
-    ```
-    # use trillium_http::{Conn, Method};
-    let mut conn = Conn::new_synthetic(Method::Get, "/some/path?and&a=query", ());
-    assert_eq!(conn.path(), "/some/path");
-    ```
-    */
+    /// retrieves the path part of the request url, up to and excluding any query component
+    /// ```
+    /// # use trillium_http::{Conn, Method};
+    /// let mut conn = Conn::new_synthetic(Method::Get, "/some/path?and&a=query", ());
+    /// assert_eq!(conn.path(), "/some/path");
+    /// ```
     pub fn path(&self) -> &str {
         match self.path.split_once('?') {
             Some((path, _)) => path,
@@ -317,18 +313,15 @@ where
         &self.path
     }
 
-    /**
-    retrieves the query component of the path
-    ```
-    # use trillium_http::{Conn, Method};
-    let mut conn = Conn::new_synthetic(Method::Get, "/some/path?and&a=query", ());
-    assert_eq!(conn.querystring(), "and&a=query");
-
-    let mut conn = Conn::new_synthetic(Method::Get, "/some/path", ());
-    assert_eq!(conn.querystring(), "");
-
-    ```
-    */
+    /// retrieves the query component of the path
+    /// ```
+    /// # use trillium_http::{Conn, Method};
+    /// let mut conn = Conn::new_synthetic(Method::Get, "/some/path?and&a=query", ());
+    /// assert_eq!(conn.querystring(), "and&a=query");
+    ///
+    /// let mut conn = Conn::new_synthetic(Method::Get, "/some/path", ());
+    /// assert_eq!(conn.querystring(), "");
+    /// ```
     pub fn querystring(&self) -> &str {
         self.path
             .split_once('?')
@@ -361,17 +354,15 @@ where
     //     }
     // }
 
-    /**
-    Sets the response body to anything that is [`impl Into<Body>`][Body].
-
-    ```
-    # use trillium_http::{Conn, Method, Body};
-    # let mut conn = Conn::new_synthetic(Method::Get, "/some/path?and&a=query", ());
-    conn.set_response_body("hello");
-    conn.set_response_body(String::from("hello"));
-    conn.set_response_body(vec![99, 97, 116]);
-    ```
-    */
+    /// Sets the response body to anything that is [`impl Into<Body>`][Body].
+    ///
+    /// ```
+    /// # use trillium_http::{Conn, Method, Body};
+    /// # let mut conn = Conn::new_synthetic(Method::Get, "/some/path?and&a=query", ());
+    /// conn.set_response_body("hello");
+    /// conn.set_response_body(String::from("hello"));
+    /// conn.set_response_body(vec![99, 97, 116]);
+    /// ```
     pub fn set_response_body(&mut self, body: impl Into<Body>) {
         self.response_body = Some(body.into());
     }
@@ -381,46 +372,38 @@ where
         self.response_body.as_ref()
     }
 
-    /**
-    remove the response body from this conn and return it
-
-    ```
-    # use trillium_http::{Conn, Method};
-    # let mut conn = Conn::new_synthetic(Method::Get, "/some/path?and&a=query", ());
-    assert!(conn.response_body().is_none());
-    conn.set_response_body("hello");
-    assert!(conn.response_body().is_some());
-    let body = conn.take_response_body();
-    assert!(body.is_some());
-    assert!(conn.response_body().is_none());
-    ```
-    */
+    /// remove the response body from this conn and return it
+    ///
+    /// ```
+    /// # use trillium_http::{Conn, Method};
+    /// # let mut conn = Conn::new_synthetic(Method::Get, "/some/path?and&a=query", ());
+    /// assert!(conn.response_body().is_none());
+    /// conn.set_response_body("hello");
+    /// assert!(conn.response_body().is_some());
+    /// let body = conn.take_response_body();
+    /// assert!(body.is_some());
+    /// assert!(conn.response_body().is_none());
+    /// ```
     pub fn take_response_body(&mut self) -> Option<Body> {
         self.response_body.take()
     }
 
-    /**
-    returns the http method for this conn's request.
-    ```
-    # use trillium_http::{Conn, Method};
-    let mut conn = Conn::new_synthetic(Method::Get, "/some/path?and&a=query", ());
-    assert_eq!(conn.method(), Method::Get);
-    ```
-     */
+    /// returns the http method for this conn's request.
+    /// ```
+    /// # use trillium_http::{Conn, Method};
+    /// let mut conn = Conn::new_synthetic(Method::Get, "/some/path?and&a=query", ());
+    /// assert_eq!(conn.method(), Method::Get);
+    /// ```
     pub fn method(&self) -> Method {
         self.method
     }
 
-    /**
-    overrides the http method for this conn
-     */
+    /// overrides the http method for this conn
     pub fn set_method(&mut self, method: Method) {
         self.method = method;
     }
 
-    /**
-    returns the http version for this conn.
-    */
+    /// returns the http version for this conn.
     pub fn http_version(&self) -> Version {
         self.version
     }
@@ -520,52 +503,48 @@ where
         )
     }
 
-    /**
-    returns the [`encoding_rs::Encoding`] for this request, as
-    determined from the mime-type charset, if available
-
-    ```
-    # use trillium_http::{Conn, Method};
-    let mut conn = Conn::new_synthetic(Method::Get, "/", ());
-    assert_eq!(conn.request_encoding(), encoding_rs::WINDOWS_1252); // the default
-    conn.request_headers_mut().insert("content-type", "text/plain;charset=utf-16");
-    assert_eq!(conn.request_encoding(), encoding_rs::UTF_16LE);
-    ```
-    */
+    /// returns the [`encoding_rs::Encoding`] for this request, as
+    /// determined from the mime-type charset, if available
+    ///
+    /// ```
+    /// # use trillium_http::{Conn, Method};
+    /// let mut conn = Conn::new_synthetic(Method::Get, "/", ());
+    /// assert_eq!(conn.request_encoding(), encoding_rs::WINDOWS_1252); // the default
+    /// conn.request_headers_mut()
+    ///     .insert("content-type", "text/plain;charset=utf-16");
+    /// assert_eq!(conn.request_encoding(), encoding_rs::UTF_16LE);
+    /// ```
     pub fn request_encoding(&self) -> &'static Encoding {
         encoding(&self.request_headers)
     }
 
-    /**
-    returns the [`encoding_rs::Encoding`] for this response, as
-    determined from the mime-type charset, if available
-
-    ```
-    # use trillium_http::{Conn, Method};
-    let mut conn = Conn::new_synthetic(Method::Get, "/", ());
-    assert_eq!(conn.response_encoding(), encoding_rs::WINDOWS_1252); // the default
-    conn.response_headers_mut().insert("content-type", "text/plain;charset=utf-16");
-    assert_eq!(conn.response_encoding(), encoding_rs::UTF_16LE);
-    ```
-    */
+    /// returns the [`encoding_rs::Encoding`] for this response, as
+    /// determined from the mime-type charset, if available
+    ///
+    /// ```
+    /// # use trillium_http::{Conn, Method};
+    /// let mut conn = Conn::new_synthetic(Method::Get, "/", ());
+    /// assert_eq!(conn.response_encoding(), encoding_rs::WINDOWS_1252); // the default
+    /// conn.response_headers_mut()
+    ///     .insert("content-type", "text/plain;charset=utf-16");
+    /// assert_eq!(conn.response_encoding(), encoding_rs::UTF_16LE);
+    /// ```
     pub fn response_encoding(&self) -> &'static Encoding {
         encoding(&self.response_headers)
     }
 
-    /**
-    returns a [`ReceivedBody`] that references this conn. the conn
-    retains all data and holds the singular transport, but the
-    `ReceivedBody` provides an interface to read body content
-    ```
-    # async_io::block_on(async {
-    # use trillium_http::{Conn, Method};
-    let mut conn = Conn::new_synthetic(Method::Get, "/", "hello");
-    let request_body = conn.request_body().await;
-    assert_eq!(request_body.content_length(), Some(5));
-    assert_eq!(request_body.read_string().await.unwrap(), "hello");
-    # });
-    ```
-    */
+    /// returns a [`ReceivedBody`] that references this conn. the conn
+    /// retains all data and holds the singular transport, but the
+    /// `ReceivedBody` provides an interface to read body content
+    /// ```
+    /// # async_io::block_on(async {
+    /// # use trillium_http::{Conn, Method};
+    /// let mut conn = Conn::new_synthetic(Method::Get, "/", "hello");
+    /// let request_body = conn.request_body().await;
+    /// assert_eq!(request_body.content_length(), Some(5));
+    /// assert_eq!(request_body.read_string().await.unwrap(), "hello");
+    /// # });
+    /// ```
     pub async fn request_body(&mut self) -> ReceivedBody<'_, Transport> {
         if self.needs_100_continue() {
             self.send_100_continue().await.ok();
@@ -783,9 +762,7 @@ where
         self.secure = secure;
     }
 
-    /**
-    calculates any auto-generated headers for this conn prior to sending it
-    */
+    /// calculates any auto-generated headers for this conn prior to sending it
     pub fn finalize_headers(&mut self) {
         if self.status == Some(Status::SwitchingProtocols) {
             return;
@@ -814,16 +791,14 @@ where
         }
     }
 
-    /**
-    Registers a function to call after the http response has been
-    completely transferred. Please note that this is a sync function
-    and should be computationally lightweight. If your _application_
-    needs additional async processing, use your runtime's task spawn
-    within this hook.  If your _library_ needs additional async
-    processing in an `after_send` hook, please open an issue. This hook
-    is currently designed for simple instrumentation and logging, and
-    should be thought of as equivalent to a Drop hook.
-    */
+    /// Registers a function to call after the http response has been
+    /// completely transferred. Please note that this is a sync function
+    /// and should be computationally lightweight. If your _application_
+    /// needs additional async processing, use your runtime's task spawn
+    /// within this hook.  If your _library_ needs additional async
+    /// processing in an `after_send` hook, please open an issue. This hook
+    /// is currently designed for simple instrumentation and logging, and
+    /// should be thought of as equivalent to a Drop hook.
     pub fn after_send<F>(&mut self, after_send: F)
     where
         F: FnOnce(SendStatus) + Send + Sync + 'static,

--- a/http/src/headers.rs
+++ b/http/src/headers.rs
@@ -166,7 +166,7 @@ impl Headers {
     /// will be added to the existing ones. To replace any existing
     /// values, use [`Headers::insert`]
     ///
-    /// Identical to [`headers.entry(name).append(values)`][Entry::append]
+    /// Identical to [`headers.entry(name).append(values)`][crate::headers::Entry::append]
     pub fn append(
         &mut self,
         name: impl Into<HeaderName<'static>>,
@@ -226,7 +226,7 @@ impl Headers {
     /// Add a header value or header values into this header map if
     /// and only if there is not already a header with the same name.
     ///
-    /// Identical to [`headers.entry(name).or_insert(default)`][Entry::or_insert]
+    /// Identical to [`headers.entry(name).or_insert(default)`][crate::headers::Entry::or_insert]
     pub fn try_insert(
         &mut self,
         name: impl Into<HeaderName<'static>>,
@@ -237,7 +237,8 @@ impl Headers {
 
     /// if a key does not exist already, execute the provided function and insert a value
     ///
-    /// Identical to [`headers.entry(name).or_insert_with(values)`][Entry::or_insert_with]
+    /// Identical to
+    /// [`headers.entry(name).or_insert_with(values)`][crate::headers::Entry::or_insert_with]
     pub fn try_insert_with<V>(
         &mut self,
         name: impl Into<HeaderName<'static>>,

--- a/http/src/headers/known_header_name.rs
+++ b/http/src/headers/known_header_name.rs
@@ -65,24 +65,23 @@ macro_rules! known_headers {
     }
 }
 
-/* generated with
-
-console.log($$('main > article > div > dl > dt > a > code').map(code => {
-let lowered = code.innerText.toLowerCase();
-let enum_ = lowered.replace(/(?:-|^)([a-z])/g, (_, p1) => p1.toUpperCase());
-return`("${code.innerText}", ${enum_}, "${lowered}")`
-}).join(",\n"))
-
- on https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers
-
-
-per https://httpwg.org/specs/rfc9110.html#rfc.section.5.3,
-
-The order in which field lines with differing field names are received in a section is not
-significant. However, it is good practice to send header fields that contain additional control data
-first, such as Host on requests and Date on responses, so that implementations can decide when not
-to handle a message as early as possible.
-*/
+// generated with
+//
+// console.log($$('main > article > div > dl > dt > a > code').map(code => {
+// let lowered = code.innerText.toLowerCase();
+// let enum_ = lowered.replace(/(?:-|^)([a-z])/g, (_, p1) => p1.toUpperCase());
+// return`("${code.innerText}", ${enum_}, "${lowered}")`
+// }).join(",\n"))
+//
+// on https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers
+//
+//
+// per https://httpwg.org/specs/rfc9110.html#rfc.section.5.3,
+//
+// The order in which field lines with differing field names are received in a section is not
+// significant. However, it is good practice to send header fields that contain additional control
+// data first, such as Host on requests and Date on responses, so that implementations can decide
+// when not to handle a message as early as possible.
 known_headers! {
     ("Host", Host),
     ("Date", Date),

--- a/http/src/http_config.rs
+++ b/http/src/http_config.rs
@@ -12,114 +12,112 @@ pub const DEFAULT_CONFIG: HttpConfig = HttpConfig {
     received_body_max_preallocate: 1024 * 1024,
 };
 
-/**
-# Performance and security parameters for trillium-http.
-
-Trillium's http implementation is built with sensible defaults, but applications differ in usage and
-this escape hatch allows an application to be tuned. It is best to tune these parameters in context
-of realistic benchmarks for your application.
-
-Long term, trillium may export several standard defaults for different constraints and application
-types. In the distant future, these may turn into initial values and trillium will tune itself based
-on values seen at runtime.
-
-
-## Performance parameters
-
-### `response_buffer_len`
-
-The initial buffer allocated for the response. Ideally this would be exactly the length of the
-combined response headers and body, if the body is short. If the value is shorter than the headers
-plus the body, multiple transport writes will be performed, and if the value is longer, unnecessary
-memory will be allocated for each conn. Although a tcp packet can be up to 64kb, it is probably
-better to use a value less than 1.5kb.
-
-**Default**: `512`
-
-**Unit**: byte count
-
-### `request_buffer_initial_len`
-
-The initial buffer allocated for the request headers. Ideally this is the length of the request
-headers. It will grow nonlinearly until `max_head_len` or the end of the headers are reached,
-whichever happens first.
-
-**Default**: `128`
-
-**Unit**: byte count
-
-### `received_body_initial_len`
-
-The initial buffer capacity allocated when reading a chunked http body to bytes or string. Ideally
-this would be the size of the http body, which is highly application dependent. As with other
-initial buffer lengths, further allocation will be performed until the necessary length is
-achieved. A smaller number will result in more vec resizing, and a larger number will result in
-unnecessary allocation.
-
-**Default**: `128`
-
-**Unit**: byte count
-
-
-### `copy_loops_per_yield`
-
-A sort of cooperative task yielding knob. Decreasing this number will improve tail latencies at a
-slight cost to total throughput for fast clients. This will have more of an impact on servers that
-spend a lot of time in IO compared to app handlers.
-
-**Default**: `16`
-
-**Unit**: the number of consecutive `Poll::Ready` async writes to perform before yielding
-the task back to the runtime.
-
-### `response_header_initial_capacity`
-
-The number of response headers to allocate space for on conn creation. Headers will grow on
-insertion when they reach this size.
-
-**Default**: `16`
-
-**Unit**: Header count
-
-### `received_body_max_preallocate`
-
-When we receive a fixed-length (not chunked-encoding) body that is smaller than this size, we can
-allocate a buffer with exactly the right size before we receive the body. However, if this is
-unbounded, malicious clients can issue headers with large content-length and then keep the
-connection open without sending any bytes, allowing them to allocate memory faster than their
-bandwidth usage. This does not limit the ability to receive fixed-length bodies larger than this,
-but the memory allocation will grow as with chunked bodies. Note that this has no impact on chunked
-bodies. If this is set higher than the `received_body_max_len`, this parameter has no effect. This
-parameter only impacts [`ReceivedBody::read_string`] and [`ReceivedBody::read_bytes`].
-
-**Default**: `1mb` in bytes
-
-**Unit**: Byte count
-
-
-## Security parameters
-
-These parameters represent worst cases, to delineate between malicious (or malformed) requests and
-acceptable ones.
-
-### `head_max_len`
-
-The maximum length allowed before the http body begins for a given request.
-
-**Default**: `8kb` in bytes
-
-**Unit**: Byte count
-
-### `received_body_max_len`
-
-The maximum length of a received body. This applies to both chunked and fixed-length request bodies,
-and the correct value will be application dependent.
-
-**Default**: `500mb` in bytes
-
-**Unit**: Byte count
-
-*/
+/// # Performance and security parameters for trillium-http.
+///
+/// Trillium's http implementation is built with sensible defaults, but applications differ in usage
+/// and this escape hatch allows an application to be tuned. It is best to tune these parameters in
+/// context of realistic benchmarks for your application.
+///
+/// Long term, trillium may export several standard defaults for different constraints and
+/// application types. In the distant future, these may turn into initial values and trillium will
+/// tune itself based on values seen at runtime.
+///
+///
+/// ## Performance parameters
+///
+/// ### `response_buffer_len`
+///
+/// The initial buffer allocated for the response. Ideally this would be exactly the length of the
+/// combined response headers and body, if the body is short. If the value is shorter than the
+/// headers plus the body, multiple transport writes will be performed, and if the value is longer,
+/// unnecessary memory will be allocated for each conn. Although a tcp packet can be up to 64kb, it
+/// is probably better to use a value less than 1.5kb.
+///
+/// **Default**: `512`
+///
+/// **Unit**: byte count
+///
+/// ### `request_buffer_initial_len`
+///
+/// The initial buffer allocated for the request headers. Ideally this is the length of the request
+/// headers. It will grow nonlinearly until `max_head_len` or the end of the headers are reached,
+/// whichever happens first.
+///
+/// **Default**: `128`
+///
+/// **Unit**: byte count
+///
+/// ### `received_body_initial_len`
+///
+/// The initial buffer capacity allocated when reading a chunked http body to bytes or string.
+/// Ideally this would be the size of the http body, which is highly application dependent. As with
+/// other initial buffer lengths, further allocation will be performed until the necessary length is
+/// achieved. A smaller number will result in more vec resizing, and a larger number will result in
+/// unnecessary allocation.
+///
+/// **Default**: `128`
+///
+/// **Unit**: byte count
+///
+///
+/// ### `copy_loops_per_yield`
+///
+/// A sort of cooperative task yielding knob. Decreasing this number will improve tail latencies at
+/// a slight cost to total throughput for fast clients. This will have more of an impact on servers
+/// that spend a lot of time in IO compared to app handlers.
+///
+/// **Default**: `16`
+///
+/// **Unit**: the number of consecutive `Poll::Ready` async writes to perform before yielding
+/// the task back to the runtime.
+///
+/// ### `response_header_initial_capacity`
+///
+/// The number of response headers to allocate space for on conn creation. Headers will grow on
+/// insertion when they reach this size.
+///
+/// **Default**: `16`
+///
+/// **Unit**: Header count
+///
+/// ### `received_body_max_preallocate`
+///
+/// When we receive a fixed-length (not chunked-encoding) body that is smaller than this size, we
+/// can allocate a buffer with exactly the right size before we receive the body. However, if this
+/// is unbounded, malicious clients can issue headers with large content-length and then keep the
+/// connection open without sending any bytes, allowing them to allocate memory faster than their
+/// bandwidth usage. This does not limit the ability to receive fixed-length bodies larger than
+/// this, but the memory allocation will grow as with chunked bodies. Note that this has no impact
+/// on chunked bodies. If this is set higher than the `received_body_max_len`, this parameter has no
+/// effect. This parameter only impacts [`ReceivedBody::read_string`] and
+/// [`ReceivedBody::read_bytes`].
+///
+/// **Default**: `1mb` in bytes
+///
+/// **Unit**: Byte count
+///
+///
+/// ## Security parameters
+///
+/// These parameters represent worst cases, to delineate between malicious (or malformed) requests
+/// and acceptable ones.
+///
+/// ### `head_max_len`
+///
+/// The maximum length allowed before the http body begins for a given request.
+///
+/// **Default**: `8kb` in bytes
+///
+/// **Unit**: Byte count
+///
+/// ### `received_body_max_len`
+///
+/// The maximum length of a received body. This applies to both chunked and fixed-length request
+/// bodies, and the correct value will be application dependent.
+///
+/// **Default**: `500mb` in bytes
+///
+/// **Unit**: Byte count
 
 #[derive(Clone, Copy, Debug)]
 pub struct HttpConfig {

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -9,65 +9,73 @@
 )]
 #![warn(missing_docs, clippy::pedantic, clippy::perf, clippy::cargo)]
 #![allow(clippy::must_use_candidate, clippy::module_name_repetitions)]
-/*!
-This crate provides the http 1.x implementation for Trillium.
-
-## Stability
-
-As this is primarily intended for internal use by the [Trillium
-crate](https://docs.trillium.rs/trillium), the api is likely to be
-less stable than that of the higher level abstractions in Trillium.
-
-## Example
-
-This is an elaborate example that demonstrates some of `trillium_http`'s
-capabilities.  Please note that trillium itself provides a much more
-usable interface on top of `trillium_http`, at very little cost.
-
-```
-# fn main() -> trillium_http::Result<()> { smol::block_on(async {
-use async_net::{TcpListener, TcpStream};
-use futures_lite::StreamExt;
-use trillium_http::{Conn, Result, Swansong};
-
-let swansong = Swansong::new();
-let listener = TcpListener::bind(("localhost", 0)).await?;
-let port = listener.local_addr()?.port();
-
-let server_swansong = swansong.clone();
-let server_handle = smol::spawn(async move {
-    let mut incoming = server_swansong.interrupt(listener.incoming());
-
-    while let Some(Ok(stream)) = incoming.next().await {
-        let swansong = server_swansong.clone();
-        smol::spawn(Conn::map(stream, swansong, |mut conn: Conn<TcpStream>| async move {
-            conn.set_response_body("hello world");
-            conn.set_status(200);
-            conn
-         })).detach()
-    }
-
-    Result::Ok(())
-});
-
-// this example uses the trillium client
-// any other http client would work here too
-let url = format!("http://localhost:{}/", port);
-let client = trillium_client::Client::new(trillium_smol::ClientConfig::default());
-let mut client_conn = client.get(&*url).await?;
-
-assert_eq!(client_conn.status().unwrap(), 200);
-assert_eq!(client_conn.response_headers().get_str("content-length"), Some("11"));
-assert_eq!(
-    client_conn.response_body().read_string().await?,
-    "hello world"
-);
-
-swansong.shut_down(); // stop the server after one request
-server_handle.await?; // wait for the server to shut down
-# Result::Ok(()) }) }
-```
-*/
+//! This crate provides the http 1.x implementation for Trillium.
+//!
+//! ## Stability
+//!
+//! As this is primarily intended for internal use by the [Trillium
+//! crate](https://docs.trillium.rs/trillium), the api is likely to be
+//! less stable than that of the higher level abstractions in Trillium.
+//!
+//! ## Example
+//!
+//! This is an elaborate example that demonstrates some of `trillium_http`'s
+//! capabilities.  Please note that trillium itself provides a much more
+//! usable interface on top of `trillium_http`, at very little cost.
+//!
+//! ```
+//! # fn main() -> trillium_http::Result<()> { smol::block_on(async {
+//! use async_net::{TcpListener, TcpStream};
+//! use futures_lite::StreamExt;
+//! use trillium_http::{Conn, Result, Swansong};
+//!
+//! let swansong = Swansong::new();
+//! let listener = TcpListener::bind(("localhost", 0)).await?;
+//! let port = listener.local_addr()?.port();
+//!
+//! let server_swansong = swansong.clone();
+//! let server_handle = smol::spawn(async move {
+//!     let mut incoming = server_swansong.interrupt(listener.incoming());
+//!
+//!     while let Some(Ok(stream)) = incoming.next().await {
+//!         let swansong = server_swansong.clone();
+//!         smol::spawn(Conn::map(
+//!             stream,
+//!             swansong,
+//!             |mut conn: Conn<TcpStream>| async move {
+//!                 conn.set_response_body("hello world");
+//!                 conn.set_status(200);
+//!                 conn
+//!             },
+//!         ))
+//!         .detach()
+//!     }
+//!
+//!     Result::Ok(())
+//! });
+//!
+//! // this example uses the trillium client
+//! // any other http client would work here too
+//!
+//! let url = format!("http://localhost:{}/", port);
+//! let client = trillium_client::Client::new(trillium_smol::ClientConfig::default());
+//! let mut client_conn = client.get(&*url).await?;
+//!
+//! assert_eq!(client_conn.status().unwrap(), 200);
+//! assert_eq!(
+//!     client_conn.response_headers().get_str("content-length"),
+//!     Some("11")
+//! );
+//! assert_eq!(
+//!     client_conn.response_body().read_string().await?,
+//!     "hello world"
+//! );
+//!
+//! swansong.shut_down(); // stop the server after one request
+//! server_handle.await?; // wait for the server to shut down
+//! //
+//! # Result::Ok(()) }) }
+//! ```
 
 mod received_body;
 pub use received_body::ReceivedBody;

--- a/http/src/received_body.rs
+++ b/http/src/received_body.rs
@@ -14,35 +14,34 @@ use ReceivedBodyState::{Chunked, End, FixedLength, PartialChunkSize, Start};
 mod chunked;
 mod fixed_length;
 
-/** A received http body
-
-This type represents a body that will be read from the underlying
-transport, which it may either borrow from a [`Conn`](crate::Conn) or
-own.
-
-```rust
-# trillium_testing::block_on(async {
-# use trillium_http::{Method, Conn};
-let mut conn = Conn::new_synthetic(Method::Get, "/", "hello");
-let body = conn.request_body().await;
-assert_eq!(body.read_string().await?, "hello");
-# trillium_http::Result::Ok(()) }).unwrap();
-```
-
-## Bounds checking
-
-Every `ReceivedBody` has a maximum length beyond which it will return an error, expressed as a
-u64. To override this on the specific `ReceivedBody`, use [`ReceivedBody::with_max_len`] or
-[`ReceivedBody::set_max_len`]
-
-The default maximum length is currently set to 500mb. In the next semver-minor release, this value
-will decrease substantially.
-
-## Large chunks, small read buffers
-
-Attempting to read a chunked body with a buffer that is shorter than the chunk size in hex will
-result in an error. This limitation is temporary.
-*/
+/// A received http body
+///
+/// This type represents a body that will be read from the underlying
+/// transport, which it may either borrow from a [`Conn`](crate::Conn) or
+/// own.
+///
+/// ```rust
+/// # trillium_testing::block_on(async {
+/// # use trillium_http::{Method, Conn};
+/// let mut conn = Conn::new_synthetic(Method::Get, "/", "hello");
+/// let body = conn.request_body().await;
+/// assert_eq!(body.read_string().await?, "hello");
+/// # trillium_http::Result::Ok(()) }).unwrap();
+/// ```
+///
+/// ## Bounds checking
+///
+/// Every `ReceivedBody` has a maximum length beyond which it will return an error, expressed as a
+/// u64. To override this on the specific `ReceivedBody`, use [`ReceivedBody::with_max_len`] or
+/// [`ReceivedBody::set_max_len`]
+///
+/// The default maximum length is currently set to 500mb. In the next semver-minor release, this
+/// value will decrease substantially.
+///
+/// ## Large chunks, small read buffers
+///
+/// Attempting to read a chunked body with a buffer that is shorter than the chunk size in hex will
+/// result in an error. This limitation is temporary.
 
 pub struct ReceivedBody<'conn, Transport> {
     content_length: Option<u64>,
@@ -112,21 +111,19 @@ where
         }
     }
 
-    /**
-    Returns the content-length of this body, if available. This
-    usually is derived from the content-length header. If the http
-    request or response that this body is attached to uses
-    transfer-encoding chunked, this will be None.
-
-    ```rust
-    # trillium_testing::block_on(async {
-    # use trillium_http::{Method, Conn};
-    let mut conn = Conn::new_synthetic(Method::Get, "/", "hello");
-    let body = conn.request_body().await;
-    assert_eq!(body.content_length(), Some(5));
-    # trillium_http::Result::Ok(()) }).unwrap();
-    ```
-    */
+    /// Returns the content-length of this body, if available. This
+    /// usually is derived from the content-length header. If the http
+    /// request or response that this body is attached to uses
+    /// transfer-encoding chunked, this will be None.
+    ///
+    /// ```rust
+    /// # trillium_testing::block_on(async {
+    /// # use trillium_http::{Method, Conn};
+    /// let mut conn = Conn::new_synthetic(Method::Get, "/", "hello");
+    /// let body = conn.request_body().await;
+    /// assert_eq!(body.content_length(), Some(5));
+    /// # trillium_http::Result::Ok(()) }).unwrap();
+    /// ```
     pub fn content_length(&self) -> Option<u64> {
         self.content_length
     }
@@ -209,10 +206,8 @@ where
         Ok(vec)
     }
 
-    /**
-    returns the character encoding of this body, usually determined from the content type
-    (mime-type) of the associated Conn.
-    */
+    /// returns the character encoding of this body, usually determined from the content type
+    /// (mime-type) of the associated Conn.
     pub fn encoding(&self) -> &'static Encoding {
         self.encoding
     }
@@ -225,16 +220,14 @@ where
         }
     }
 
-    /**
-    Consumes the remainder of this body from the underlying transport by reading it to the end and
-    discarding the contents. This is important for http1.1 keepalive, but most of the time you do
-    not need to directly call this. It returns the number of bytes consumed.
-
-    # Errors
-
-    This will return an [`std::io::Result::Err`] if there is an io error on the underlying
-    transport, such as a disconnect
-    */
+    /// Consumes the remainder of this body from the underlying transport by reading it to the end
+    /// and discarding the contents. This is important for http1.1 keepalive, but most of the
+    /// time you do not need to directly call this. It returns the number of bytes consumed.
+    ///
+    /// # Errors
+    ///
+    /// This will return an [`std::io::Result::Err`] if there is an io error on the underlying
+    /// transport, such as a disconnect
     #[allow(clippy::missing_errors_doc)] // false positive
     pub async fn drain(self) -> io::Result<u64> {
         let copy_loops_per_yield = self.copy_loops_per_yield;

--- a/http/src/status.rs
+++ b/http/src/status.rs
@@ -278,7 +278,6 @@ pub enum Status {
     /// This response code means the expectation indicated by the Expect request
     /// header field can't be met by the server.
     ExpectationFailed = 417,
-    ///
     /// 418 I'm a teapot
     ///
     /// The server refuses the attempt to brew coffee with a teapot.

--- a/http/src/synthetic.rs
+++ b/http/src/synthetic.rs
@@ -9,13 +9,11 @@ use std::{
     time::Instant,
 };
 
-/**
-Synthetic represents a simple transport that contains fixed
-content. This is exclusively useful for testing or for server
-implementations that are not read from an io connection, such as a
-faas function, in which the entire body may be available immediately
-on invocation.
-*/
+/// Synthetic represents a simple transport that contains fixed
+/// content. This is exclusively useful for testing or for server
+/// implementations that are not read from an io connection, such as a
+/// faas function, in which the entire body may be available immediately
+/// on invocation.
 #[derive(Debug)]
 pub struct Synthetic {
     data: Cursor<Vec<u8>>,
@@ -119,15 +117,13 @@ impl From<Option<Vec<u8>>> for Synthetic {
 }
 
 impl Conn<Synthetic> {
-    /**
-    Construct a new synthetic conn with provided method, path, and body.
-    ```rust
-    # use trillium_http::{Method, Conn};
-    let conn = Conn::new_synthetic(Method::Get, "/", "hello");
-    assert_eq!(conn.method(), Method::Get);
-    assert_eq!(conn.path(), "/");
-    ```
-    */
+    /// Construct a new synthetic conn with provided method, path, and body.
+    /// ```rust
+    /// # use trillium_http::{Method, Conn};
+    /// let conn = Conn::new_synthetic(Method::Get, "/", "hello");
+    /// assert_eq!(conn.method(), Method::Get);
+    /// assert_eq!(conn.path(), "/");
+    /// ```
     pub fn new_synthetic(
         method: Method,
         path: impl Into<String>,
@@ -164,9 +160,7 @@ impl Conn<Synthetic> {
         self.transport.close();
     }
 
-    /**
-    Replaces the synthetic body. This is intended for testing use.
-     */
+    /// Replaces the synthetic body. This is intended for testing use.
     pub fn replace_body(&mut self, body: impl Into<Synthetic>) {
         let transport = body.into();
         self.request_headers_mut()

--- a/http/src/transport/boxed_transport.rs
+++ b/http/src/transport/boxed_transport.rs
@@ -13,7 +13,6 @@ use trillium_macros::{AsyncRead, AsyncWrite};
 #[doc(hidden)]
 pub(crate) trait AnyTransport: Transport + Any {
     fn as_box_any(self: Box<Self>) -> Box<dyn Any>;
-    //    fn as_box_transport(self: Box<Self>) -> Box<dyn Transport>;
     fn as_any(&self) -> &dyn Any;
     fn as_mut_any(&mut self) -> &mut dyn Any;
     fn as_transport(&self) -> &dyn Transport;
@@ -23,9 +22,6 @@ impl<T: Transport + Any> AnyTransport for T {
         self
     }
 
-    // fn as_box_transport(self: Box<Self>) -> Box<dyn Transport> {
-    //     self
-    // }
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -39,18 +35,16 @@ impl<T: Transport + Any> AnyTransport for T {
     }
 }
 
-/**
-# A type for dyn [`Transport`][crate::transport::Transport] trait objects
-
-`BoxedTransport` represents a `Box<dyn Transport + Any>` that supports
-downcasting to the original Transport. This is used in trillium to
-erase the generic on Conn, in order to avoid writing `Conn<TcpStream>`
-throughout an application.
-
-**Stability Note:** This may go away at some point and be
-replaced by a type alias exported from a
-`trillium_server_common::Server` crate.
-*/
+/// # A type for dyn [`Transport`][crate::transport::Transport] trait objects
+///
+/// `BoxedTransport` represents a `Box<dyn Transport + Any>` that supports
+/// downcasting to the original Transport. This is used in trillium to
+/// erase the generic on Conn, in order to avoid writing `Conn<TcpStream>`
+/// throughout an application.
+///
+/// **Stability Note:** This may go away at some point and be
+/// replaced by a type alias exported from a
+/// `trillium_server_common::Server` crate.
 #[derive(Debug, AsyncRead, AsyncWrite)]
 pub struct BoxedTransport(Box<dyn AnyTransport>);
 
@@ -61,56 +55,48 @@ impl Debug for Box<dyn AnyTransport> {
 }
 
 impl BoxedTransport {
-    /**
-    Create a new `BoxedTransport` from some Transport.
-
-    ```
-    use trillium_http::transport::BoxedTransport;
-    use trillium_testing::TestTransport;
-    // this examples uses trillium_testing::TestTransport as an
-    // easily-constructed AsyncRead+AsyncWrite.
-    let (test_transport, _) = TestTransport::new();
-
-    let boxed = BoxedTransport::new(test_transport);
-
-    let downcast: Option<Box<TestTransport>> = boxed.downcast();
-    assert!(downcast.is_some());
-
-    let boxed_again = BoxedTransport::new(*downcast.unwrap());
-    assert!(boxed_again.downcast::<async_net::TcpStream>().is_none());
-    ```
-    */
+    /// Create a new `BoxedTransport` from some Transport.
+    ///
+    /// ```
+    /// use trillium_http::transport::BoxedTransport;
+    /// use trillium_testing::TestTransport;
+    /// // this examples uses trillium_testing::TestTransport as an
+    /// // easily-constructed AsyncRead+AsyncWrite.
+    /// let (test_transport, _) = TestTransport::new();
+    ///
+    /// let boxed = BoxedTransport::new(test_transport);
+    ///
+    /// let downcast: Option<Box<TestTransport>> = boxed.downcast();
+    /// assert!(downcast.is_some());
+    ///
+    /// let boxed_again = BoxedTransport::new(*downcast.unwrap());
+    /// assert!(boxed_again.downcast::<async_net::TcpStream>().is_none());
+    /// ```
 
     pub fn new<T: Transport + Any>(t: T) -> Self {
         Self(Box::new(t))
     }
 
-    /**
-    Attempt to convert the trait object into a specific transport
-    T. This will only succeed if T is the type that was originally
-    passed to [`BoxedTransport::new`], and will return None otherwise
-
-    see [`BoxedTransport::new`] for example usage
-    */
+    /// Attempt to convert the trait object into a specific transport
+    /// T. This will only succeed if T is the type that was originally
+    /// passed to [`BoxedTransport::new`], and will return None otherwise
+    ///
+    /// see [`BoxedTransport::new`] for example usage
     #[must_use = "downcasting takes the inner transport, so you should use it"]
     pub fn downcast<T: 'static>(self) -> Option<Box<T>> {
         self.0.as_box_any().downcast().ok()
     }
 
-    /**
-    Attempt to get a reference to the trait object as a specific transport type T. This will only
-    succeed if T is the type that was originally passed to [`BoxedTransport::new`], and will return
-    None otherwise
-    */
+    /// Attempt to get a reference to the trait object as a specific transport type T. This will
+    /// only succeed if T is the type that was originally passed to [`BoxedTransport::new`], and
+    /// will return None otherwise
     pub fn downcast_ref<T: Transport>(&self) -> Option<&T> {
         self.0.as_any().downcast_ref()
     }
 
-    /**
-    Attempt to get a mutable reference to the trait object as a specific transport type T. This
-    will only succeed if T is the type that was originally passed to [`BoxedTransport::new`], and
-    will return None otherwise
-    */
+    /// Attempt to get a mutable reference to the trait object as a specific transport type T. This
+    /// will only succeed if T is the type that was originally passed to [`BoxedTransport::new`],
+    /// and will return None otherwise
     pub fn downcast_mut<T: Transport>(&mut self) -> Option<&mut T> {
         self.0.as_mut_any().downcast_mut()
     }

--- a/http/src/transport/mod.rs
+++ b/http/src/transport/mod.rs
@@ -3,23 +3,21 @@ pub use boxed_transport::BoxedTransport;
 use futures_lite::{AsyncRead, AsyncWrite};
 use std::{any::Any, io::Result, net::SocketAddr, time::Duration};
 
-/**
-# The interface that the http protocol is communicated over.
-
-This trait supports several common interfaces supported by tcp
-streams, but also can be implemented for other stream types. All trait
-functions are currently optional.
-
-**Note:** `Transport` is currently designed around
-[`AsyncWrite`](https://docs.rs/futures/0.3.15/futures/io/trait.AsyncWrite.html)
-and
-[`AsyncRead`](https://docs.rs/futures/0.3.15/futures/io/trait.AsyncRead.html)
-from the futures crate, which are different from the tokio
-[`AsyncRead`](https://docs.rs/tokio/1.6.0/tokio/io/trait.AsyncRead.html) and
-[`AsyncWrite`](https://docs.rs/tokio/1.6.0/tokio/io/trait.AsyncWrite.html) traits.
-Hopefully this is a temporary
-situation.
-*/
+/// # The interface that the http protocol is communicated over.
+///
+/// This trait supports several common interfaces supported by tcp
+/// streams, but also can be implemented for other stream types. All trait
+/// functions are currently optional.
+///
+/// **Note:** `Transport` is currently designed around
+/// [`AsyncWrite`](https://docs.rs/futures/0.3.15/futures/io/trait.AsyncWrite.html)
+/// and
+/// [`AsyncRead`](https://docs.rs/futures/0.3.15/futures/io/trait.AsyncRead.html)
+/// from the futures crate, which are different from the tokio
+/// [`AsyncRead`](https://docs.rs/tokio/1.6.0/tokio/io/trait.AsyncRead.html) and
+/// [`AsyncWrite`](https://docs.rs/tokio/1.6.0/tokio/io/trait.AsyncWrite.html) traits.
+/// Hopefully this is a temporary
+/// situation.
 #[allow(unused)]
 pub trait Transport: Any + AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static {
     /// # Sets the linger duration of this transport by setting the `SO_LINGER` option

--- a/http/src/upgrade.rs
+++ b/http/src/upgrade.rs
@@ -10,17 +10,15 @@ use std::{
 };
 use trillium_macros::AsyncWrite;
 
-/**
-This open (pub fields) struct represents a http upgrade. It contains
-all of the data available on a Conn, as well as owning the underlying
-transport.
-
-Important implementation note: When reading directly from the
-transport, ensure that you read from `buffer` first if there are bytes
-in it. Alternatively, read directly from the Upgrade, as that
-[`AsyncRead`] implementation will drain the buffer first before
-reading from the transport.
-*/
+/// This open (pub fields) struct represents a http upgrade. It contains
+/// all of the data available on a Conn, as well as owning the underlying
+/// transport.
+///
+/// Important implementation note: When reading directly from the
+/// transport, ensure that you read from `buffer` first if there are bytes
+/// in it. Alternatively, read directly from the Upgrade, as that
+/// [`AsyncRead`] implementation will drain the buffer first before
+/// reading from the transport.
 #[derive(AsyncWrite)]
 #[non_exhaustive]
 pub struct Upgrade<Transport> {

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -6,29 +6,23 @@
     unused_qualifications
 )]
 
-/*!
-Welcome to the trillium logger!
-*/
+//! Welcome to the trillium logger!
 pub use crate::formatters::{apache_combined, apache_common, dev_formatter};
 use std::{fmt::Display, io::IsTerminal, sync::Arc};
 use trillium::{Conn, Handler, Info};
-/**
-Components with which common log formats can be constructed
-*/
+/// Components with which common log formats can be constructed
 pub mod formatters;
 
-/**
-A configuration option that determines if format will be colorful.
-
-The default is [`ColorMode::Auto`], which only enables color if stdout
-is detected to be a shell terminal (tty). If this detection is
-incorrect, you can explicitly set it to [`ColorMode::On`] or
-[`ColorMode::Off`]
-
-**Note**: The actual colorization of output is determined by the log
-formatters, so it is possible for this to be correctly enabled but for
-the output to have no colored components.
-*/
+/// A configuration option that determines if format will be colorful.
+///
+/// The default is [`ColorMode::Auto`], which only enables color if stdout
+/// is detected to be a shell terminal (tty). If this detection is
+/// incorrect, you can explicitly set it to [`ColorMode::On`] or
+/// [`ColorMode::Off`]
+///
+/// **Note**: The actual colorization of output is determined by the log
+/// formatters, so it is possible for this to be correctly enabled but for
+/// the output to have no colored components.
 
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
@@ -37,7 +31,7 @@ pub enum ColorMode {
     Auto,
     /// always enable colorful output
     On,
-    /// alwasy disable colorful output
+    /// always disable colorful output
     Off,
 }
 
@@ -57,23 +51,17 @@ impl Default for ColorMode {
     }
 }
 
-/**
-Specifies where the logger output should be sent
-
-The default is [`Target::Stdout`].
-*/
+/// Specifies where the logger output should be sent
+///
+/// The default is [`Target::Stdout`].
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 pub enum Target {
-    /**
-    Send trillium logger output to a log crate backend. See
-    [`log`] for output options
-    */
+    /// Send trillium logger output to a log crate backend. See
+    /// [`log`] for output options
     Logger(log::Level),
 
-    /**
-    Send trillium logger output to stdout
-    */
+    /// Send trillium logger output to stdout
     Stdout,
 }
 
@@ -113,81 +101,72 @@ impl Default for Target {
     }
 }
 
-/**
-The interface to format a &[`Conn`] as a [`Display`]-able output
-
-In general, the included loggers provide a mechanism for composing
-these, so top level formats like [`dev_formatter`], [`apache_common`]
-and [`apache_combined`] are composed in terms of component formatters
-like [`formatters::method`], [`formatters::ip`],
-[`formatters::timestamp`], and many others (see [`formatters`] for a
-full list)
-
-When implementing this trait, note that [`Display::fmt`] is called on
-[`LogFormatter::Output`] _after_ the response has been fully sent, but
-that the [`LogFormatter::format`] is called _before_ the response has
-been sent. If you need to perform timing-sensitive calculations that
-represent the full http cycle, move whatever data is needed to make
-the calculation into a new type that implements Display, ensuring that
-it is calculated at the right time.
-
-
-## Implementations
-
-### Tuples
-
-LogFormatter is implemented for all tuples of other LogFormatter
-types, from 2-26 formatters long. The output of these formatters is
-concatenated with no space between.
-
-### `&'static str`
-
-LogFormatter is implemented for &'static str, allowing for
-interspersing spaces and other static formatting details into tuples.
-
-```rust
-use trillium_logger::{Logger, formatters};
-let handler = Logger::new()
-    .with_formatter(("-> ", formatters::method, " ", formatters::url));
-```
-
-### `Fn(&Conn, bool) -> impl Display`
-
-LogFormatter is implemented for all functions that conform to this signature.
-
-```rust
-# use trillium_logger::{Logger, dev_formatter};
-# use trillium::Conn;
-# use std::borrow::Cow;
-# struct User(String); impl User { fn name(&self) -> &str { &self.0 } }
-fn user(conn: &Conn, color: bool) -> Cow<'static, str> {
-     match conn.state::<User>() {
-        Some(user) => String::from(user.name()).into(),
-        None => "guest".into()
-    }
-}
-
-let handler = Logger::new().with_formatter((dev_formatter, " ", user));
-```
-*/
+/// The interface to format a &[`Conn`] as a [`Display`]-able output
+///
+/// In general, the included loggers provide a mechanism for composing
+/// these, so top level formats like [`dev_formatter`], [`apache_common`]
+/// and [`apache_combined`] are composed in terms of component formatters
+/// like [`formatters::method`], [`formatters::ip`],
+/// [`formatters::timestamp`], and many others (see [`formatters`] for a
+/// full list)
+///
+/// When implementing this trait, note that [`Display::fmt`] is called on
+/// [`LogFormatter::Output`] _after_ the response has been fully sent, but
+/// that the [`LogFormatter::format`] is called _before_ the response has
+/// been sent. If you need to perform timing-sensitive calculations that
+/// represent the full http cycle, move whatever data is needed to make
+/// the calculation into a new type that implements Display, ensuring that
+/// it is calculated at the right time.
+///
+///
+/// ## Implementations
+///
+/// ### Tuples
+///
+/// LogFormatter is implemented for all tuples of other LogFormatter
+/// types, from 2-26 formatters long. The output of these formatters is
+/// concatenated with no space between.
+///
+/// ### `&'static str`
+///
+/// LogFormatter is implemented for &'static str, allowing for
+/// interspersing spaces and other static formatting details into tuples.
+///
+/// ```rust
+/// use trillium_logger::{formatters, Logger};
+/// let handler = Logger::new().with_formatter(("-> ", formatters::method, " ", formatters::url));
+/// ```
+///
+/// ### `Fn(&Conn, bool) -> impl Display`
+///
+/// LogFormatter is implemented for all functions that conform to this signature.
+///
+/// ```rust
+/// # use trillium_logger::{Logger, dev_formatter};
+/// # use trillium::Conn;
+/// # use std::borrow::Cow;
+/// # struct User(String); impl User { fn name(&self) -> &str { &self.0 } }
+/// fn user(conn: &Conn, color: bool) -> Cow<'static, str> {
+///     match conn.state::<User>() {
+///         Some(user) => String::from(user.name()).into(),
+///         None => "guest".into(),
+///     }
+/// }
+///
+/// let handler = Logger::new().with_formatter((dev_formatter, " ", user));
+/// ```
 pub trait LogFormatter: Send + Sync + 'static {
-    /**
-    The display type for this formatter
-
-    For a simple formatter, this will likely be a String, or even
-    better, a lightweight type that implements Display.
-    */
+    /// The display type for this formatter
+    ///
+    /// For a simple formatter, this will likely be a String, or even
+    /// better, a lightweight type that implements Display.
     type Output: Display + Send + Sync + 'static;
 
-    /**
-    Extract Output from this Conn
-     */
+    /// Extract Output from this Conn
     fn format(&self, conn: &Conn, color: bool) -> Self::Output;
 }
 
-/**
-The trillium handler for this crate, and the core type
-*/
+/// The trillium handler for this crate, and the core type
 pub struct Logger<F> {
     format: F,
     color_mode: ColorMode,
@@ -195,15 +174,13 @@ pub struct Logger<F> {
 }
 
 impl Logger<()> {
-    /**
-    Builds a new logger
-
-    Defaults:
-
-    * formatter: [`dev_formatter`]
-    * color mode: [`ColorMode::Auto`]
-    * target: [`Target::Stdout`]
-    */
+    /// Builds a new logger
+    ///
+    /// Defaults:
+    ///
+    /// * formatter: [`dev_formatter`]
+    /// * color mode: [`ColorMode::Auto`]
+    /// * target: [`Target::Stdout`]
     pub fn new() -> Logger<impl LogFormatter> {
         Logger {
             format: dev_formatter,
@@ -214,17 +191,15 @@ impl Logger<()> {
 }
 
 impl<T> Logger<T> {
-    /**
-    replace the formatter with any type that implements [`LogFormatter`]
-
-    see the trait documentation for [`LogFormatter`] for more details. note that this can be chained
-    with [`Logger::with_target`] and [`Logger::with_color_mode`]
-
-    ```
-    use trillium_logger::{Logger, apache_common};
-    Logger::new().with_formatter(apache_common("-", "-"));
-    ```
-    */
+    /// replace the formatter with any type that implements [`LogFormatter`]
+    ///
+    /// see the trait documentation for [`LogFormatter`] for more details. note that this can be
+    /// chained with [`Logger::with_target`] and [`Logger::with_color_mode`]
+    ///
+    /// ```
+    /// use trillium_logger::{apache_common, Logger};
+    /// Logger::new().with_formatter(apache_common("-", "-"));
+    /// ```
     pub fn with_formatter<Formatter: LogFormatter>(
         self,
         formatter: Formatter,
@@ -238,32 +213,28 @@ impl<T> Logger<T> {
 }
 
 impl<F: LogFormatter> Logger<F> {
-    /**
-    specify the color mode for this logger.
-
-    see [`ColorMode`] for more details. note that this can be chained
-    with [`Logger::with_target`] and [`Logger::with_formatter`]
-    ```
-    use trillium_logger::{Logger, ColorMode};
-    Logger::new().with_color_mode(ColorMode::On);
-    ```
-    */
+    /// specify the color mode for this logger.
+    ///
+    /// see [`ColorMode`] for more details. note that this can be chained
+    /// with [`Logger::with_target`] and [`Logger::with_formatter`]
+    /// ```
+    /// use trillium_logger::{ColorMode, Logger};
+    /// Logger::new().with_color_mode(ColorMode::On);
+    /// ```
     pub fn with_color_mode(mut self, color_mode: ColorMode) -> Self {
         self.color_mode = color_mode;
         self
     }
 
-    /**
-    specify the logger target
-
-    see [`Target`] for more details. note that this can be chained
-    with [`Logger::with_color_mode`] and [`Logger::with_formatter`]
-
-    ```
-    use trillium_logger::{Logger, Target};
-    Logger::new().with_target(Target::Logger(log::Level::Info));
-    ```
-    */
+    /// specify the logger target
+    ///
+    /// see [`Target`] for more details. note that this can be chained
+    /// with [`Logger::with_color_mode`] and [`Logger::with_formatter`]
+    ///
+    /// ```
+    /// use trillium_logger::{Logger, Target};
+    /// Logger::new().with_target(Target::Logger(log::Level::Info));
+    /// ```
     pub fn with_target(mut self, target: impl Targetable) -> Self {
         self.target = Arc::new(target);
         self

--- a/method-override/src/lib.rs
+++ b/method-override/src/lib.rs
@@ -1,21 +1,19 @@
-/*!
-# Trillium method override handler
-
-This allows http clients that are unable to generate http methods
-other than `GET` and `POST` to use `POST` requests that are
-interpreted as other methods such as `PUT`, `PATCH`, or `DELETE`.
-
-This is currently supported with a querystring parameter of
-`_method`. To change the querystring parameter's name, use
-[`MethodOverride::with_param_name`]
-
-By default, the only methods allowed are `PUT`, `PATCH`, and
-`DELETE`. To override this, use
-[`MethodOverride::with_allowed_methods`]
-
-Subsequent handlers see the requested method on the conn instead of
-POST.
-*/
+//! # Trillium method override handler
+//!
+//! This allows http clients that are unable to generate http methods
+//! other than `GET` and `POST` to use `POST` requests that are
+//! interpreted as other methods such as `PUT`, `PATCH`, or `DELETE`.
+//!
+//! This is currently supported with a querystring parameter of
+//! `_method`. To change the querystring parameter's name, use
+//! [`MethodOverride::with_param_name`]
+//!
+//! By default, the only methods allowed are `PUT`, `PATCH`, and
+//! `DELETE`. To override this, use
+//! [`MethodOverride::with_allowed_methods`]
+//!
+//! Subsequent handlers see the requested method on the conn instead of
+//! POST.
 #![forbid(unsafe_code)]
 #![deny(
     missing_copy_implementations,
@@ -30,11 +28,9 @@ use querystrong::QueryStrong;
 use std::{collections::HashSet, fmt::Debug};
 use trillium::{conn_unwrap, Conn, Handler, Method};
 
-/**
-Trillium method override handler
-
-See crate-level docs for an explanation
-*/
+/// Trillium method override handler
+///
+/// See crate-level docs for an explanation
 #[derive(Clone, Debug)]
 pub struct MethodOverride {
     param: &'static str,
@@ -56,16 +52,14 @@ impl MethodOverride {
         Self::default()
     }
 
-    /**
-    replace the default allowed methods with the provided list of methods
-
-    default: `put`, `patch`, `delete`
-
-    ```
-    # use trillium_method_override::MethodOverride;
-    let handler = MethodOverride::new().with_allowed_methods(["put", "patch"]);
-    ```
-    */
+    /// replace the default allowed methods with the provided list of methods
+    ///
+    /// default: `put`, `patch`, `delete`
+    ///
+    /// ```
+    /// # use trillium_method_override::MethodOverride;
+    /// let handler = MethodOverride::new().with_allowed_methods(["put", "patch"]);
+    /// ```
     pub fn with_allowed_methods<M>(mut self, methods: impl IntoIterator<Item = M>) -> Self
     where
         M: TryInto<Method>,
@@ -75,15 +69,13 @@ impl MethodOverride {
         self
     }
 
-    /**
-    replace the default param name with the provided param name
-
-    default: `_method`
-    ```
-    # use trillium_method_override::MethodOverride;
-    let handler = MethodOverride::new().with_param_name("_http_method");
-    ```
-    */
+    /// replace the default param name with the provided param name
+    ///
+    /// default: `_method`
+    /// ```
+    /// # use trillium_method_override::MethodOverride;
+    /// let handler = MethodOverride::new().with_param_name("_http_method");
+    /// ```
 
     pub fn with_param_name(mut self, param_name: &'static str) -> Self {
         self.param = param_name;

--- a/native-tls/src/client.rs
+++ b/native-tls/src/client.rs
@@ -9,20 +9,16 @@ use std::{
 };
 use trillium_server_common::{AsyncRead, AsyncWrite, Connector, Transport, Url};
 
-/**
-Configuration for the native tls client connector
-*/
+/// Configuration for the native tls client connector
 #[derive(Clone)]
 pub struct NativeTlsConfig<Config> {
     /// configuration for the inner Connector (usually tcp)
     pub tcp_config: Config,
 
-    /**
-    native tls configuration
-
-    Although async_native_tls calls this
-    a TlsConnector, it's actually a builder ¯\_(ツ)_/¯
-    */
+    /// native tls configuration
+    ///
+    /// Although async_native_tls calls this
+    /// a TlsConnector, it's actually a builder ¯\_(ツ)_/¯
     pub tls_connector: Arc<TlsConnector>,
 }
 
@@ -104,12 +100,10 @@ impl<T: Connector> Connector for NativeTlsConfig<T> {
     }
 }
 
-/**
-Client [`Transport`] for the native tls connector
-
-This may represent either an encrypted tls connection or a plaintext
-connection
-*/
+/// Client [`Transport`] for the native tls connector
+///
+/// This may represent either an encrypted tls connection or a plaintext
+/// connection
 
 #[derive(Debug)]
 pub struct NativeTlsClientTransport<T>(NativeTlsClientTransportInner<T>);

--- a/native-tls/src/lib.rs
+++ b/native-tls/src/lib.rs
@@ -9,10 +9,8 @@
     unused_qualifications
 )]
 
-/*!
-This crate provides native tls trait implementations for trillium
-client ([`NativeTlsConnector`]) and server ([`NativeTlsAcceptor`]).
-*/
+//! This crate provides native tls trait implementations for trillium
+//! client ([`NativeTlsConnector`]) and server ([`NativeTlsAcceptor`]).
 
 pub use async_native_tls;
 pub use native_tls::{self, Identity};

--- a/native-tls/src/server.rs
+++ b/native-tls/src/server.rs
@@ -8,36 +8,28 @@ use std::{
 };
 use trillium_server_common::{Acceptor, AsyncRead, AsyncWrite, Transport};
 
-/**
-trillium [`Acceptor`] for native-tls
-*/
+/// trillium [`Acceptor`] for native-tls
 
 #[derive(Clone, Debug)]
 pub struct NativeTlsAcceptor(TlsAcceptor);
 
 impl NativeTlsAcceptor {
-    /**
-    constructs a NativeTlsAcceptor from a [`native_tls::TlsAcceptor`],
-    an [`async_native_tls::TlsAcceptor`], or an [`Identity`]
-    */
+    /// constructs a NativeTlsAcceptor from a [`native_tls::TlsAcceptor`],
+    /// an [`async_native_tls::TlsAcceptor`], or an [`Identity`]
     pub fn new(t: impl Into<Self>) -> Self {
         t.into()
     }
 
-    /**
-    constructs a NativeTlsAcceptor from a pkcs12 key and password. See
-    See [`Identity::from_pkcs8`]
-    */
+    /// constructs a NativeTlsAcceptor from a pkcs12 key and password. See
+    /// See [`Identity::from_pkcs8`]
     pub fn from_pkcs12(der: &[u8], password: &str) -> Self {
         Identity::from_pkcs12(der, password)
             .expect("could not build Identity from provided pkcs12 key and password")
             .into()
     }
 
-    /**
-    constructs a NativeTlsAcceptor from a pkcs8 pem and private
-    key. See [`Identity::from_pkcs8`]
-    */
+    /// constructs a NativeTlsAcceptor from a pkcs8 pem and private
+    /// key. See [`Identity::from_pkcs8`]
     pub fn from_pkcs8(pem: &[u8], key: &[u8]) -> Self {
         Identity::from_pkcs8(pem, key)
             .expect("could not build Identity from provided pem and key")

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -9,10 +9,7 @@
     unused_qualifications
 )]
 
-/*!
-http reverse and forward proxy trillium handler
-
-*/
+//! http reverse and forward proxy trillium handler
 
 mod body_streamer;
 mod forward_proxy_connect;
@@ -43,9 +40,7 @@ where
     Proxy::new(client, upstream)
 }
 
-/**
-the proxy handler
-*/
+/// the proxy handler
 #[derive(Debug)]
 pub struct Proxy<U> {
     upstream: U,
@@ -57,18 +52,18 @@ pub struct Proxy<U> {
 }
 
 impl<U: UpstreamSelector> Proxy<U> {
-    /**
-    construct a new proxy handler that sends all requests to the upstream
-    provided
-
-    ```
-    use trillium_smol::ClientConfig;
-    use trillium_proxy::Proxy;
-
-    let proxy = Proxy::new(ClientConfig::default(), "http://docs.trillium.rs/trillium_proxy");
-    ```
-
-     */
+    /// construct a new proxy handler that sends all requests to the upstream
+    /// provided
+    ///
+    /// ```
+    /// use trillium_proxy::Proxy;
+    /// use trillium_smol::ClientConfig;
+    ///
+    /// let proxy = Proxy::new(
+    ///     ClientConfig::default(),
+    ///     "http://docs.trillium.rs/trillium_proxy",
+    /// );
+    /// ```
     pub fn new<I>(client: impl Into<Client>, upstream: I) -> Self
     where
         I: IntoUpstreamSelector<UpstreamSelector = U>,
@@ -83,43 +78,37 @@ impl<U: UpstreamSelector> Proxy<U> {
         }
     }
 
-    /**
-    chainable constructor to set the 404 Not Found handling
-    behavior. By default, this proxy will pass through the trillium
-    Conn unmodified if the proxy response is a 404 not found, allowing
-    it to be chained in a tuple handler. To modify this behavior, call
-    proxy_not_found, and the full 404 response will be forwarded. The
-    Conn will be halted unless [`Proxy::without_halting`] was
-    configured
-
-    ```
-    # use trillium_smol::ClientConfig;
-    # use trillium_proxy::Proxy;
-    let proxy = Proxy::new(ClientConfig::default(), "http://trillium.rs")
-        .proxy_not_found();
-    ```
-    */
+    /// chainable constructor to set the 404 Not Found handling
+    /// behavior. By default, this proxy will pass through the trillium
+    /// Conn unmodified if the proxy response is a 404 not found, allowing
+    /// it to be chained in a tuple handler. To modify this behavior, call
+    /// proxy_not_found, and the full 404 response will be forwarded. The
+    /// Conn will be halted unless [`Proxy::without_halting`] was
+    /// configured
+    ///
+    /// ```
+    /// # use trillium_smol::ClientConfig;
+    /// # use trillium_proxy::Proxy;
+    /// let proxy = Proxy::new(ClientConfig::default(), "http://trillium.rs").proxy_not_found();
+    /// ```
     pub fn proxy_not_found(mut self) -> Self {
         self.pass_through_not_found = false;
         self
     }
 
-    /**
-    The default behavior for this handler is to halt the conn on any
-    response other than a 404. If [`Proxy::proxy_not_found`] has been
-    configured, the default behavior for all response statuses is to
-    halt the trillium conn. To change this behavior, call
-    without_halting when constructing the proxy, and it will not halt
-    the conn. This is useful when passing the proxy reply through
-    [`trillium_html_rewriter`](https://docs.trillium.rs/trillium_html_rewriter).
-
-    ```
-    # use trillium_smol::ClientConfig;
-    # use trillium_proxy::Proxy;
-    let proxy = Proxy::new(ClientConfig::default(), "http://trillium.rs")
-        .without_halting();
-    ```
-    */
+    /// The default behavior for this handler is to halt the conn on any
+    /// response other than a 404. If [`Proxy::proxy_not_found`] has been
+    /// configured, the default behavior for all response statuses is to
+    /// halt the trillium conn. To change this behavior, call
+    /// without_halting when constructing the proxy, and it will not halt
+    /// the conn. This is useful when passing the proxy reply through
+    /// [`trillium_html_rewriter`](https://docs.trillium.rs/trillium_html_rewriter).
+    ///
+    /// ```
+    /// # use trillium_smol::ClientConfig;
+    /// # use trillium_proxy::Proxy;
+    /// let proxy = Proxy::new(ClientConfig::default(), "http://trillium.rs").without_halting();
+    /// ```
     pub fn without_halting(mut self) -> Self {
         self.halt = false;
         self

--- a/redirect/src/lib.rs
+++ b/redirect/src/lib.rs
@@ -1,6 +1,4 @@
-/*!
-Trillium handler for redirection
-*/
+//! Trillium handler for redirection
 #![forbid(unsafe_code)]
 #![deny(
     missing_copy_implementations,

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -9,53 +9,56 @@
     unused_qualifications
 )]
 
-/*!
-# Welcome to the trillium router crate!
-
-This router is built on top of
-[routefinder](https://github.com/jbr/routefinder), and the details of
-route resolution and definition are documented on that repository.
-
-```
-use trillium::{conn_unwrap, Conn};
-use trillium_router::{Router, RouterConnExt};
-
-let router = Router::new()
-    .get("/", |conn: Conn| async move { conn.ok("you have reached the index") })
-    .get("/pages/:page_name", |conn: Conn| async move {
-        let page_name = conn_unwrap!(conn.param("page_name"), conn);
-        let content = format!("you have reached the page named {}", page_name);
-        conn.ok(content)
-    });
-
-use trillium_testing::prelude::*;
-assert_ok!(get("/").on(&router), "you have reached the index");
-assert_ok!(get("/pages/trillium").on(&router), "you have reached the page named trillium");
-assert_not_handled!(get("/unknown/route").on(&router));
-```
-
-Although this is currently the only trillium router, it is an
-important aspect of trillium's architecture that the router uses only
-public apis and is interoperable with other router implementations. If
-you have different ideas of how a router might work, please publish a
-crate! It should be possible to nest different types of routers (and
-different versions of router crates) within each other as long as they
-all depend on the same version of the `trillium` crate.
-
-## Options handling
-
-By default, the trillium router will reply to an OPTIONS request with
-the list of supported http methods at the given route. If the OPTIONS
-request is sent for `*`, it responds with the full set of http methods
-supported by this router.
-
-**Note:** This behavior is superceded by an explicit OPTIONS handler
-or an `any` handler.
-
-To disable the default OPTIONS behavior, use
-[`Router::without_options_handling`] or
-[`RouterRef::set_options_handling`]
-*/
+//! # Welcome to the trillium router crate!
+//!
+//! This router is built on top of
+//! [routefinder](https://github.com/jbr/routefinder), and the details of
+//! route resolution and definition are documented on that repository.
+//!
+//! ```
+//! use trillium::{conn_unwrap, Conn};
+//! use trillium_router::{Router, RouterConnExt};
+//!
+//! let router = Router::new()
+//!     .get("/", |conn: Conn| async move {
+//!         conn.ok("you have reached the index")
+//!     })
+//!     .get("/pages/:page_name", |conn: Conn| async move {
+//!         let page_name = conn_unwrap!(conn.param("page_name"), conn);
+//!         let content = format!("you have reached the page named {}", page_name);
+//!         conn.ok(content)
+//!     });
+//!
+//! use trillium_testing::prelude::*;
+//! assert_ok!(get("/").on(&router), "you have reached the index");
+//! assert_ok!(
+//!     get("/pages/trillium").on(&router),
+//!     "you have reached the page named trillium"
+//! );
+//! assert_not_handled!(get("/unknown/route").on(&router));
+//! ```
+//!
+//! Although this is currently the only trillium router, it is an
+//! important aspect of trillium's architecture that the router uses only
+//! public apis and is interoperable with other router implementations. If
+//! you have different ideas of how a router might work, please publish a
+//! crate! It should be possible to nest different types of routers (and
+//! different versions of router crates) within each other as long as they
+//! all depend on the same version of the `trillium` crate.
+//!
+//! ## Options handling
+//!
+//! By default, the trillium router will reply to an OPTIONS request with
+//! the list of supported http methods at the given route. If the OPTIONS
+//! request is sent for `*`, it responds with the full set of http methods
+//! supported by this router.
+//!
+//! **Note:** This behavior is superceded by an explicit OPTIONS handler
+//! or an `any` handler.
+//!
+//! To disable the default OPTIONS behavior, use
+//! [`Router::without_options_handling`] or
+//! [`RouterRef::set_options_handling`]
 
 mod router;
 pub use router::Router;
@@ -66,33 +69,31 @@ pub use router_ref::RouterRef;
 mod router_conn_ext;
 pub use router_conn_ext::RouterConnExt;
 
-/**
-The routes macro represents an experimental macro for defining
-routers.
-
-**stability note:** this may be removed entirely if it is not widely
-used. please open an issue if you like it, or if you have ideas to
-improve it.
-
-```
-use trillium::{conn_unwrap, Conn};
-use trillium_router::{routes, RouterConnExt};
-
-let router = routes!(
-    get "/" |conn: Conn| async move { conn.ok("you have reached the index") },
-    get "/pages/:page_name" |conn: Conn| async move {
-        let page_name = conn_unwrap!(conn.param("page_name"), conn);
-        let content = format!("you have reached the page named {}", page_name);
-        conn.ok(content)
-    }
-);
-
-use trillium_testing::prelude::*;
-assert_ok!(get("/").on(&router), "you have reached the index");
-assert_ok!(get("/pages/trillium").on(&router), "you have reached the page named trillium");
-assert_not_handled!(get("/unknown/route").on(&router));
-```
-*/
+/// The routes macro represents an experimental macro for defining
+/// routers.
+///
+/// **stability note:** this may be removed entirely if it is not widely
+/// used. please open an issue if you like it, or if you have ideas to
+/// improve it.
+///
+/// ```
+/// use trillium::{conn_unwrap, Conn};
+/// use trillium_router::{routes, RouterConnExt};
+///
+/// let router = routes!(
+/// get "/" |conn: Conn| async move { conn.ok("you have reached the index") },
+/// get "/pages/:page_name" |conn: Conn| async move {
+/// let page_name = conn_unwrap!(conn.param("page_name"), conn);
+/// let content = format!("you have reached the page named {}", page_name);
+/// conn.ok(content)
+/// }
+/// );
+///
+/// use trillium_testing::prelude::*;
+/// assert_ok!(get("/").on(&router), "you have reached the index");
+/// assert_ok!(get("/pages/trillium").on(&router), "you have reached the page named trillium");
+/// assert_not_handled!(get("/unknown/route").on(&router));
+/// ```
 #[macro_export]
 macro_rules! routes {
     ($($method:ident $path:literal $(-> )?$handler:expr),+ $(,)?) => {

--- a/router/src/router.rs
+++ b/router/src/router.rs
@@ -125,12 +125,9 @@ impl MethodRoutefinder {
     }
 }
 
-/**
-# The Router handler
-
-See crate level docs for more, as this is the primary type in this crate.
-
-*/
+/// # The Router handler
+///
+/// See crate level docs for more, as this is the primary type in this crate.
 pub struct Router {
     routefinder: MethodRoutefinder,
     handle_options: bool,
@@ -204,79 +201,79 @@ impl Router {
 
     method!(patch, Patch);
 
-    /**
-    Constructs a new Router. This is often used with [`Router::get`],
-    [`Router::post`], [`Router::put`], [`Router::delete`], and
-    [`Router::patch`] chainable methods to build up an application.
-
-    For an alternative way of constructing a Router, see [`Router::build`]
-
-    ```
-    # use trillium::Conn;
-    # use trillium_router::Router;
-
-    let router = Router::new()
-        .get("/", |conn: Conn| async move { conn.ok("you have reached the index") })
-        .get("/some/:param", |conn: Conn| async move { conn.ok("you have reached /some/:param") })
-        .post("/", |conn: Conn| async move { conn.ok("post!") });
-
-    use trillium_testing::prelude::*;
-    assert_ok!(get("/").on(&router), "you have reached the index");
-    assert_ok!(get("/some/route").on(&router), "you have reached /some/:param");
-    assert_ok!(post("/").on(&router), "post!");
-    ```
-     */
+    /// Constructs a new Router. This is often used with [`Router::get`],
+    /// [`Router::post`], [`Router::put`], [`Router::delete`], and
+    /// [`Router::patch`] chainable methods to build up an application.
+    ///
+    /// For an alternative way of constructing a Router, see [`Router::build`]
+    ///
+    /// ```
+    /// # use trillium::Conn;
+    /// # use trillium_router::Router;
+    ///
+    /// let router = Router::new()
+    ///     .get("/", |conn: Conn| async move {
+    ///         conn.ok("you have reached the index")
+    ///     })
+    ///     .get("/some/:param", |conn: Conn| async move {
+    ///         conn.ok("you have reached /some/:param")
+    ///     })
+    ///     .post("/", |conn: Conn| async move { conn.ok("post!") });
+    ///
+    /// use trillium_testing::prelude::*;
+    /// assert_ok!(get("/").on(&router), "you have reached the index");
+    /// assert_ok!(
+    ///     get("/some/route").on(&router),
+    ///     "you have reached /some/:param"
+    /// );
+    /// assert_ok!(post("/").on(&router), "post!");
+    /// ```
     pub fn new() -> Self {
         Self::default()
     }
 
-    /**
-    Disable the default behavior of responding to OPTIONS requests
-    with the supported methods at a given path
-    */
+    /// Disable the default behavior of responding to OPTIONS requests
+    /// with the supported methods at a given path
     pub fn without_options_handling(mut self) -> Self {
         self.set_options_handling(false);
         self
     }
 
-    /**
-    enable or disable the router's behavior of responding to OPTIONS requests with the supported methods at given path.
-
-    default: enabled
-     */
+    /// enable or disable the router's behavior of responding to OPTIONS requests with the supported
+    /// methods at given path.
+    ///
+    /// default: enabled
     pub(crate) fn set_options_handling(&mut self, options_enabled: bool) {
         self.handle_options = options_enabled;
     }
 
-    /**
-    Another way to build a router, if you don't like the chainable
-    interface described in [`Router::new`]. Note that the argument to
-    the closure is a [`RouterRef`].
-
-    ```
-    # use trillium::Conn;
-    # use trillium_router::Router;
-    let router = Router::build(|mut router| {
-        router.get("/", |conn: Conn| async move {
-            conn.ok("you have reached the index")
-        });
-
-        router.get("/some/:paramroute", |conn: Conn| async move {
-            conn.ok("you have reached /some/:param")
-        });
-
-        router.post("/", |conn: Conn| async move {
-            conn.ok("post!")
-        });
-    });
-
-
-    use trillium_testing::prelude::*;
-    assert_ok!(get("/").on(&router), "you have reached the index");
-    assert_ok!(get("/some/route").on(&router), "you have reached /some/:param");
-    assert_ok!(post("/").on(&router), "post!");
-    ```
-    */
+    /// Another way to build a router, if you don't like the chainable
+    /// interface described in [`Router::new`]. Note that the argument to
+    /// the closure is a [`RouterRef`].
+    ///
+    /// ```
+    /// # use trillium::Conn;
+    /// # use trillium_router::Router;
+    /// let router = Router::build(|mut router| {
+    ///     router.get("/", |conn: Conn| async move {
+    ///         conn.ok("you have reached the index")
+    ///     });
+    ///
+    ///     router.get("/some/:paramroute", |conn: Conn| async move {
+    ///         conn.ok("you have reached /some/:param")
+    ///     });
+    ///
+    ///     router.post("/", |conn: Conn| async move { conn.ok("post!") });
+    /// });
+    ///
+    /// use trillium_testing::prelude::*;
+    /// assert_ok!(get("/").on(&router), "you have reached the index");
+    /// assert_ok!(
+    ///     get("/some/route").on(&router),
+    ///     "you have reached /some/:param"
+    /// );
+    /// assert_ok!(post("/").on(&router), "post!");
+    /// ```
     pub fn build(builder: impl Fn(RouterRef)) -> Router {
         let mut router = Router::new();
         builder(RouterRef::new(&mut router));
@@ -291,21 +288,29 @@ impl Router {
         self.routefinder.best_match(method, path)
     }
 
-    /**
-    Registers a handler for a method other than get, put, post, patch, or delete.
-
-    ```
-    # use trillium::{Conn, Method};
-    # use trillium_router::Router;
-    let router = Router::new()
-        .with_route("OPTIONS", "/some/route", |conn: Conn| async move { conn.ok("directly handling options") })
-        .with_route(Method::Checkin, "/some/route", |conn: Conn| async move { conn.ok("checkin??") });
-
-    use trillium_testing::{prelude::*, TestConn};
-    assert_ok!(TestConn::build(Method::Options, "/some/route", ()).on(&router), "directly handling options");
-    assert_ok!(TestConn::build("checkin", "/some/route", ()).on(&router), "checkin??");
-    ```
-    */
+    /// Registers a handler for a method other than get, put, post, patch, or delete.
+    ///
+    /// ```
+    /// # use trillium::{Conn, Method};
+    /// # use trillium_router::Router;
+    /// let router = Router::new()
+    ///     .with_route("OPTIONS", "/some/route", |conn: Conn| async move {
+    ///         conn.ok("directly handling options")
+    ///     })
+    ///     .with_route(Method::Checkin, "/some/route", |conn: Conn| async move {
+    ///         conn.ok("checkin??")
+    ///     });
+    ///
+    /// use trillium_testing::{prelude::*, TestConn};
+    /// assert_ok!(
+    ///     TestConn::build(Method::Options, "/some/route", ()).on(&router),
+    ///     "directly handling options"
+    /// );
+    /// assert_ok!(
+    ///     TestConn::build("checkin", "/some/route", ()).on(&router),
+    ///     "checkin??"
+    /// );
+    /// ```
     pub fn with_route<M, R>(mut self, method: M, path: R, handler: impl Handler) -> Self
     where
         M: TryInto<Method>,
@@ -341,26 +346,30 @@ impl Router {
         self.routefinder.add((), path, handler);
     }
 
-    /**
-    Appends the handler to all (get, post, put, delete, and patch) methods.
-    ```
-    # use trillium::Conn;
-    # use trillium_router::Router;
-    let router = Router::new().all("/any", |conn: Conn| async move {
-        let response = format!("you made a {} request to /any", conn.method());
-        conn.ok(response)
-    });
-
-    use trillium_testing::prelude::*;
-    assert_ok!(get("/any").on(&router), "you made a GET request to /any");
-    assert_ok!(post("/any").on(&router), "you made a POST request to /any");
-    assert_ok!(delete("/any").on(&router), "you made a DELETE request to /any");
-    assert_ok!(patch("/any").on(&router), "you made a PATCH request to /any");
-    assert_ok!(put("/any").on(&router), "you made a PUT request to /any");
-
-    assert_not_handled!(get("/").on(&router));
-    ```
-    */
+    /// Appends the handler to all (get, post, put, delete, and patch) methods.
+    /// ```
+    /// # use trillium::Conn;
+    /// # use trillium_router::Router;
+    /// let router = Router::new().all("/any", |conn: Conn| async move {
+    ///     let response = format!("you made a {} request to /any", conn.method());
+    ///     conn.ok(response)
+    /// });
+    ///
+    /// use trillium_testing::prelude::*;
+    /// assert_ok!(get("/any").on(&router), "you made a GET request to /any");
+    /// assert_ok!(post("/any").on(&router), "you made a POST request to /any");
+    /// assert_ok!(
+    ///     delete("/any").on(&router),
+    ///     "you made a DELETE request to /any"
+    /// );
+    /// assert_ok!(
+    ///     patch("/any").on(&router),
+    ///     "you made a PATCH request to /any"
+    /// );
+    /// assert_ok!(put("/any").on(&router), "you made a PUT request to /any");
+    ///
+    /// assert_not_handled!(get("/").on(&router));
+    /// ```
     pub fn all<R>(mut self, path: R, handler: impl Handler) -> Self
     where
         R: TryInto<RouteSpec>,
@@ -370,25 +379,29 @@ impl Router {
         self
     }
 
-    /**
-    Appends the handler to each of the provided http methods.
-    ```
-    # use trillium::Conn;
-    # use trillium_router::Router;
-    let router = Router::new().any(&["get", "post"], "/get_or_post", |conn: Conn| async move {
-        let response = format!("you made a {} request to /get_or_post", conn.method());
-        conn.ok(response)
-    });
-
-    use trillium_testing::prelude::*;
-    assert_ok!(get("/get_or_post").on(&router), "you made a GET request to /get_or_post");
-    assert_ok!(post("/get_or_post").on(&router), "you made a POST request to /get_or_post");
-    assert_not_handled!(delete("/any").on(&router));
-    assert_not_handled!(patch("/any").on(&router));
-    assert_not_handled!(put("/any").on(&router));
-    assert_not_handled!(get("/").on(&router));
-    ```
-    */
+    /// Appends the handler to each of the provided http methods.
+    /// ```
+    /// # use trillium::Conn;
+    /// # use trillium_router::Router;
+    /// let router = Router::new().any(&["get", "post"], "/get_or_post", |conn: Conn| async move {
+    ///     let response = format!("you made a {} request to /get_or_post", conn.method());
+    ///     conn.ok(response)
+    /// });
+    ///
+    /// use trillium_testing::prelude::*;
+    /// assert_ok!(
+    ///     get("/get_or_post").on(&router),
+    ///     "you made a GET request to /get_or_post"
+    /// );
+    /// assert_ok!(
+    ///     post("/get_or_post").on(&router),
+    ///     "you made a POST request to /get_or_post"
+    /// );
+    /// assert_not_handled!(delete("/any").on(&router));
+    /// assert_not_handled!(patch("/any").on(&router));
+    /// assert_not_handled!(put("/any").on(&router));
+    /// assert_not_handled!(get("/").on(&router));
+    /// ```
     pub fn any<IntoMethod, R>(
         mut self,
         methods: &[IntoMethod],

--- a/router/src/router_conn_ext.rs
+++ b/router/src/router_conn_ext.rs
@@ -1,34 +1,30 @@
 use crate::{CapturesNewType, RouteSpecNewType};
 use trillium::Conn;
 
-/**
-Extends trillium::Conn with accessors for router params.
-*/
+/// Extends trillium::Conn with accessors for router params.
 pub trait RouterConnExt {
-    /**
-    Retrieves a captured param from the conn. Note that this will only
-    be Some if the exact param is present in the matched route.
-
-    Routefinder params are defined starting with a colon, but the
-    colon is not needed when fetching the param.
-
-    ```
-    use trillium::{conn_unwrap, Conn};
-    use trillium_router::{Router, RouterConnExt};
-
-    let router = Router::new().get("/pages/:page_name", |conn: Conn| async move {
-        let page_name = conn_unwrap!(conn.param("page_name"), conn);
-        let content = format!("you have reached the page named {}", page_name);
-        conn.ok(content)
-    });
-
-    use trillium_testing::prelude::*;
-    assert_ok!(
-        get("/pages/trillium").on(&router),
-        "you have reached the page named trillium"
-    );
-    ```
-    */
+    /// Retrieves a captured param from the conn. Note that this will only
+    /// be Some if the exact param is present in the matched route.
+    ///
+    /// Routefinder params are defined starting with a colon, but the
+    /// colon is not needed when fetching the param.
+    ///
+    /// ```
+    /// use trillium::{conn_unwrap, Conn};
+    /// use trillium_router::{Router, RouterConnExt};
+    ///
+    /// let router = Router::new().get("/pages/:page_name", |conn: Conn| async move {
+    ///     let page_name = conn_unwrap!(conn.param("page_name"), conn);
+    ///     let content = format!("you have reached the page named {}", page_name);
+    ///     conn.ok(content)
+    /// });
+    ///
+    /// use trillium_testing::prelude::*;
+    /// assert_ok!(
+    ///     get("/pages/trillium").on(&router),
+    ///     "you have reached the page named trillium"
+    /// );
+    /// ```
 
     fn param<'a>(&'a self, param: &str) -> Option<&'a str>;
 

--- a/router/src/router_ref.rs
+++ b/router/src/router_ref.rs
@@ -52,12 +52,10 @@ assert_not_handled!(",
     };
 }
 
-/**
-# A `&mut Router` for use with `Router::build`
-
-A wrapper around a `&mut Router` that supports imperative route
-registration. See [`Router::build`] for further documentation.
-*/
+/// # A `&mut Router` for use with `Router::build`
+///
+/// A wrapper around a `&mut Router` that supports imperative route
+/// registration. See [`Router::build`] for further documentation.
 #[derive(Debug)]
 pub struct RouterRef<'r>(&'r mut Router);
 impl<'r> RouterRef<'r> {
@@ -71,30 +69,33 @@ impl<'r> RouterRef<'r> {
 
     method_ref!(patch, Patch);
 
-    /**
-    Appends the handler to all (get, post, put, delete, and patch) methods.
-
-    ```
-    # use trillium::Conn;
-    # use trillium_router::Router;
-    let router = Router::build(|mut router| {
-        router.all("/any", |conn: Conn| async move {
-            let response = format!("you made a {} request to /any", conn.method());
-            conn.ok(response)
-        });
-    });
-
-    use trillium_testing::prelude::*;
-    assert_ok!(get("/any").on(&router), "you made a GET request to /any");
-    assert_ok!(post("/any").on(&router), "you made a POST request to /any");
-    assert_ok!(delete("/any").on(&router), "you made a DELETE request to /any");
-    assert_ok!(patch("/any").on(&router), "you made a PATCH request to /any");
-    assert_ok!(put("/any").on(&router), "you made a PUT request to /any");
-
-    assert_not_handled!(get("/").on(&router));
-    ```
-
-    */
+    /// Appends the handler to all (get, post, put, delete, and patch) methods.
+    ///
+    /// ```
+    /// # use trillium::Conn;
+    /// # use trillium_router::Router;
+    /// let router = Router::build(|mut router| {
+    ///     router.all("/any", |conn: Conn| async move {
+    ///         let response = format!("you made a {} request to /any", conn.method());
+    ///         conn.ok(response)
+    ///     });
+    /// });
+    ///
+    /// use trillium_testing::prelude::*;
+    /// assert_ok!(get("/any").on(&router), "you made a GET request to /any");
+    /// assert_ok!(post("/any").on(&router), "you made a POST request to /any");
+    /// assert_ok!(
+    ///     delete("/any").on(&router),
+    ///     "you made a DELETE request to /any"
+    /// );
+    /// assert_ok!(
+    ///     patch("/any").on(&router),
+    ///     "you made a PATCH request to /any"
+    /// );
+    /// assert_ok!(put("/any").on(&router), "you made a PUT request to /any");
+    ///
+    /// assert_not_handled!(get("/").on(&router));
+    /// ```
     pub fn all<R>(&mut self, path: R, handler: impl Handler)
     where
         R: TryInto<RouteSpec>,
@@ -103,27 +104,31 @@ impl<'r> RouterRef<'r> {
         self.0.add_all(path, handler)
     }
 
-    /**
-    Appends the handler to each of the provided http methods.
-    ```
-    # use trillium::Conn;
-    # use trillium_router::Router;
-    let router = Router::build(|mut router|{
-        router.any(&["get", "post"], "/get_or_post", |conn: Conn| async move {
-            let response = format!("you made a {} request to /get_or_post", conn.method());
-            conn.ok(response)
-        });
-    });
-
-    use trillium_testing::prelude::*;
-    assert_ok!(get("/get_or_post").on(&router), "you made a GET request to /get_or_post");
-    assert_ok!(post("/get_or_post").on(&router), "you made a POST request to /get_or_post");
-    assert_not_handled!(delete("/any").on(&router));
-    assert_not_handled!(patch("/any").on(&router));
-    assert_not_handled!(put("/any").on(&router));
-    assert_not_handled!(get("/").on(&router));
-    ```
-    */
+    /// Appends the handler to each of the provided http methods.
+    /// ```
+    /// # use trillium::Conn;
+    /// # use trillium_router::Router;
+    /// let router = Router::build(|mut router| {
+    ///     router.any(&["get", "post"], "/get_or_post", |conn: Conn| async move {
+    ///         let response = format!("you made a {} request to /get_or_post", conn.method());
+    ///         conn.ok(response)
+    ///     });
+    /// });
+    ///
+    /// use trillium_testing::prelude::*;
+    /// assert_ok!(
+    ///     get("/get_or_post").on(&router),
+    ///     "you made a GET request to /get_or_post"
+    /// );
+    /// assert_ok!(
+    ///     post("/get_or_post").on(&router),
+    ///     "you made a POST request to /get_or_post"
+    /// );
+    /// assert_not_handled!(delete("/any").on(&router));
+    /// assert_not_handled!(patch("/any").on(&router));
+    /// assert_not_handled!(put("/any").on(&router));
+    /// assert_not_handled!(get("/").on(&router));
+    /// ```
     pub fn any<IntoMethod, R>(&mut self, methods: &[IntoMethod], path: R, handler: impl Handler)
     where
         R: TryInto<RouteSpec>,
@@ -144,26 +149,30 @@ impl<'r> RouterRef<'r> {
         Self(router)
     }
 
-    /**
-    Registers a handler for a method other than get, put, post, patch, or delete.
-    ```
-    # use trillium::{Conn, Method};
-    # use trillium_router::Router;
-    let router = Router::build(|mut router| {
-        router.add_route("OPTIONS", "/some/route", |conn: Conn| async move {
-            conn.ok("directly handling options")
-        });
-
-        router.add_route(Method::Checkin, "/some/route", |conn: Conn| async move {
-            conn.ok("checkin??")
-        });
-    });
-
-    use trillium_testing::{prelude::*, TestConn};
-    assert_ok!(TestConn::build(Method::Options, "/some/route", ()).on(&router), "directly handling options");
-    assert_ok!(TestConn::build("checkin", "/some/route", ()).on(&router), "checkin??");
-    ```
-    */
+    /// Registers a handler for a method other than get, put, post, patch, or delete.
+    /// ```
+    /// # use trillium::{Conn, Method};
+    /// # use trillium_router::Router;
+    /// let router = Router::build(|mut router| {
+    ///     router.add_route("OPTIONS", "/some/route", |conn: Conn| async move {
+    ///         conn.ok("directly handling options")
+    ///     });
+    ///
+    ///     router.add_route(Method::Checkin, "/some/route", |conn: Conn| async move {
+    ///         conn.ok("checkin??")
+    ///     });
+    /// });
+    ///
+    /// use trillium_testing::{prelude::*, TestConn};
+    /// assert_ok!(
+    ///     TestConn::build(Method::Options, "/some/route", ()).on(&router),
+    ///     "directly handling options"
+    /// );
+    /// assert_ok!(
+    ///     TestConn::build("checkin", "/some/route", ()).on(&router),
+    ///     "checkin??"
+    /// );
+    /// ```
     pub fn add_route<M, R>(&mut self, method: M, path: R, handler: impl Handler)
     where
         M: TryInto<Method>,
@@ -174,14 +183,12 @@ impl<'r> RouterRef<'r> {
         self.0.add(path, method.try_into().unwrap(), handler);
     }
 
-    /**
-    enable or disable the router's behavior of responding to OPTIONS
-    requests with the supported methods at given path.
-
-    default: enabled
-
-    see crate-level docs for further explanation of the default behavior.
-     */
+    /// enable or disable the router's behavior of responding to OPTIONS
+    /// requests with the supported methods at given path.
+    ///
+    /// default: enabled
+    ///
+    /// see crate-level docs for further explanation of the default behavior.
     pub fn set_options_handling(&mut self, options_enabled: bool) {
         self.0.set_options_handling(options_enabled);
     }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,11 +1,12 @@
-unstable_features = true
+comment_width = 100
 format_code_in_doc_comments = true
 format_macro_matchers = true
 format_strings = true
-imports_granularity = "Crate"
 group_imports = "One"
-wrap_comments = true
-comment_width = 100
+imports_granularity = "Crate"
+normalize_comments = true
 reorder_impl_items = true
+unstable_features = true
 use_field_init_shorthand = true
 version = "Two"
+wrap_comments = true

--- a/rustls/src/client.rs
+++ b/rustls/src/client.rs
@@ -21,9 +21,7 @@ use RustlsClientTransportInner::{Tcp, Tls};
 #[derive(Clone, Debug)]
 pub struct RustlsClientConfig(Arc<ClientConfig>);
 
-/**
-Client configuration for RustlsConnector
-*/
+/// Client configuration for RustlsConnector
 #[derive(Clone, Default)]
 pub struct RustlsConfig<Config> {
     /// configuration for rustls itself
@@ -149,12 +147,10 @@ enum RustlsClientTransportInner<T> {
     Tls(Box<TlsStream<T>>),
 }
 
-/**
-Transport for the rustls connector
-
-This may represent either an encrypted tls connection or a plaintext
-connection, depending on the request schema
-*/
+/// Transport for the rustls connector
+///
+/// This may represent either an encrypted tls connection or a plaintext
+/// connection, depending on the request schema
 #[derive(Debug)]
 pub struct RustlsClientTransport<T>(RustlsClientTransportInner<T>);
 impl<T> From<T> for RustlsClientTransport<T> {

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -9,63 +9,62 @@
     unused_qualifications
 )]
 
-/*!  This crate provides rustls trait implementations for trillium client ([`RustlsConnector`]) and
-server ([`RustlsAcceptor`]).
-
-# Cargo Features
-
-This crate's default features should be appropriate for most users. To pare down on dependencies or
-customize trillium-rustls' usage of rustls, opt out of default features and reenable the appropriate
-features for your use case.
-
-## `server` and `client` features
-
-This crate offers a `server` feature and a `client` feature. Opting out of default features allows
-you to avoid building any dependencies for the unused other component. By default, both `server` and
-`client` features are enabled.
-
-## Cryptographic backend selection
-
-Rustls supports pluggable cryptographic backends as well as a process-default cryptographic
-cryptographic backend. There are two built-in feature-enabled cryptographic backends and other
-community provided cryptographic backends.
-
-⚠️ There are three cryptographic backend cargo features, and they behave differently than the rustls
-features. Please read the following section.⚠️
-
-`trillium-rustls` tries to avoid runtime panics where possible, so compiling this crate without a
-valid cryptographic backend will result in a compile time error. To opt into rustls's default
-process-default behavior, enable `custom-crypto-provider` as described below. Enabling multiple
-crypto providers will select exactly one of them at compile time in the following order:
-
-### `aws-lc-rs`
-
-This is the default cryptographic backend in concordance with rustls' default. This backend will be
-selected if the feature is enabled. If either of the other two cryptographic backends are selected,
-trillium-rustls will log an error but use `aws-lc-rs`.
-
-### `ring`
-
-If this feature is enabled, this backend will be selected even if `custom-crypto-provider` is also
-enabled.
-
-### `custom-crypto-provider`
-
-In order to use a crypto provider other than the above two options, enable the
-`custom-crypto-provider` feature and either configure a
-[`trillium_rustls::rustls::ClientConfig`][rustls::ClientConfig] or
-[`trillium_rustls::rustls::ServerConfig`][rustls::ServerConfig] yourself to convert the equivalent
-`trillium-rustls` type, or install a custom process-default crypto provider with
-[`trillium_rustls::rustls::crypto::CryptoProvider::install_default`][rustls::crypto::CryptoProvider::install_default]
-prior to executing trillium-rustls code.
-
-## Client verifier
-
-This crate offers a `platform-verifier` feature for client usage that builds a ClientConfig with the
-selected cryptographic backend and uses
-[`rustls-platform-verifier`](https://docs.rs/rustls-platform-verifier/). This feature is enabled by
-default. If you disable the feature, [`webpki_roots`] will be used.
-*/
+//!  This crate provides rustls trait implementations for trillium client ([`RustlsConnector`]) and
+//! server ([`RustlsAcceptor`]).
+//!
+//! # Cargo Features
+//!
+//! This crate's default features should be appropriate for most users. To pare down on dependencies
+//! or customize trillium-rustls' usage of rustls, opt out of default features and reenable the
+//! appropriate features for your use case.
+//!
+//! ## `server` and `client` features
+//!
+//! This crate offers a `server` feature and a `client` feature. Opting out of default features
+//! allows you to avoid building any dependencies for the unused other component. By default, both
+//! `server` and `client` features are enabled.
+//!
+//! ## Cryptographic backend selection
+//!
+//! Rustls supports pluggable cryptographic backends as well as a process-default cryptographic
+//! cryptographic backend. There are two built-in feature-enabled cryptographic backends and other
+//! community provided cryptographic backends.
+//!
+//! ⚠️ There are three cryptographic backend cargo features, and they behave differently than the
+//! rustls features. Please read the following section.⚠️
+//!
+//! `trillium-rustls` tries to avoid runtime panics where possible, so compiling this crate without
+//! a valid cryptographic backend will result in a compile time error. To opt into rustls's default
+//! process-default behavior, enable `custom-crypto-provider` as described below. Enabling multiple
+//! crypto providers will select exactly one of them at compile time in the following order:
+//!
+//! ### `aws-lc-rs`
+//!
+//! This is the default cryptographic backend in concordance with rustls' default. This backend will
+//! be selected if the feature is enabled. If either of the other two cryptographic backends are
+//! selected, trillium-rustls will log an error but use `aws-lc-rs`.
+//!
+//! ### `ring`
+//!
+//! If this feature is enabled, this backend will be selected even if `custom-crypto-provider` is
+//! also enabled.
+//!
+//! ### `custom-crypto-provider`
+//!
+//! In order to use a crypto provider other than the above two options, enable the
+//! `custom-crypto-provider` feature and either configure a
+//! [`trillium_rustls::rustls::ClientConfig`][rustls::ClientConfig] or
+//! [`trillium_rustls::rustls::ServerConfig`][rustls::ServerConfig] yourself to convert the
+//! equivalent `trillium-rustls` type, or install a custom process-default crypto provider with
+//! [`trillium_rustls::rustls::crypto::CryptoProvider::install_default`][rustls::crypto::CryptoProvider::install_default]
+//! prior to executing trillium-rustls code.
+//!
+//! ## Client verifier
+//!
+//! This crate offers a `platform-verifier` feature for client usage that builds a ClientConfig with
+//! the selected cryptographic backend and uses
+//! [`rustls-platform-verifier`](https://docs.rs/rustls-platform-verifier/). This feature is enabled by
+//! default. If you disable the feature, [`webpki_roots`] will be used.
 
 #[cfg(feature = "client")]
 mod client;

--- a/rustls/src/server.rs
+++ b/rustls/src/server.rs
@@ -13,9 +13,7 @@ use std::{
 };
 use trillium_server_common::{Acceptor, AsyncRead, AsyncWrite, Transport};
 
-/**
-trillium [`Acceptor`] for Rustls
-*/
+/// trillium [`Acceptor`] for Rustls
 
 #[derive(Clone)]
 pub struct RustlsAcceptor(TlsAcceptor);
@@ -26,39 +24,37 @@ impl Debug for RustlsAcceptor {
 }
 
 impl RustlsAcceptor {
-    /**
-    build a new RustlsAcceptor from a [`ServerConfig`] or a [`TlsAcceptor`]
-    */
+    /// build a new RustlsAcceptor from a [`ServerConfig`] or a [`TlsAcceptor`]
     pub fn new(t: impl Into<Self>) -> Self {
         t.into()
     }
 
-    /**
-    build a new RustlsAcceptor from a cert chain (pem) and private key.
-
-    See
-    [`ConfigBuilder::with_single_cert`][`crate::rustls::ConfigBuilder::with_single_cert`]
-    for accepted formats. If you need to customize the
-    [`ServerConfig`], use ServerConfig's Into RustlsAcceptor, eg
-
-    ```rust,ignore
-    use trillium_rustls::{rustls::ServerConfig, RustlsAcceptor};
-    let rustls_acceptor: RustlsAcceptor = ServerConfig::builder()
-        .with_no_client_auth()
-        .with_single_cert(certs, private_key)
-        .expect("could not build rustls ServerConfig")
-        .into();
-    ```
-
-    # Example
-
-    ```rust,no_run
-    use trillium_rustls::RustlsAcceptor;
-    const KEY: &[u8] = include_bytes!("../examples/key.pem");
-    const CERT: &[u8] = include_bytes!("../examples/cert.pem");
-    let rustls_acceptor = RustlsAcceptor::from_single_cert(CERT, KEY);
-    ```
-    */
+    /// build a new RustlsAcceptor from a cert chain (pem) and private key.
+    ///
+    /// See
+    /// [`ConfigBuilder::with_single_cert`][`crate::rustls::ConfigBuilder::with_single_cert`]
+    /// for accepted formats. If you need to customize the
+    /// [`ServerConfig`], use ServerConfig's `Into<RustlsAcceptor>`, eg
+    ///
+    /// ```rust,no_run
+    /// use trillium_rustls::{rustls::ServerConfig, RustlsAcceptor};
+    /// # let certs = vec![];
+    /// # let mut private_key = rustls_pemfile::private_key(&mut std::io::Cursor::new(b"")).unwrap().unwrap();
+    /// let rustls_acceptor: RustlsAcceptor = ServerConfig::builder()
+    ///     .with_no_client_auth()
+    ///     .with_single_cert(certs, private_key)
+    ///     .expect("could not build rustls ServerConfig")
+    ///     .into();
+    /// ```
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use trillium_rustls::RustlsAcceptor;
+    /// const KEY: &[u8] = include_bytes!("../examples/key.pem");
+    /// const CERT: &[u8] = include_bytes!("../examples/cert.pem");
+    /// let rustls_acceptor = RustlsAcceptor::from_single_cert(CERT, KEY);
+    /// ```
     pub fn from_single_cert(cert: &[u8], key: &[u8]) -> Self {
         use std::io::Cursor;
 

--- a/server-common/src/acceptor.rs
+++ b/server-common/src/acceptor.rs
@@ -1,14 +1,11 @@
 use crate::Transport;
 use std::{convert::Infallible, fmt::Debug, future::Future};
 
-/**
-This trait provides the common interface for server-side tls
-acceptors, abstracting over various implementations
-
-The only implementation provided by this crate is `()`, which is
-a noop acceptor, and passes through the `Input` type.
-
-*/
+/// This trait provides the common interface for server-side tls
+/// acceptors, abstracting over various implementations
+///
+/// The only implementation provided by this crate is `()`, which is
+/// a noop acceptor, and passes through the `Input` type.
 pub trait Acceptor<Input>: Clone + Send + Sync + 'static
 where
     Input: Transport,
@@ -19,14 +16,8 @@ where
     /// An error type that [`Acceptor::accept`] may return
     type Error: Debug + Send + Sync;
 
-    /**
-    Transform an Input (`AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static`) into Self::Output
-
-    Async trait signature:
-    ```rust,ignore
-    async fn accept(&self, input: Input) -> Result<Self::Output, Self::Error>;
-    ```
-    */
+    /// Transform an Input (`AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static`) into
+    /// Self::Output
     fn accept(
         &self,
         input: Input,

--- a/server-common/src/client.rs
+++ b/server-common/src/client.rs
@@ -8,13 +8,11 @@ use std::{
     sync::Arc,
 };
 use trillium_http::transport::BoxedTransport;
-/**
-Interface for runtime and tls adapters for the trillium client
-
-See
-[`trillium_client`](https://docs.trillium.rs/trillium_client) for more
-information on usage.
-*/
+/// Interface for runtime and tls adapters for the trillium client
+///
+/// See
+/// [`trillium_client`](https://docs.trillium.rs/trillium_client) for more
+/// information on usage.
 pub trait Connector: Send + Sync + 'static {
     /// the [`Transport`] that [`connect`] returns
     type Transport: Transport;

--- a/server-common/src/config.rs
+++ b/server-common/src/config.rs
@@ -8,54 +8,52 @@ use std::{
 };
 use trillium::{Handler, HttpConfig, Info, Swansong};
 
-/**
-# Primary entrypoint for configuring and running a trillium server
-
-The associated methods on this struct are intended to be chained.
-
-## Example
-```rust,no_run
-trillium_smol::config() // or trillium_async_std, trillium_tokio
-    .with_port(8080) // the default
-    .with_host("localhost") // the default
-    .with_nodelay()
-    .with_max_connections(Some(10000))
-    .without_signals()
-    .run(|conn: trillium::Conn| async move { conn.ok("hello") });
-```
-
-# Socket binding
-
-The socket binding logic is as follows:
-
-* If a LISTEN_FD environment variable is available on `cfg(unix)`
-  systems, that will be used, overriding host and port settings
-* Otherwise:
-  * Host will be selected from explicit configuration using
-    [`Config::with_host`] or else the `HOST` environment variable,
-    or else a default of "localhost".
-    * On `cfg(unix)` systems only: If the host string (as set by env var
-      or direct config) begins with `.`, `/`, or `~`, it is
-      interpreted to be a path, and trillium will bind to it as a unix
-      domain socket. Port will be ignored. The socket will be deleted
-      on clean shutdown.
-  * Port will be selected from explicit configuration using
-    [`Config::with_port`] or else the `PORT` environment variable,
-    or else a default of 8080.
-
-## Signals
-
-On `cfg(unix)` systems, `SIGTERM`, `SIGINT`, and `SIGQUIT` are all
-registered to perform a graceful shutdown on the first signal and an
-immediate shutdown on a subsequent signal. This behavior may change as
-trillium matures. To disable this behavior, use
-[`Config::without_signals`].
-
-## For runtime adapter authors
-
-In order to use this to _implement_ a trillium server, see
-[`trillium_server_common::ConfigExt`](crate::ConfigExt)
-*/
+/// # Primary entrypoint for configuring and running a trillium server
+///
+/// The associated methods on this struct are intended to be chained.
+///
+/// ## Example
+/// ```rust,no_run
+/// trillium_smol::config() // or trillium_async_std, trillium_tokio
+///     .with_port(8080) // the default
+///     .with_host("localhost") // the default
+///     .with_nodelay()
+///     .with_max_connections(Some(10000))
+///     .without_signals()
+///     .run(|conn: trillium::Conn| async move { conn.ok("hello") });
+/// ```
+///
+/// # Socket binding
+///
+/// The socket binding logic is as follows:
+///
+/// If a LISTEN_FD environment variable is available on `cfg(unix)`
+/// systems, that will be used, overriding host and port settings
+/// Otherwise:
+/// Host will be selected from explicit configuration using
+/// [`Config::with_host`] or else the `HOST` environment variable,
+/// or else a default of "localhost".
+/// On `cfg(unix)` systems only: If the host string (as set by env var
+/// or direct config) begins with `.`, `/`, or `~`, it is
+/// interpreted to be a path, and trillium will bind to it as a unix
+/// domain socket. Port will be ignored. The socket will be deleted
+/// on clean shutdown.
+/// Port will be selected from explicit configuration using
+/// [`Config::with_port`] or else the `PORT` environment variable,
+/// or else a default of 8080.
+///
+/// ## Signals
+///
+/// On `cfg(unix)` systems, `SIGTERM`, `SIGINT`, and `SIGQUIT` are all
+/// registered to perform a graceful shutdown on the first signal and an
+/// immediate shutdown on a subsequent signal. This behavior may change as
+/// trillium matures. To disable this behavior, use
+/// [`Config::without_signals`].
+///
+/// ## For runtime adapter authors
+///
+/// In order to use this to _implement_ a trillium server, see
+/// [`trillium_server_common::ConfigExt`](crate::ConfigExt)
 
 #[derive(Debug)]
 pub struct Config<ServerType: Server, AcceptorType> {
@@ -199,11 +197,9 @@ where
         self
     }
 
-    /**
-    Configures the maximum number of connections to accept. The
-    default is 75% of the soft rlimit_nofile (`ulimit -n`) on unix
-    systems, and None on other sytems.
-    */
+    /// Configures the maximum number of connections to accept. The
+    /// default is 75% of the soft rlimit_nofile (`ulimit -n`) on unix
+    /// systems, and None on other sytems.
     pub fn with_max_connections(mut self, max_connections: Option<usize>) -> Self {
         self.max_connections = max_connections;
         self

--- a/server-common/src/lib.rs
+++ b/server-common/src/lib.rs
@@ -8,21 +8,19 @@
     unused_qualifications
 )]
 
-/*!
-# Utilities and traits for building trillium runtime adapters
-
-Trillium applications should never need to depend directly on this
-library. Server adapters should reexport any types from this crate
-that an application author would need to use.
-
-The parts of this crate that are not application facing should be
-expected to change more frequently than the parts that are application
-facing.
-
-If you are depending on this crate for private code that cannot be
-discovered through docs.rs' reverse dependencies, please open an
-issue.
-*/
+//! # Utilities and traits for building trillium runtime adapters
+//!
+//! Trillium applications should never need to depend directly on this
+//! library. Server adapters should reexport any types from this crate
+//! that an application author would need to use.
+//!
+//! The parts of this crate that are not application facing should be
+//! expected to change more frequently than the parts that are application
+//! facing.
+//!
+//! If you are depending on this crate for private code that cannot be
+//! discovered through docs.rs' reverse dependencies, please open an
+//! issue.
 pub use futures_lite::{AsyncRead, AsyncWrite, Stream};
 pub use trillium_http::transport::Transport;
 pub use url::{self, Url};

--- a/server-common/src/server.rs
+++ b/server-common/src/server.rs
@@ -2,9 +2,7 @@ use crate::{Acceptor, ArcHandler, Config, ConfigExt, RuntimeTrait, Swansong, Tra
 use std::{future::Future, io::Result, sync::Arc};
 use trillium::{Handler, Info};
 
-/**
-The server trait, for standard network-based server implementations.
-*/
+/// The server trait, for standard network-based server implementations.
 pub trait Server: Sized + Send + Sync + 'static {
     /// the individual byte stream that http
     /// will be communicated over. This is often an async "stream"

--- a/sessions/src/lib.rs
+++ b/sessions/src/lib.rs
@@ -9,110 +9,112 @@
     unused_qualifications
 )]
 
-/*!
-# Trillium sessions
-
-Trillium sessions is built on top of
-[`async-session`](https://github.com/http-rs/async-session).
-
-Sessions allows trillium to securely attach data to a browser session
-allowing for retrieval and modification of this data within trillium
-on subsequent visits. Session data is generally only retained for the
-duration of a browser session.
-
-Trillium's session implementation provides guest sessions by default,
-meaning that all web requests to a session-enabled trillium host will
-have a cookie attached, whether or not there is anything stored in
-that client's session yet.
-
-## Stores
-
-Although this crate provides two bundled session stores, it is highly
-recommended that trillium applications use an
-external-datastore-backed session storage. For a list of currently
-available session stores, see [the documentation for
-async-session](https://github.com/http-rs/async-session).
-
-## Security
-
-Although each session store may have different security implications,
-the general approach of trillium's session system is as follows: On
-each request, trillium checks the cookie configurable as `cookie_name`
-on the handler.
-
-### If no cookie is found:
-
-A cryptographically random cookie value is generated. A cookie is set
-on the outbound response and signed with an HKDF key derived from the
-`secret` provided on creation of the SessionHandler.  The configurable
-session store uses a SHA256 digest of the cookie value and stores the
-session along with a potential expiry.
-
-### If a cookie is found:
-
-The hkdf derived signing key is used to verify the cookie value's
-signature. If it verifies, it is then passed to the session store to
-retrieve a Session. For most session stores, this will involve taking
-a SHA256 digest of the cookie value and retrieving a serialized
-Session from an external datastore based on that digest.
-
-### Expiry
-
-In addition to setting an expiry on the session cookie, trillium
-sessions include the same expiry in their serialization format. If an
-adversary were able to tamper with the expiry of a cookie, trillium
-sessions would still check the expiry on the contained session before
-using it
-
-### If anything goes wrong with the above process
-
-If there are any failures in the above session retrieval process, a
-new empty session is generated for the request, which proceeds through
-the application as normal.
-
-## Stale/expired session cleanup
-
-Any session store other than the cookie store will accumulate stale
-sessions.  Although the trillium session handler ensures that they
-will not be used as valid sessions, For most session stores, it is the
-trillium application's responsibility to call cleanup on the session
-store if it requires it
-
-```
-use trillium::Conn;
-use trillium_cookies::{CookiesHandler, cookie::Cookie};
-use trillium_sessions::{MemoryStore, SessionConnExt, SessionHandler};
-# std::env::set_var("TRILLIUM_SESSION_SECRET", "this is just for testing and you should not do this");
-let session_secret = std::env::var("TRILLIUM_SESSION_SECRET").unwrap();
-
-let handler = (
-    CookiesHandler::new(),
-    SessionHandler::new(MemoryStore::new(), session_secret.as_bytes()),
-    |conn: Conn| async move {
-        let count: usize = conn.session().get("count").unwrap_or_default();
-        conn.with_session("count", count + 1)
-            .ok(format!("count: {}", count))
-    },
-);
-
-use trillium_testing::prelude::*;
-let mut conn = get("/").on(&handler);
-assert_ok!(&mut conn, "count: 0");
-
-let set_cookie_header = conn.response_headers().get_str("set-cookie").unwrap();
-let cookie = Cookie::parse_encoded(set_cookie_header).unwrap();
-
-let make_request = || get("/")
-    .with_request_header("cookie", format!("{}={}", cookie.name(), cookie.value()))
-    .on(&handler);
-
-assert_ok!(make_request(), "count: 1");
-assert_ok!(make_request(), "count: 2");
-assert_ok!(make_request(), "count: 3");
-assert_ok!(make_request(), "count: 4");
-```
-*/
-
+//! # Trillium sessions
+//!
+//! Trillium sessions is built on top of
+//! [`async-session`](https://github.com/http-rs/async-session).
+//!
+//! Sessions allows trillium to securely attach data to a browser session
+//! allowing for retrieval and modification of this data within trillium
+//! on subsequent visits. Session data is generally only retained for the
+//! duration of a browser session.
+//!
+//! Trillium's session implementation provides guest sessions by default,
+//! meaning that all web requests to a session-enabled trillium host will
+//! have a cookie attached, whether or not there is anything stored in
+//! that client's session yet.
+//!
+//! ## Stores
+//!
+//! Although this crate provides two bundled session stores, it is highly
+//! recommended that trillium applications use an
+//! external-datastore-backed session storage. For a list of currently
+//! available session stores, see [the documentation for
+//! async-session](https://github.com/http-rs/async-session).
+//!
+//! ## Security
+//!
+//! Although each session store may have different security implications,
+//! the general approach of trillium's session system is as follows: On
+//! each request, trillium checks the cookie configurable as `cookie_name`
+//! on the handler.
+//!
+//! ### If no cookie is found:
+//!
+//! A cryptographically random cookie value is generated. A cookie is set
+//! on the outbound response and signed with an HKDF key derived from the
+//! `secret` provided on creation of the SessionHandler.  The configurable
+//! session store uses a SHA256 digest of the cookie value and stores the
+//! session along with a potential expiry.
+//!
+//! ### If a cookie is found:
+//!
+//! The hkdf derived signing key is used to verify the cookie value's
+//! signature. If it verifies, it is then passed to the session store to
+//! retrieve a Session. For most session stores, this will involve taking
+//! a SHA256 digest of the cookie value and retrieving a serialized
+//! Session from an external datastore based on that digest.
+//!
+//! ### Expiry
+//!
+//! In addition to setting an expiry on the session cookie, trillium
+//! sessions include the same expiry in their serialization format. If an
+//! adversary were able to tamper with the expiry of a cookie, trillium
+//! sessions would still check the expiry on the contained session before
+//! using it
+//!
+//! ### If anything goes wrong with the above process
+//!
+//! If there are any failures in the above session retrieval process, a
+//! new empty session is generated for the request, which proceeds through
+//! the application as normal.
+//!
+//! ## Stale/expired session cleanup
+//!
+//! Any session store other than the cookie store will accumulate stale
+//! sessions.  Although the trillium session handler ensures that they
+//! will not be used as valid sessions, For most session stores, it is the
+//! trillium application's responsibility to call cleanup on the session
+//! store if it requires it
+//!
+//! ```
+//! use trillium::Conn;
+//! use trillium_cookies::{cookie::Cookie, CookiesHandler};
+//! use trillium_sessions::{MemoryStore, SessionConnExt, SessionHandler};
+//! # std::env::set_var(
+//! #    "TRILLIUM_SESSION_SECRET",
+//! #     "this is just for testing and you should not do this",
+//! # );
+//! let session_secret = std::env::var("TRILLIUM_SESSION_SECRET").unwrap();
+//!
+//! let handler = (
+//!     CookiesHandler::new(),
+//!     SessionHandler::new(MemoryStore::new(), session_secret.as_bytes()),
+//!     |conn: Conn| async move {
+//!         let count: usize = conn.session().get("count").unwrap_or_default();
+//!         conn.with_session("count", count + 1)
+//!             .ok(format!("count: {}", count))
+//!     },
+//! );
+//!
+//! use trillium_testing::prelude::*;
+//! let mut conn = get("/").on(&handler);
+//! assert_ok!(&mut conn, "count: 0");
+//!
+//! let set_cookie_header = conn.response_headers().get_str("set-cookie").unwrap();
+//! let cookie = Cookie::parse_encoded(set_cookie_header).unwrap();
+//!
+//! let make_request = || {
+//!     get("/")
+//!         .with_request_header("cookie", format!("{}={}", cookie.name(), cookie.value()))
+//!         .on(&handler)
+//! };
+//!
+//! assert_ok!(make_request(), "count: 1");
+//! assert_ok!(make_request(), "count: 2");
+//! assert_ok!(make_request(), "count: 3");
+//! assert_ok!(make_request(), "count: 4");
+//! ```
 mod session_conn_ext;
 pub use session_conn_ext::SessionConnExt;
 

--- a/sessions/src/session_conn_ext.rs
+++ b/sessions/src/session_conn_ext.rs
@@ -1,27 +1,19 @@
 use async_session::{serde::Serialize, Session};
 use trillium::Conn;
 
-/**
-extension trait to add session support to [`Conn`]
-
-[`SessionHandler`](crate::SessionHandler) **MUST** be called on the
-conn prior to using any of these functions.
-*/
+/// extension trait to add session support to [`Conn`]
+///
+/// [`SessionHandler`](crate::SessionHandler) **MUST** be called on the
+/// conn prior to using any of these functions.
 pub trait SessionConnExt {
-    /**
-    append a key-value pair to the current session, where the key is a
-    &str and the value is anything serde-serializable.
-    */
+    /// append a key-value pair to the current session, where the key is a
+    /// &str and the value is anything serde-serializable.
     fn with_session(self, key: &str, value: impl Serialize) -> Self;
 
-    /**
-    retrieve a reference to the current session
-    */
+    /// retrieve a reference to the current session
     fn session(&self) -> &Session;
 
-    /**
-    retrieve a mutable reference to the current session
-    */
+    /// retrieve a mutable reference to the current session
     fn session_mut(&mut self) -> &mut Session;
 }
 

--- a/sessions/src/session_handler.rs
+++ b/sessions/src/session_handler.rs
@@ -16,13 +16,10 @@ use trillium_cookies::{
     CookiesConnExt,
 };
 
-/**
-# Handler to enable sessions.
-
-See crate-level docs for an overview of this crate's approach to
-sessions and security.
-*/
-
+/// # Handler to enable sessions.
+///
+/// See crate-level docs for an overview of this crate's approach to
+/// sessions and security.
 pub struct SessionHandler<Store> {
     store: Store,
     cookie_path: String,
@@ -52,57 +49,59 @@ impl<Store: SessionStore> Debug for SessionHandler<Store> {
 }
 
 impl<Store: SessionStore> SessionHandler<Store> {
-    /**
-    Constructs a SessionHandler from the given
-    [`async_session::SessionStore`] and secret. The `secret` MUST be
-    at least 32 bytes long, and MUST be cryptographically random to be
-    secure. It is recommended to retrieve this at runtime from the
-    environment instead of compiling it into your application.
-
-    # Panics
-
-    SessionHandler::new will panic if the secret is fewer than
-    32 bytes.
-
-    # Defaults
-
-    The defaults for SessionHandler are:
-    * cookie path: "/"
-    * cookie name: "trillium.sid"
-    * session ttl: one day
-    * same site: strict
-    * save unchanged: enabled
-    * older secrets: none
-
-    # Customization
-
-    Although the above defaults are appropriate for most applications,
-    they can be overridden. Please be careful changing these settings,
-    as they can weaken your application's security:
-
-    ```rust
-    # use std::time::Duration;
-    # use trillium_sessions::{SessionHandler, MemoryStore};
-    # use trillium_cookies::{CookiesHandler, cookie::SameSite};
-    # std::env::set_var("TRILLIUM_SESSION_SECRETS", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-    // this logic will be unique to your deployment
-    let secrets_var = std::env::var("TRILLIUM_SESSION_SECRETS").unwrap();
-    let session_secrets = secrets_var.split(' ').collect::<Vec<_>>();
-
-    let handler = (
-        CookiesHandler::new(),
-        SessionHandler::new(MemoryStore::new(), session_secrets[0])
-            .with_cookie_name("custom.cookie.name")
-            .with_cookie_path("/some/path")
-            .with_cookie_domain("trillium.rs")
-            .with_same_site_policy(SameSite::Strict)
-            .with_session_ttl(Some(Duration::from_secs(1)))
-            .with_older_secrets(&session_secrets[1..])
-            .without_save_unchanged()
-    );
-
-    ```
-    */
+    /// Constructs a SessionHandler from the given
+    /// [`async_session::SessionStore`] and secret.
+    ///
+    /// The `secret` MUST be at least 32 bytes long, and MUST be cryptographically random to be
+    /// secure. It is recommended to retrieve this at runtime from the environment instead of
+    /// compiling it into your application.
+    ///
+    /// # Panics
+    ///
+    /// `SessionHandler::new` will panic if the secret is fewer than 32 bytes.
+    ///
+    /// # Defaults
+    ///
+    /// The defaults for `SessionHandler` are:
+    ///
+    /// * cookie path: "/"
+    /// * cookie name: "trillium.sid"
+    /// * session ttl: one day
+    /// * same site: strict
+    /// * save unchanged: enabled
+    /// * older secrets: none
+    ///
+    /// # Customization
+    ///
+    /// Although the above defaults are appropriate for most applications, they can be
+    /// overridden. Please be careful changing these settings, as they can weaken your application's
+    /// security:
+    ///
+    /// ```rust
+    /// # use std::time::Duration;
+    /// # let secrets = concat!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ",
+    /// #     "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    /// # std::env::set_var("TRILLIUM_SESSION_SECRETS", secrets);
+    ///
+    /// use trillium_cookies::{cookie::SameSite, CookiesHandler};
+    /// use trillium_sessions::{MemoryStore, SessionHandler};
+    ///
+    /// // this logic will be unique to your deployment
+    /// let secrets_var = std::env::var("TRILLIUM_SESSION_SECRETS").unwrap();
+    /// let session_secrets = secrets_var.split(' ').collect::<Vec<_>>();
+    ///
+    /// let handler = (
+    ///     CookiesHandler::new(),
+    ///     SessionHandler::new(MemoryStore::new(), session_secrets[0])
+    ///         .with_cookie_name("custom.cookie.name")
+    ///         .with_cookie_path("/some/path")
+    ///         .with_cookie_domain("trillium.rs")
+    ///         .with_same_site_policy(SameSite::Strict)
+    ///         .with_session_ttl(Some(Duration::from_secs(1)))
+    ///         .with_older_secrets(&session_secrets[1..])
+    ///         .without_save_unchanged(),
+    /// );
+    /// ```
     pub fn new(store: Store, secret: impl AsRef<[u8]>) -> Self {
         Self {
             store,
@@ -124,11 +123,12 @@ impl<Store: SessionStore> SessionHandler<Store> {
         self
     }
 
-    /// Sets a session ttl. This will be used both for the cookie
-    /// expiry and also for the session-internal expiry.
+    /// Sets a session ttl.
     ///
-    /// The default for this value is one day. Set this to None to not
-    /// set a cookie or session expiry. This is not recommended.
+    /// This will be used both for the cookie expiry and also for the session-internal expiry.
+    ///
+    /// The default for this value is one day. Set this to None to not set a cookie or session
+    /// expiry. This is not recommended.
     pub fn with_session_ttl(mut self, session_ttl: Option<Duration>) -> Self {
         self.session_ttl = session_ttl;
         self
@@ -136,30 +136,28 @@ impl<Store: SessionStore> SessionHandler<Store> {
 
     /// Sets the name of the cookie that the session is stored with or in.
     ///
-    /// If you are running multiple trillium applications on the same
-    /// domain, you will need different values for each
-    /// application. The default value is "trillium.sid"
+    /// If you are running multiple trillium applications on the same domain, you will need
+    /// different values for each application. The default value is "trillium.sid"
     pub fn with_cookie_name(mut self, cookie_name: impl AsRef<str>) -> Self {
         cookie_name.as_ref().clone_into(&mut self.cookie_name);
         self
     }
 
-    /// Disables the `save_unchanged` setting. When `save_unchanged`
-    /// is enabled, a session will cookie will always be set. With
-    /// `save_unchanged` disabled, the session data must be modified
-    /// from the `Default` value in order for it to save. If a session
-    /// already exists and its data unmodified in the course of a
-    /// request, the session will only be persisted if
-    /// `save_unchanged` is enabled.
+    /// Disables the `save_unchanged` setting.
+    ///
+    /// When `save_unchanged` is enabled, a session will cookie will always be set. With
+    /// `save_unchanged` disabled, the session data must be modified from the `Default` value in
+    /// order for it to save. If a session already exists and its data unmodified in the course of a
+    /// request, the session will only be persisted if `save_unchanged` is enabled.
     pub fn without_save_unchanged(mut self) -> Self {
         self.save_unchanged = false;
         self
     }
 
-    /// Sets the same site policy for the session cookie. Defaults to
-    /// SameSite::Strict. See [incrementally better
-    /// cookies](https://tools.ietf.org/html/draft-west-cookie-incrementalism-01)
-    /// for more information about this setting
+    /// Sets the same site policy for the session cookie. Defaults to SameSite::Strict. See
+    /// [incrementally better
+    /// cookies](https://tools.ietf.org/html/draft-west-cookie-incrementalism-01) for more
+    /// information about this setting
     pub fn with_same_site_policy(mut self, policy: SameSite) -> Self {
         self.same_site_policy = policy;
         self
@@ -171,9 +169,8 @@ impl<Store: SessionStore> SessionHandler<Store> {
         self
     }
 
-    /// Sets optional older signing keys that will not be used to sign
-    /// cookies, but can be used to validate previously signed
-    /// cookies.
+    /// Sets optional older signing keys that will not be used to sign cookies, but can be used to
+    /// validate previously signed cookies.
     pub fn with_older_secrets(mut self, secrets: &[impl AsRef<[u8]>]) -> Self {
         self.older_keys = secrets
             .iter()
@@ -236,11 +233,11 @@ impl<Store: SessionStore> SessionHandler<Store> {
         cookie.set_value(new_value);
     }
 
-    // the following is reused verbatim from
+    // the following is based on
     // https://github.com/SergioBenitez/cookie-rs/blob/master/src/secure/signed.rs#L51-L66
-    /// Given a signed value `str` where the signature is prepended to `value`,
-    /// verifies the signed value and returns it. If there's a problem, returns
-    /// an `Err` with a string describing the issue.
+    /// Given a signed value `str` where the signature is prepended to `value`, verifies the signed
+    /// value and returns it. If there's a problem, returns an `Err` with a string describing the
+    /// issue.
     fn verify_signature<'a>(&self, cookie_value: &'a str) -> Option<&'a str> {
         if cookie_value.len() < BASE64_DIGEST_LEN {
             log::trace!("length of value is <= BASE64_DIGEST_LEN");

--- a/smol/src/client.rs
+++ b/smol/src/client.rs
@@ -6,9 +6,7 @@ use trillium_server_common::{
     Connector, Transport,
 };
 
-/**
-configuration for the tcp Connector
-*/
+/// configuration for the tcp Connector
 #[derive(Default, Debug, Clone, Copy)]
 pub struct ClientConfig {
     /// disable [nagle's algorithm](https://en.wikipedia.org/wiki/Nagle%27s_algorithm)

--- a/smol/src/lib.rs
+++ b/smol/src/lib.rs
@@ -8,56 +8,48 @@
     unused_qualifications
 )]
 
-/*!
-# Trillium adapter using smol and async-global-executor
-
-## Default / 12-factor applications
-
-```rust,no_run
-trillium_smol::run(|conn: trillium::Conn| async move {
-    conn.ok("hello smol")
-});
-```
-
-## Server configuration
-
-For more details, see [trillium_smol::config](crate::config).
-
-```rust
-let swansong = trillium_smol::Swansong::new();
-# swansong.shut_down(); // stoppping the server immediately for the test
-trillium_smol::config()
-    .with_port(0)
-    .with_host("127.0.0.1")
-    .without_signals()
-    .with_nodelay()
-    .with_acceptor(()) // see [`trillium_rustls`] and [`trillium_native_tls`]
-    .with_swansong(swansong)
-    .run(|conn: trillium::Conn| async move {
-        conn.ok("hello smol")
-    });
-```
-
-## Client
-
-```rust
-# #[cfg(feature = "smol")]
-trillium_testing::with_server("ok", |url| async move {
-    use trillium_smol::TcpConnector;
-    use trillium_client::{Conn, Client};
-    let mut conn = Conn::<TcpConnector>::get(url.clone()).execute().await?;
-    assert_eq!(conn.response_body().read_string().await?, "ok");
-
-    let client = Client::<TcpConnector>::new().with_default_pool();
-    let mut conn = client.get(url);
-    conn.send().await?;
-    assert_eq!(conn.response_body().read_string().await?, "ok");
-    Ok(())
-});
-```
-
-
-*/
+//! # Trillium adapter using smol and async-global-executor
+//!
+//! ## Default / 12-factor applications
+//!
+//! ```rust,no_run
+//! trillium_smol::run(|conn: trillium::Conn| async move { conn.ok("hello smol") });
+//! ```
+//!
+//! ## Server configuration
+//!
+//! For more details, see [trillium_smol::config](crate::config).
+//!
+//! ```rust
+//! let swansong = trillium_smol::Swansong::new();
+//! # swansong.shut_down(); // stoppping the server immediately for the test
+//! trillium_smol::config()
+//!     .with_port(0)
+//!     .with_host("127.0.0.1")
+//!     .without_signals()
+//!     .with_nodelay()
+//!     .with_acceptor(()) // see [`trillium_rustls`] and [`trillium_native_tls`]
+//!     .with_swansong(swansong)
+//!     .run(|conn: trillium::Conn| async move { conn.ok("hello smol") });
+//! ```
+//!
+//! ## Client
+//!
+//! ```rust
+//! # #[cfg(feature = "smol")]
+//! trillium_testing::with_server("ok", |url| async move {
+//!     use trillium_client::{Client, Conn};
+//!     use trillium_smol::TcpConnector;
+//!     let mut conn = Conn::<TcpConnector>::get(url.clone()).execute().await?;
+//!     assert_eq!(conn.response_body().read_string().await?, "ok");
+//!
+//!     let client = Client::<TcpConnector>::new().with_default_pool();
+//!     let mut conn = client.get(url);
+//!     conn.send().await?;
+//!     assert_eq!(conn.response_body().read_string().await?, "ok");
+//!     Ok(())
+//! });
+//! ```
 
 use trillium::Handler;
 pub use trillium_server_common::{Binding, Connector, Runtime, RuntimeTrait, Swansong};
@@ -77,68 +69,58 @@ pub use transport::SmolTransport;
 mod runtime;
 pub use runtime::SmolRuntime;
 
-/**
-# Runs a trillium handler in a sync context with default config
-
-Runs a trillium handler on the async-global-executor runtime with
-default configuration. See [`crate::config`] for what the defaults are
-and how to override them
-
-
-This function will block the current thread until the server shuts
-down
-*/
+/// # Runs a trillium handler in a sync context with default config
+///
+/// Runs a trillium handler on the async-global-executor runtime with
+/// default configuration. See [`crate::config`] for what the defaults are
+/// and how to override them
+///
+///
+/// This function will block the current thread until the server shuts
+/// down
 pub fn run(handler: impl Handler) {
     config().run(handler)
 }
 
-/**
-# Runs a trillium handler in an async context with default config
-
-Run the provided trillium handler on an already-running async-executor
-with default settings. The defaults are the same as [`crate::run`]. To
-customize these settings, see [`crate::config`].
-
-This function will poll pending until the server shuts down.
-
-*/
+/// # Runs a trillium handler in an async context with default config
+///
+/// Run the provided trillium handler on an already-running async-executor
+/// with default settings. The defaults are the same as [`crate::run`]. To
+/// customize these settings, see [`crate::config`].
+///
+/// This function will poll pending until the server shuts down.
 pub async fn run_async(handler: impl Handler) {
     config().run_async(handler).await
 }
 
-/**
-# Configures a server before running it
-
-## Defaults
-
-The default configuration is as follows:
-
-* port: the contents of the `PORT` env var or else 8080
-* host: the contents of the `HOST` env var or else "localhost"
-* signals handling and graceful shutdown: enabled on cfg(unix) systems
-* tcp nodelay: disabled
-* tls acceptor: none
-
-## Usage
-
-```rust
-let swansong = trillium_smol::Swansong::new();
-# swansong.shut_down(); // stoppping the server immediately for the test
-trillium_smol::config()
-    .with_port(0)
-    .with_host("127.0.0.1")
-    .without_signals()
-    .with_nodelay()
-    .with_acceptor(()) // see [`trillium_rustls`] and [`trillium_native_tls`]
-    .with_swansong(swansong)
-    .run(|conn: trillium::Conn| async move {
-        conn.ok("hello smol")
-    });
-```
-
-See [`trillium_server_common::Config`] for more details
-
-*/
+/// # Configures a server before running it
+///
+/// ## Defaults
+///
+/// The default configuration is as follows:
+///
+/// port: the contents of the `PORT` env var or else 8080
+/// host: the contents of the `HOST` env var or else "localhost"
+/// signals handling and graceful shutdown: enabled on cfg(unix) systems
+/// tcp nodelay: disabled
+/// tls acceptor: none
+///
+/// ## Usage
+///
+/// ```rust
+/// let swansong = trillium_smol::Swansong::new();
+/// # swansong.shut_down(); // stoppping the server immediately for the test
+/// trillium_smol::config()
+///     .with_port(0)
+///     .with_host("127.0.0.1")
+///     .without_signals()
+///     .with_nodelay()
+///     .with_acceptor(()) // see [`trillium_rustls`] and [`trillium_native_tls`]
+///     .with_swansong(swansong)
+///     .run(|conn: trillium::Conn| async move { conn.ok("hello smol") });
+/// ```
+///
+/// See [`trillium_server_common::Config`] for more details
 pub fn config() -> Config<()> {
     Config::new()
 }

--- a/sse/src/lib.rs
+++ b/sse/src/lib.rs
@@ -1,60 +1,57 @@
-/*!
-# Trillium tools for server sent events
-
-This primarily provides [`SseConnExt`](crate::SseConnExt), an
-extension trait for [`trillium::Conn`] that has a
-[`with_sse_stream`](crate::SseConnExt::with_sse_stream) chainable
-method that takes a [`Stream`](futures_lite::Stream) where the `Item`
-implements [`Eventable`].
-
-Often, you will want this stream to be something like a channel, but
-the specifics of that are dependent on the event fanout
-characteristics of your application.
-
-This crate implements [`Eventable`] for an [`Event`] type that you can
-use in your application, for `String`, and for `&'static str`. You can
-also implement [`Eventable`] for any type in your application.
-
-## Example usage
-
-```
-use broadcaster::BroadcastChannel;
-use trillium::{conn_try, conn_unwrap, log_error, Conn, Method, State};
-use trillium_sse::SseConnExt;
-use trillium_static_compiled::static_compiled;
-
-type Channel = BroadcastChannel<String>;
-
-fn get_sse(mut conn: Conn) -> Conn {
-    let broadcaster = conn_unwrap!(conn.take_state::<Channel>(), conn);
-    conn.with_sse_stream(broadcaster)
-}
-
-async fn post_broadcast(mut conn: Conn) -> Conn {
-    let broadcaster = conn_unwrap!(conn.take_state::<Channel>(), conn);
-    let body = conn_try!(conn.request_body_string().await, conn);
-    log_error!(broadcaster.send(&body).await);
-    conn.ok("sent")
-}
-
-fn main() {
-    let handler = (
-        static_compiled!("examples/static").with_index_file("index.html"),
-        State::new(Channel::new()),
-        |conn: Conn| async move {
-            match (conn.method(), conn.path()) {
-                (Method::Get, "/sse") => get_sse(conn),
-                (Method::Post, "/broadcast") => post_broadcast(conn).await,
-                _ => conn,
-            }
-        },
-    );
-
-    // trillium_smol::run(handler);
-}
-
-```
-*/
+//! # Trillium tools for server sent events
+//!
+//! This primarily provides [`SseConnExt`](crate::SseConnExt), an
+//! extension trait for [`trillium::Conn`] that has a
+//! [`with_sse_stream`](crate::SseConnExt::with_sse_stream) chainable
+//! method that takes a [`Stream`](futures_lite::Stream) where the `Item`
+//! implements [`Eventable`].
+//!
+//! Often, you will want this stream to be something like a channel, but
+//! the specifics of that are dependent on the event fanout
+//! characteristics of your application.
+//!
+//! This crate implements [`Eventable`] for an [`Event`] type that you can
+//! use in your application, for `String`, and for `&'static str`. You can
+//! also implement [`Eventable`] for any type in your application.
+//!
+//! ## Example usage
+//!
+//! ```
+//! use broadcaster::BroadcastChannel;
+//! use trillium::{conn_try, conn_unwrap, log_error, Conn, Method, State};
+//! use trillium_sse::SseConnExt;
+//! use trillium_static_compiled::static_compiled;
+//!
+//! type Channel = BroadcastChannel<String>;
+//!
+//! fn get_sse(mut conn: Conn) -> Conn {
+//!     let broadcaster = conn_unwrap!(conn.take_state::<Channel>(), conn);
+//!     conn.with_sse_stream(broadcaster)
+//! }
+//!
+//! async fn post_broadcast(mut conn: Conn) -> Conn {
+//!     let broadcaster = conn_unwrap!(conn.take_state::<Channel>(), conn);
+//!     let body = conn_try!(conn.request_body_string().await, conn);
+//!     log_error!(broadcaster.send(&body).await);
+//!     conn.ok("sent")
+//! }
+//!
+//! fn main() {
+//!     let handler = (
+//!         static_compiled!("examples/static").with_index_file("index.html"),
+//!         State::new(Channel::new()),
+//!         |conn: Conn| async move {
+//!             match (conn.method(), conn.path()) {
+//!                 (Method::Get, "/sse") => get_sse(conn),
+//!                 (Method::Post, "/broadcast") => post_broadcast(conn).await,
+//!                 _ => conn,
+//!             }
+//!         },
+//!     );
+//!
+//!     // trillium_smol::run(handler);
+//! }
+//! ```
 #![forbid(unsafe_code)]
 #![deny(
     missing_copy_implementations,
@@ -161,18 +158,14 @@ where
     }
 }
 
-/**
-Extension trait for server sent events
-*/
+/// Extension trait for server sent events
 pub trait SseConnExt {
-    /**
-    builds and sets a streaming response body that conforms to the
-    [server-sent-events
-    spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events)
-    from a Stream of any [`Eventable`](crate::Eventable) type (such as
-    [`Event`](crate::Event), as well as setting appropiate headers for
-    this response.
-    */
+    /// builds and sets a streaming response body that conforms to the
+    /// [server-sent-events
+    /// spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events)
+    /// from a Stream of any [`Eventable`](crate::Eventable) type (such as
+    /// [`Event`](crate::Event), as well as setting appropiate headers for
+    /// this response.
     fn with_sse_stream<S, E>(self, sse_stream: S) -> Self
     where
         S: Stream<Item = E> + Unpin + Send + Sync + 'static,
@@ -194,12 +187,10 @@ impl SseConnExt for Conn {
     }
 }
 
-/**
-A trait that allows any Unpin + Send + Sync type to act as an event.
-
-For a concrete implementation of this trait, you can use [`Event`],
-but it is also implemented for [`String`] and [`&'static str`].
-*/
+/// A trait that allows any Unpin + Send + Sync type to act as an event.
+///
+/// For a concrete implementation of this trait, you can use [`Event`],
+/// but it is also implemented for [`String`] and [`&'static str`].
 
 pub trait Eventable: Unpin + Send + Sync + 'static {
     /// return the data for this event. non-optional.
@@ -238,9 +229,7 @@ impl Eventable for String {
     }
 }
 
-/**
-Events are a concrete implementation of the [`Eventable`] trait.
-*/
+/// Events are a concrete implementation of the [`Eventable`] trait.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Event {
     data: Cow<'static, str>,
@@ -269,40 +258,34 @@ impl From<Cow<'static, str>> for Event {
 }
 
 impl Event {
-    /**
-    builds a new [`Event`]
-
-    by default, this event has no event type. to set an event type,
-    use [`Event::with_type`] or [`Event::set_type`]
-    */
+    /// builds a new [`Event`]
+    ///
+    /// by default, this event has no event type. to set an event type,
+    /// use [`Event::with_type`] or [`Event::set_type`]
     pub fn new(data: impl Into<Cow<'static, str>>) -> Self {
         Self::from(data.into())
     }
 
-    /**
-    chainable constructor to set the type on an event
-
-    ```
-    let event = trillium_sse::Event::new("event data").with_type("userdata");
-    assert_eq!(event.event_type(), Some("userdata"));
-    assert_eq!(event.data(), "event data");
-    ```
-    */
+    /// chainable constructor to set the type on an event
+    ///
+    /// ```
+    /// let event = trillium_sse::Event::new("event data").with_type("userdata");
+    /// assert_eq!(event.event_type(), Some("userdata"));
+    /// assert_eq!(event.data(), "event data");
+    /// ```
     pub fn with_type(mut self, event_type: impl Into<Cow<'static, str>>) -> Self {
         self.set_type(event_type);
         self
     }
 
-    /**
-    set the event type for this Event. The default is None.
-
-    ```
-    let mut event = trillium_sse::Event::new("event data");
-    assert_eq!(event.event_type(), None);
-    event.set_type("userdata");
-    assert_eq!(event.event_type(), Some("userdata"));
-    ```
-     */
+    /// set the event type for this Event. The default is None.
+    ///
+    /// ```
+    /// let mut event = trillium_sse::Event::new("event data");
+    /// assert_eq!(event.event_type(), None);
+    /// event.set_type("userdata");
+    /// assert_eq!(event.event_type(), Some("userdata"));
+    /// ```
     pub fn set_type(&mut self, event_type: impl Into<Cow<'static, str>>) {
         self.event_type = Some(event_type.into());
     }

--- a/static-compiled-macros/src/lib.rs
+++ b/static-compiled-macros/src/lib.rs
@@ -1,19 +1,17 @@
-/*!
-Internal-use fork of
-[`include_dir_macros`](https://docs.rs/include_dir_macros/) for
-[`trillium.rs`](https://trillium.rs). It is not intended for general
-use. Credit for the bulk of the code goes to the authors of the
-upstream crate.
-
-Differences from upstream:
-
-* include_entry was added, which returns a DirEntry instead of a Dir,
-  making direct inclusion of files possible
-* Metadata is always enabled
-* relative paths are resolved from a root of CARGO_MANIFEST_DIR
-* hygiene is maintained by using a macro_rules macro to import
-  relevant structs
-*/
+//! Internal-use fork of
+//! [`include_dir_macros`](https://docs.rs/include_dir_macros/) for
+//! [`trillium.rs`](https://trillium.rs). It is not intended for general
+//! use. Credit for the bulk of the code goes to the authors of the
+//! upstream crate.
+//!
+//! Differences from upstream:
+//!
+//! include_entry was added, which returns a DirEntry instead of a Dir,
+//! making direct inclusion of files possible
+//! Metadata is always enabled
+//! relative paths are resolved from a root of CARGO_MANIFEST_DIR
+//! hygiene is maintained by using a macro_rules macro to import
+//! relevant structs
 
 use proc_macro::{TokenStream, TokenTree};
 use proc_macro2::Literal;

--- a/static-compiled/src/lib.rs
+++ b/static-compiled/src/lib.rs
@@ -9,85 +9,77 @@
     unused_qualifications
 )]
 
-/*!
-Serves static file assets from memory, as included in the binary at
-compile time. Because this includes file system content at compile
-time, it requires a macro interface, [`static_compiled`](crate::static_compiled).
-
-If the root is a directory, it will recursively serve any files
-relative to the path that this handler is mounted at, or an index file
-if one is configured with
-[`with_index_file`](crate::StaticCompiledHandler::with_index_file).
-
-If the root is a file, it will serve that file at all request paths.
-
-This crate contains code from [`include_dir`][include_dir], but with
-several tweaks to make it more suitable for this specific use case.
-
-[include_dir]:https://docs.rs/include_dir/latest/include_dir/
-
-```
-# #[cfg(not(unix))] fn main() {}
-# #[cfg(unix)] fn main() {
-use trillium_static_compiled::static_compiled;
-
-let handler = static_compiled!("./examples/files")
-    .with_index_file("index.html");
-
-// given the following directory layout
-//
-// examples/files
-// ├── index.html
-// ├── subdir
-// │  └── index.html
-// └── subdir_with_no_index
-//    └── plaintext.txt
-//
-
-use trillium_testing::prelude::*;
-
-assert_ok!(
-    get("/").on(&handler),
-    "<html>\n  <head>\n    <script src=\"/js.js\"></script>\n  </head>\n  <body>\n    <h1>hello world</h1>\n  </body>\n</html>",
-    "content-type" => "text/html"
-);
-assert_not_handled!(get("/file_that_does_not_exist.txt").on(&handler));
-assert_ok!(get("/index.html").on(&handler));
-assert_ok!(
-    get("/subdir/index.html").on(&handler),
-    "subdir index.html 🎈",
-    "content-type" => "text/html; charset=utf-8"
-);
-assert_ok!(get("/subdir").on(&handler), "subdir index.html 🎈");
-assert_not_handled!(get("/subdir_with_no_index").on(&handler));
-assert_ok!(
-    get("/subdir_with_no_index/plaintext.txt").on(&handler),
-    "plaintext file",
-    "content-type" => "text/plain"
-);
-
-
-// with a different index file
-let plaintext_index = static_compiled!("./examples/files")
-    .with_index_file("plaintext.txt");
-
-assert_not_handled!(get("/").on(&plaintext_index));
-assert_not_handled!(get("/subdir").on(&plaintext_index));
-assert_ok!(
-    get("/subdir_with_no_index").on(&plaintext_index),
-    "plaintext file",
-    "content-type" => "text/plain"
-);
-
-// with no index file
-let no_index = static_compiled!("./examples/files");
-
-assert_not_handled!(get("/").on(&no_index));
-assert_not_handled!(get("/subdir").on(&no_index));
-assert_not_handled!(get("/subdir_with_no_index").on(&no_index));
-# }
-```
-*/
+//! Serves static file assets from memory, as included in the binary at
+//! compile time. Because this includes file system content at compile
+//! time, it requires a macro interface, [`static_compiled`](crate::static_compiled).
+//!
+//! If the root is a directory, it will recursively serve any files
+//! relative to the path that this handler is mounted at, or an index file
+//! if one is configured with
+//! [`with_index_file`](crate::StaticCompiledHandler::with_index_file).
+//!
+//! If the root is a file, it will serve that file at all request paths.
+//!
+//! This crate contains code from [`include_dir`][include_dir], but with
+//! several tweaks to make it more suitable for this specific use case.
+//!
+//! [include_dir]:https://docs.rs/include_dir/latest/include_dir/
+//!
+//! ```
+//! use trillium_static_compiled::static_compiled;
+//!
+//! let handler = static_compiled!("./examples/files").with_index_file("index.html");
+//!
+//! // given the following directory layout
+//! //
+//! // examples/files
+//! // ├── index.html
+//! // ├── subdir
+//! // │  └── index.html
+//! // └── subdir_with_no_index
+//! //    └── plaintext.txt
+//!
+//! use trillium_testing::prelude::*;
+//!
+//! let index = include_str!("../examples/files/index.html");
+//! assert_ok!(
+//!     get("/").on(&handler),
+//!     index,
+//!     "content-type" => "text/html"
+//! );
+//! assert_not_handled!(get("/file_that_does_not_exist.txt").on(&handler));
+//! assert_ok!(get("/index.html").on(&handler));
+//! assert_ok!(
+//!     get("/subdir/index.html").on(&handler),
+//!     "subdir index.html 🎈",
+//!     "content-type" => "text/html; charset=utf-8"
+//! );
+//! assert_ok!(get("/subdir").on(&handler), "subdir index.html 🎈");
+//! assert_not_handled!(get("/subdir_with_no_index").on(&handler));
+//! assert_ok!(
+//!     get("/subdir_with_no_index/plaintext.txt").on(&handler),
+//!     "plaintext file",
+//!     "content-type" => "text/plain"
+//! );
+//!
+//! // with a different index file
+//! let plaintext_index = static_compiled!("./examples/files").with_index_file("plaintext.txt");
+//!
+//! assert_not_handled!(get("/").on(&plaintext_index));
+//! assert_not_handled!(get("/subdir").on(&plaintext_index));
+//! assert_ok!(
+//!     get("/subdir_with_no_index").on(&plaintext_index),
+//!     "plaintext file",
+//!     "content-type" => "text/plain"
+//! );
+//!
+//! // with no index file
+//! let no_index = static_compiled!("./examples/files");
+//!
+//! assert_not_handled!(get("/").on(&no_index));
+//! assert_not_handled!(get("/subdir").on(&no_index));
+//! assert_not_handled!(get("/subdir_with_no_index").on(&no_index));
+//! ```
 
 use trillium::{
     Conn, Handler,
@@ -107,11 +99,8 @@ pub mod __macro_internals {
     pub use trillium_static_compiled_macros::{include_dir, include_entry};
 }
 
-/**
-The static compiled handler which contains the compile-time loaded
-assets
-
-*/
+/// The static compiled handler which contains the compile-time loaded
+/// assets
 #[derive(Debug, Clone, Copy)]
 pub struct StaticCompiledHandler {
     root: DirEntry,
@@ -203,36 +192,34 @@ impl Handler for StaticCompiledHandler {
     }
 }
 
-/**
-The preferred interface to build a StaticCompiledHandler
-
-Macro interface to build a
-[`StaticCompiledHandler`]. `static_compiled!("assets")` is
-identical to
-`StaticCompiledHandler::new(root!("assets"))`.
-
-This takes one argument, which must be a string literal.
-
-## Relative paths
-
-Relative paths are expanded and canonicalized relative to
-`$CARGO_MANIFEST_DIR`, which is usually the directory that contains
-your Cargo.toml. If compiled within a workspace, this will be the
-subcrate's Cargo.toml.
-
-## Environment variable expansion
-
-If the argument to `static_compiled` contains substrings that are
-formatted like an environment variable, beginning with a $, they will
-be interpreted in the compile time environment.
-
-For example "$OUT_DIR/some_directory" will expand to the directory
-`some_directory` within the env variable `$OUT_DIR` set by cargo. See
-[this link][env_vars] for further documentation on the environment
-variables set by cargo.
-
-[env_vars]:https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
-*/
+/// The preferred interface to build a StaticCompiledHandler
+///
+/// Macro interface to build a
+/// [`StaticCompiledHandler`]. `static_compiled!("assets")` is
+/// identical to
+/// `StaticCompiledHandler::new(root!("assets"))`.
+///
+/// This takes one argument, which must be a string literal.
+///
+/// ## Relative paths
+///
+/// Relative paths are expanded and canonicalized relative to
+/// `$CARGO_MANIFEST_DIR`, which is usually the directory that contains
+/// your Cargo.toml. If compiled within a workspace, this will be the
+/// subcrate's Cargo.toml.
+///
+/// ## Environment variable expansion
+///
+/// If the argument to `static_compiled` contains substrings that are
+/// formatted like an environment variable, beginning with a $, they will
+/// be interpreted in the compile time environment.
+///
+/// For example "$OUT_DIR/some_directory" will expand to the directory
+/// `some_directory` within the env variable `$OUT_DIR` set by cargo. See
+/// [this link][env_vars] for further documentation on the environment
+/// variables set by cargo.
+///
+/// [env_vars]:https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
 
 #[macro_export]
 macro_rules! static_compiled {
@@ -241,32 +228,29 @@ macro_rules! static_compiled {
     };
 }
 
-/**
-Include the path as root. To be passed into [`StaticCompiledHandler::new`].
-
-This takes one argument, which must be a string literal.
-
-## Relative paths
-
-Relative paths are expanded and canonicalized relative to
-`$CARGO_MANIFEST_DIR`, which is usually the directory that contains
-your Cargo.toml. If compiled within a workspace, this will be the
-subcrate's Cargo.toml.
-
-## Environment variable expansion
-
-If the argument to `static_compiled` contains substrings that are
-formatted like an environment variable, beginning with a $, they will
-be interpreted in the compile time environment.
-
-For example "$OUT_DIR/some_directory" will expand to the directory
-`some_directory` within the env variable `$OUT_DIR` set by cargo. See
-[this link][env_vars] for further documentation on the environment
-variables set by cargo.
-
-[env_vars]:https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
-
-*/
+/// Include the path as root. To be passed into [`StaticCompiledHandler::new`].
+///
+/// This takes one argument, which must be a string literal.
+///
+/// ## Relative paths
+///
+/// Relative paths are expanded and canonicalized relative to
+/// `$CARGO_MANIFEST_DIR`, which is usually the directory that contains
+/// your Cargo.toml. If compiled within a workspace, this will be the
+/// subcrate's Cargo.toml.
+///
+/// ## Environment variable expansion
+///
+/// If the argument to `static_compiled` contains substrings that are
+/// formatted like an environment variable, beginning with a $, they will
+/// be interpreted in the compile time environment.
+///
+/// For example "$OUT_DIR/some_directory" will expand to the directory
+/// `some_directory` within the env variable `$OUT_DIR` set by cargo. See
+/// [this link][env_vars] for further documentation on the environment
+/// variables set by cargo.
+///
+/// [env_vars]:https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
 #[macro_export]
 macro_rules! root {
     ($path:tt) => {{

--- a/static/src/handler.rs
+++ b/static/src/handler.rs
@@ -6,9 +6,7 @@ use crate::{
 use std::path::{Path, PathBuf};
 use trillium::{conn_unwrap, Conn, Handler};
 
-/**
-trillium handler to serve static files from the filesystem
-*/
+/// trillium handler to serve static files from the filesystem
 #[derive(Debug)]
 pub struct StaticFileHandler {
     fs_root: PathBuf,
@@ -67,32 +65,30 @@ impl StaticFileHandler {
         }
     }
 
-    /**
-    builds a new StaticFileHandler
-
-    If the fs_root is a file instead of a directory, that file will be served at all paths.
-
-    ```
-    # #[cfg(not(unix))] fn main() {}
-    # #[cfg(unix)] fn main() {
-    # use trillium::Handler;
-    # trillium_testing::block_on(async {
-    use trillium_static::{StaticFileHandler, crate_relative_path};
-    use trillium_testing::prelude::*;
-
-    let mut handler = StaticFileHandler::new(crate_relative_path!("examples/files"));
-    # handler.init(&mut "testing".into()).await;
-
-    assert_not_handled!(get("/").run_async(&handler).await); // no index file configured
-
-    assert_ok!(
-        get("/index.html").run_async(&handler).await,
-        "<h1>hello world</h1>",
-        "content-type" => "text/html; charset=utf-8"
-    );
-    # }); }
-    ```
-    */
+    /// builds a new StaticFileHandler
+    ///
+    /// If the fs_root is a file instead of a directory, that file will be served at all paths.
+    ///
+    /// ```
+    /// # #[cfg(not(unix))] fn main() {}
+    /// # #[cfg(unix)] fn main() {
+    /// # use trillium::Handler;
+    /// # trillium_testing::block_on(async {
+    /// use trillium_static::{StaticFileHandler, crate_relative_path};
+    /// use trillium_testing::prelude::*;
+    ///
+    /// let mut handler = StaticFileHandler::new(crate_relative_path!("examples/files"));
+    /// # handler.init(&mut "testing".into()).await;
+    ///
+    /// assert_not_handled!(get("/").run_async(&handler).await); // no index file configured
+    ///
+    /// assert_ok!(
+    /// get("/index.html").run_async(&handler).await,
+    /// "<h1>hello world</h1>",
+    /// "content-type" => "text/html; charset=utf-8"
+    /// );
+    /// # }); }
+    /// ```
     pub fn new(fs_root: impl AsRef<Path>) -> Self {
         let fs_root = fs_root.as_ref().canonicalize().unwrap();
         Self {
@@ -115,28 +111,26 @@ impl StaticFileHandler {
         self
     }
 
-    /**
-    sets the index file on this StaticFileHandler
-    ```
-    # #[cfg(not(unix))] fn main() {}
-    # #[cfg(unix)] fn main() {
-    # use trillium::Handler;
-    # trillium_testing::block_on(async {
-
-    use trillium_static::{StaticFileHandler, crate_relative_path};
-
-    let mut handler = StaticFileHandler::new(crate_relative_path!("examples/files"))
-        .with_index_file("index.html");
-    # handler.init(&mut "testing".into()).await;
-
-    use trillium_testing::prelude::*;
-    assert_ok!(
-        get("/").run_async(&handler).await,
-        "<h1>hello world</h1>", "content-type" => "text/html; charset=utf-8"
-    );
-    # }); }
-    ```
-    */
+    /// sets the index file on this StaticFileHandler
+    /// ```
+    /// # #[cfg(not(unix))] fn main() {}
+    /// # #[cfg(unix)] fn main() {
+    /// # use trillium::Handler;
+    /// # trillium_testing::block_on(async {
+    ///
+    /// use trillium_static::{StaticFileHandler, crate_relative_path};
+    ///
+    /// let mut handler = StaticFileHandler::new(crate_relative_path!("examples/files"))
+    /// .with_index_file("index.html");
+    /// # handler.init(&mut "testing".into()).await;
+    ///
+    /// use trillium_testing::prelude::*;
+    /// assert_ok!(
+    /// get("/").run_async(&handler).await,
+    /// "<h1>hello world</h1>", "content-type" => "text/html; charset=utf-8"
+    /// );
+    /// # }); }
+    /// ```
     pub fn with_index_file(mut self, file: &str) -> Self {
         self.index_file = Some(file.to_string());
         self

--- a/static/src/lib.rs
+++ b/static/src/lib.rs
@@ -9,83 +9,87 @@
     unused_qualifications
 )]
 
-/*!
-Serves static file assets from the file system.
-
-```
-# #[cfg(not(unix))] fn main() {}
-# #[cfg(unix)] fn main() {
-use trillium_static::{StaticFileHandler, crate_relative_path};
-
-# trillium_testing::block_on(async {
-
-let mut handler = StaticFileHandler::new(crate_relative_path!("examples/files"))
-    .with_index_file("index.html");
-
-
-// given the following directory layout
-//
-// examples/files
-// ├── index.html
-// ├── subdir
-// │  └── index.html
-// └── subdir_with_no_index
-//    └── plaintext.txt
-//
-
-
-use trillium_testing::prelude::*;
-# use trillium::Handler;
-
-handler.init(&mut "testing".into()).await;
-
-assert_ok!(
-    get("/").run_async(&handler).await,
-    "<h1>hello world</h1>",
-    "content-type" => "text/html; charset=utf-8"
-);
-assert_not_handled!(get("/file_that_does_not_exist.txt").run_async(&handler).await);
-assert_ok!(get("/index.html").run_async(&handler).await);
-assert_ok!(get("/subdir/index.html").run_async(&handler).await, "subdir index.html");
-assert_ok!(get("/subdir").run_async(&handler).await, "subdir index.html");
-assert_not_handled!(get("/subdir_with_no_index").run_async(&handler).await);
-assert_ok!(
-    get("/subdir_with_no_index/plaintext.txt").run_async(&handler).await,
-    "plaintext file",
-    "content-type" => "text/plain; charset=utf-8"
-);
-
-
-// with a different index file
-let plaintext_index = StaticFileHandler::new(crate_relative_path!("examples/files"))
-    .with_index_file("plaintext.txt");
-
-assert_not_handled!(get("/").run_async(&plaintext_index).await);
-assert_not_handled!(get("/subdir").run_async(&plaintext_index).await);
-assert_ok!(
-    get("/subdir_with_no_index").run_async(&plaintext_index).await,
-    "plaintext file",
-    "content-type" => "text/plain; charset=utf-8"
-);
-# }); }
-```
-
-
-## ❗IMPORTANT❗
-
-this crate has three features currently: `smol`, `async-std`, and
-`tokio`.
-
-You **must** enable one of these in order to use the crate. This
-is intended to be a temporary situation, and eventually you will not
-need to specify the runtime through feature flags.
-
-## stability note
-
-Please note that this crate is fairly incomplete, while functional. It
-does not include any notion of range requests or cache headers. It
-serves all files from disk every time, with no in-memory caching.
-*/
+//! Serves static file assets from the file system.
+//!
+//! ```
+//! # #[cfg(not(unix))] fn main() {}
+//! # #[cfg(unix)] fn main() {
+//! use trillium_static::{crate_relative_path, StaticFileHandler};
+//!
+//! # trillium_testing::block_on(async {
+//! let mut handler = StaticFileHandler::new(crate_relative_path!("examples/files"))
+//!     .with_index_file("index.html");
+//!
+//! // given the following directory layout
+//! //
+//! // examples/files
+//! // ├── index.html
+//! // ├── subdir
+//! // │  └── index.html
+//! // └── subdir_with_no_index
+//! //    └── plaintext.txt
+//!
+//! use trillium::Handler;
+//! use trillium_testing::prelude::*;
+//!
+//! handler.init(&mut "testing".into()).await;
+//!
+//! assert_ok!(
+//!     get("/").run_async(&handler).await,
+//!     "<h1>hello world</h1>",
+//!     "content-type" => "text/html; charset=utf-8"
+//! );
+//! assert_not_handled!(
+//!     get("/file_that_does_not_exist.txt")
+//!         .run_async(&handler)
+//!         .await
+//! );
+//! assert_ok!(get("/index.html").run_async(&handler).await);
+//! assert_ok!(
+//!     get("/subdir/index.html").run_async(&handler).await,
+//!     "subdir index.html"
+//! );
+//! assert_ok!(
+//!     get("/subdir").run_async(&handler).await,
+//!     "subdir index.html"
+//! );
+//! assert_not_handled!(get("/subdir_with_no_index").run_async(&handler).await);
+//! assert_ok!(
+//!     get("/subdir_with_no_index/plaintext.txt").run_async(&handler).await,
+//!     "plaintext file",
+//!     "content-type" => "text/plain; charset=utf-8"
+//! );
+//!
+//! // with a different index file
+//! let plaintext_index = StaticFileHandler::new(crate_relative_path!("examples/files"))
+//!     .with_index_file("plaintext.txt");
+//!
+//! assert_not_handled!(get("/").run_async(&plaintext_index).await);
+//! assert_not_handled!(get("/subdir").run_async(&plaintext_index).await);
+//! assert_ok!(
+//!     get("/subdir_with_no_index").run_async(&plaintext_index).await,
+//!     "plaintext file",
+//!     "content-type" => "text/plain; charset=utf-8"
+//! );
+//! # });
+//! # }
+//! ```
+//!
+//!
+//! ## ❗IMPORTANT❗
+//!
+//! this crate has three features currently: `smol`, `async-std`, and
+//! `tokio`.
+//!
+//! You **must** enable one of these in order to use the crate. This
+//! is intended to be a temporary situation, and eventually you will not
+//! need to specify the runtime through feature flags.
+//!
+//! ## stability note
+//!
+//! Please note that this crate is fairly incomplete, while functional. It
+//! does not include any notion of range requests or cache headers. It
+//! serves all files from disk every time, with no in-memory caching.
 
 mod fs_shims;
 mod handler;

--- a/tera/src/lib.rs
+++ b/tera/src/lib.rs
@@ -9,38 +9,35 @@
     unused_qualifications
 )]
 
-/*!
-
-# this crate provides the tera templating language for trillium
-
-See [the tera site](https://tera.netlify.app/) for more information on
-the tera template language.
-
-```
-# fn main() -> tera::Result<()> {
-use trillium::Conn;
-use trillium_tera::{TeraHandler, Tera, TeraConnExt};
-
-let mut tera = Tera::default();
-tera.add_raw_template("hello.html", "hello {{name}} from {{render_engine}}")?;
-
-let handler = (
-    TeraHandler::new(tera),
-    |conn: Conn| async move { conn.assign("render_engine", "tera") },
-    |conn: Conn| async move {
-        conn.assign("name", "trillium").render("hello.html")
-    }
-);
-
-use trillium_testing::prelude::*;
-assert_ok!(
-    get("/").on(&handler),
-    "hello trillium from tera",
-    "content-type" => "text/html"
-);
-# Ok(()) }
-```
-*/
+//! # this crate provides the tera templating language for trillium
+//!
+//! See [the tera site](https://tera.netlify.app/) for more information on
+//! the tera template language.
+//!
+//! ```
+//! # fn main() -> tera::Result<()> {
+//! use trillium::Conn;
+//! use trillium_tera::{TeraHandler, Tera, TeraConnExt};
+//!
+//! let mut tera = Tera::default();
+//! tera.add_raw_template("hello.html", "hello {{name}} from {{render_engine}}")?;
+//!
+//! let handler = (
+//! TeraHandler::new(tera),
+//! |conn: Conn| async move { conn.assign("render_engine", "tera") },
+//! |conn: Conn| async move {
+//! conn.assign("name", "trillium").render("hello.html")
+//! }
+//! );
+//!
+//! use trillium_testing::prelude::*;
+//! assert_ok!(
+//! get("/").on(&handler),
+//! "hello trillium from tera",
+//! "content-type" => "text/html"
+//! );
+//! # Ok(()) }
+//! ```
 
 mod tera_handler;
 pub use tera_handler::TeraHandler;

--- a/tera/src/tera_conn_ext.rs
+++ b/tera/src/tera_conn_ext.rs
@@ -3,9 +3,7 @@ use serde::Serialize;
 use tera::{Context, Tera};
 use trillium::{Conn, KnownHeaderName};
 
-/**
-Extends trillium::Conn with tera template-rendering functionality.
-*/
+/// Extends trillium::Conn with tera template-rendering functionality.
 pub trait TeraConnExt {
     /// Adds a key-value pair to the assigns [`Context`], where the key is
     /// a &str and the value is any [`Serialize`] type.

--- a/tera/src/tera_handler.rs
+++ b/tera/src/tera_handler.rs
@@ -2,9 +2,7 @@ use std::{path::PathBuf, sync::Arc};
 use tera::{Context, Tera};
 use trillium::{Conn, Handler};
 
-/**
-
-*/
+///
 #[derive(Clone, Debug)]
 pub struct TeraHandler(Arc<Tera>);
 

--- a/testing/src/assertions.rs
+++ b/testing/src/assertions.rs
@@ -1,31 +1,28 @@
-/**
-assert that the status code of a conn is as specified.
-
-```
-use trillium_testing::prelude::*;
-async fn handler(conn: trillium::Conn) -> trillium::Conn {
-    conn.with_status(418)
-}
-
-
-assert_status!(get("/").on(&handler), 418);
-assert_status!(get("/").on(&handler), Status::ImATeapot);
-
-let conn = get("/").on(&handler);
-assert_status!(&conn, 418);
-assert_status!(conn, 418);
-```
-
-
-```rust,should_panic
-use trillium_testing::prelude::*;
-async fn handler(conn: trillium::Conn) -> trillium::Conn {
-    conn.ok("handled")
-}
-
-assert_status!(get("/").on(&handler), 418);
-```
-*/
+/// assert that the status code of a conn is as specified.
+///
+/// ```
+/// use trillium_testing::prelude::*;
+/// async fn handler(conn: trillium::Conn) -> trillium::Conn {
+///     conn.with_status(418)
+/// }
+///
+/// assert_status!(get("/").on(&handler), 418);
+/// assert_status!(get("/").on(&handler), Status::ImATeapot);
+///
+/// let conn = get("/").on(&handler);
+/// assert_status!(&conn, 418);
+/// assert_status!(conn, 418);
+/// ```
+///
+///
+/// ```rust,should_panic
+/// use trillium_testing::prelude::*;
+/// async fn handler(conn: trillium::Conn) -> trillium::Conn {
+///     conn.ok("handled")
+/// }
+///
+/// assert_status!(get("/").on(&handler), 418);
+/// ```
 
 #[macro_export]
 macro_rules! assert_status {
@@ -41,36 +38,33 @@ macro_rules! assert_status {
     }};
 }
 
-/**
-assert that all of the following are true:
-* the status was not set
-* the body was not set
-* the conn was not halted
-
-```
-use trillium_testing::prelude::*;
-async fn handler(conn: trillium::Conn) -> trillium::Conn {
-    conn
-}
-
-
-assert_not_handled!(get("/").on(&handler));
-
-let conn = get("/").on(&handler);
-assert_not_handled!(&conn);
-assert_not_handled!(conn);
-```
-
-
-```rust,should_panic
-use trillium_testing::prelude::*;
-async fn handler(conn: trillium::Conn) -> trillium::Conn {
-    conn.ok("handled")
-}
-
-assert_not_handled!(get("/").on(&handler));
-```
-*/
+/// assert that all of the following are true:
+/// the status was not set
+/// the body was not set
+/// the conn was not halted
+///
+/// ```
+/// use trillium_testing::prelude::*;
+/// async fn handler(conn: trillium::Conn) -> trillium::Conn {
+///     conn
+/// }
+///
+/// assert_not_handled!(get("/").on(&handler));
+///
+/// let conn = get("/").on(&handler);
+/// assert_not_handled!(&conn);
+/// assert_not_handled!(conn);
+/// ```
+///
+///
+/// ```rust,should_panic
+/// use trillium_testing::prelude::*;
+/// async fn handler(conn: trillium::Conn) -> trillium::Conn {
+///     conn.ok("handled")
+/// }
+///
+/// assert_not_handled!(get("/").on(&handler));
+/// ```
 
 #[macro_export]
 macro_rules! assert_not_handled {
@@ -82,36 +76,33 @@ macro_rules! assert_not_handled {
     }};
 }
 
-/**
-assert that the response body is as specified. this assertion requires mutation of the conn.
-
-```
-use trillium_testing::prelude::*;
-async fn handler(conn: trillium::Conn) -> trillium::Conn {
-    conn.ok("it's-a-me, trillium")
-}
-
-
-assert_body!(get("/").on(&handler), "it's-a-me, trillium");
-
-let mut conn = get("/").on(&handler);
-assert_body!(&mut conn, "it's-a-me, trillium");
-
-let mut conn = get("/").on(&handler);
-assert_body!(conn, "it's-a-me, trillium");
-```
-
-
-```rust,should_panic
-use trillium_testing::prelude::*;
-assert_body!(get("/").on(&()), "what body?");
-```
-
-```rust,should_panic
-use trillium_testing::prelude::*;
-assert_body!(get("/").on(&"beach body"), "winter body");
-```
-*/
+/// assert that the response body is as specified. this assertion requires mutation of the conn.
+///
+/// ```
+/// use trillium_testing::prelude::*;
+/// async fn handler(conn: trillium::Conn) -> trillium::Conn {
+///     conn.ok("it's-a-me, trillium")
+/// }
+///
+/// assert_body!(get("/").on(&handler), "it's-a-me, trillium");
+///
+/// let mut conn = get("/").on(&handler);
+/// assert_body!(&mut conn, "it's-a-me, trillium");
+///
+/// let mut conn = get("/").on(&handler);
+/// assert_body!(conn, "it's-a-me, trillium");
+/// ```
+///
+///
+/// ```rust,should_panic
+/// use trillium_testing::prelude::*;
+/// assert_body!(get("/").on(&()), "what body?");
+/// ```
+///
+/// ```rust,should_panic
+/// use trillium_testing::prelude::*;
+/// assert_body!(get("/").on(&"beach body"), "winter body");
+/// ```
 
 #[macro_export]
 macro_rules! assert_body {
@@ -124,31 +115,27 @@ macro_rules! assert_body {
     };
 }
 
-/**
-
-asserts that the response body matches the specified pattern, using [`str::contains`]
-```
-use trillium_testing::prelude::*;
-let handler = "there's a needle in this haystack";
-assert_body_contains!(get("/").on(&handler), "needle");
-
-let mut conn = get("/").on(&handler);
-let body = assert_body_contains!(&mut conn, "needle");
-assert!(body.contains("haystack"));
-
-```
-
-
-```rust,should_panic
-use trillium_testing::prelude::*;
-assert_body_contains!(get("/").on(&()), "what body?");
-```
-
-```rust,should_panic
-use trillium_testing::prelude::*;
-assert_body_contains!(get("/").on(&"just a haystack"), "needle");
-```
-*/
+/// asserts that the response body matches the specified pattern, using [`str::contains`]
+/// ```
+/// use trillium_testing::prelude::*;
+/// let handler = "there's a needle in this haystack";
+/// assert_body_contains!(get("/").on(&handler), "needle");
+///
+/// let mut conn = get("/").on(&handler);
+/// let body = assert_body_contains!(&mut conn, "needle");
+/// assert!(body.contains("haystack"));
+/// ```
+///
+///
+/// ```rust,should_panic
+/// use trillium_testing::prelude::*;
+/// assert_body_contains!(get("/").on(&()), "what body?");
+/// ```
+///
+/// ```rust,should_panic
+/// use trillium_testing::prelude::*;
+/// assert_body_contains!(get("/").on(&"just a haystack"), "needle");
+/// ```
 
 #[macro_export]
 macro_rules! assert_body_contains {
@@ -168,37 +155,32 @@ macro_rules! assert_body_contains {
     };
 }
 
-/**
-combines several other assertions. this assertion can be used to assert:
-* just a status code,
-* a status code and a response body, or
-* a status code, a response body, and any number of headers
-
-```
-use trillium_testing::prelude::*;
-async fn handler(conn: Conn) -> Conn {
-    conn.with_body("just tea stuff here")
-        .with_status(418)
-        .with_response_header("server", "zojirushi")
-}
-
-assert_response!(get("/").on(&handler), 418);
-assert_response!(get("/").on(&handler), Status::ImATeapot);
-assert_response!(get("/").on(&handler), 418, "just tea stuff here");
-assert_response!(get("/").on(&handler), Status::ImATeapot, "just tea stuff here");
-
-assert_response!(
-    get("/").on(&handler),
-    Status::ImATeapot,
-    "just tea stuff here",
-    "server" => "zojirushi",
-    "content-length" => "19"
-);
-
-```
-
-
-*/
+/// combines several other assertions. this assertion can be used to assert:
+/// just a status code,
+/// a status code and a response body, or
+/// a status code, a response body, and any number of headers
+///
+/// ```
+/// use trillium_testing::prelude::*;
+/// async fn handler(conn: Conn) -> Conn {
+/// conn.with_body("just tea stuff here")
+/// .with_status(418)
+/// .with_response_header("server", "zojirushi")
+/// }
+///
+/// assert_response!(get("/").on(&handler), 418);
+/// assert_response!(get("/").on(&handler), Status::ImATeapot);
+/// assert_response!(get("/").on(&handler), 418, "just tea stuff here");
+/// assert_response!(get("/").on(&handler), Status::ImATeapot, "just tea stuff here");
+///
+/// assert_response!(
+/// get("/").on(&handler),
+/// Status::ImATeapot,
+/// "just tea stuff here",
+/// "server" => "zojirushi",
+/// "content-length" => "19"
+/// );
+/// ```
 
 #[macro_export]
 macro_rules! assert_response {
@@ -224,27 +206,24 @@ macro_rules! assert_response {
 
 }
 
-/**
-asserts any number of response headers
-
-```
-use trillium_testing::prelude::*;
-async fn handler(conn: Conn) -> Conn {
-    conn.ok("headers")
-        .with_response_header("server", "special-custom-server")
-        .with_response_header("request-id", "10")
-}
-
-assert_headers!(get("/").on(&handler), "server" => "special-custom-server");
-assert_headers!(
-    get("/").on(&handler),
-    "server" => "special-custom-server",
-    "request-id" => "10",
-    "content-length" => "7"
-);
-
-```
-*/
+/// asserts any number of response headers
+///
+/// ```
+/// use trillium_testing::prelude::*;
+/// async fn handler(conn: Conn) -> Conn {
+/// conn.ok("headers")
+/// .with_response_header("server", "special-custom-server")
+/// .with_response_header("request-id", "10")
+/// }
+///
+/// assert_headers!(get("/").on(&handler), "server" => "special-custom-server");
+/// assert_headers!(
+/// get("/").on(&handler),
+/// "server" => "special-custom-server",
+/// "request-id" => "10",
+/// "content-length" => "7"
+/// );
+/// ```
 #[macro_export]
 macro_rules! assert_headers {
     (@pair, $conn:expr, $header_name:tt, None) => {
@@ -276,39 +255,34 @@ macro_rules! assert_headers {
     }
 }
 
-/**
-assert_ok is like [`assert_response!`] except it always asserts a status of 200 Ok.
-
-it can be used to assert:
-* just that the response was successful,
-* that the response was successful and a response body, or
-* that the response was successful, a response body, and any number of headers
-
-```
-use trillium_testing::prelude::*;
-async fn handler(conn: Conn) -> Conn {
-    conn.ok("body")
-        .with_response_header("server", "special-custom-server")
-        .with_response_header("request-id", "10")
-}
-
-assert_ok!(get("/").on(&handler));
-assert_ok!(get("/").on(&handler), "body");
-assert_ok!(get("/").on(&handler), "body");
-assert_ok!(get("/").on(&handler), "body", "server" => "special-custom-server");
-
-assert_ok!(
-    get("/").on(&handler),
-    "body",
-    "server" => "special-custom-server",
-    "request-id" => "10",
-    "content-length" => "4"
-);
-
-```
-
-
-*/
+/// assert_ok is like [`assert_response!`] except it always asserts a status of 200 Ok.
+///
+/// it can be used to assert:
+/// just that the response was successful,
+/// that the response was successful and a response body, or
+/// that the response was successful, a response body, and any number of headers
+///
+/// ```
+/// use trillium_testing::prelude::*;
+/// async fn handler(conn: Conn) -> Conn {
+/// conn.ok("body")
+/// .with_response_header("server", "special-custom-server")
+/// .with_response_header("request-id", "10")
+/// }
+///
+/// assert_ok!(get("/").on(&handler));
+/// assert_ok!(get("/").on(&handler), "body");
+/// assert_ok!(get("/").on(&handler), "body");
+/// assert_ok!(get("/").on(&handler), "body", "server" => "special-custom-server");
+///
+/// assert_ok!(
+/// get("/").on(&handler),
+/// "body",
+/// "server" => "special-custom-server",
+/// "request-id" => "10",
+/// "content-length" => "4"
+/// );
+/// ```
 
 #[macro_export]
 macro_rules! assert_ok {

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -9,58 +9,53 @@
     unused_qualifications
 )]
 
-/*!
-testing utilities for trillium applications.
-
-this crate is intended to be used as a development dependency.
-
-```
-use trillium_testing::prelude::*;
-use trillium::{Conn, conn_try};
-async fn handler(mut conn: Conn) -> Conn {
-    let request_body = conn_try!(conn.request_body_string().await, conn);
-    conn.with_body(format!("request body was: {}", request_body))
-        .with_status(418)
-        .with_response_header("request-id", "special-request")
-}
-
-assert_response!(
-    post("/").with_request_body("hello trillium!").on(&handler),
-    Status::ImATeapot,
-    "request body was: hello trillium!",
-    "request-id" => "special-request",
-    "content-length" => "33"
-);
-
-```
-
-## Features
-
-**You must enable a runtime feature for trillium testing**
-
-### Tokio:
-```toml
-[dev-dependencies]
-# ...
-trillium-testing = { version = "0.2", features = ["tokio"] }
-```
-
-### Async-std:
-```toml
-[dev-dependencies]
-# ...
-trillium-testing = { version = "0.2", features = ["async-std"] }
-```
-
-### Smol:
-```toml
-[dev-dependencies]
-# ...
-trillium-testing = { version = "0.2", features = ["smol"] }
-```
-
-
-*/
+//! testing utilities for trillium applications.
+//!
+//! this crate is intended to be used as a development dependency.
+//!
+//! ```
+//! use trillium::{conn_try, Conn};
+//! use trillium_testing::prelude::*;
+//! async fn handler(mut conn: Conn) -> Conn {
+//!     let request_body = conn_try!(conn.request_body_string().await, conn);
+//!     conn.with_body(format!("request body was: {}", request_body))
+//!         .with_status(418)
+//!         .with_response_header("request-id", "special-request")
+//! }
+//!
+//! assert_response!(
+//!     post("/").with_request_body("hello trillium!").on(&handler),
+//!     Status::ImATeapot,
+//!     "request body was: hello trillium!",
+//!     "request-id" => "special-request",
+//!     "content-length" => "33"
+//! );
+//! ```
+//!
+//! ## Features
+//!
+//! You must enable a runtime feature for **trillium testing**
+//!
+//! ### Tokio:
+//! ```toml
+//! [dev-dependencies]
+//! # ...
+//! trillium-testing = { version = "0.2", features = ["tokio"] }
+//! ```
+//!
+//! ### Async-std:
+//! ```toml
+//! [dev-dependencies]
+//! # ...
+//! trillium-testing = { version = "0.2", features = ["async-std"] }
+//! ```
+//!
+//! ### Smol:
+//! ```toml
+//! [dev-dependencies]
+//! # ...
+//! trillium-testing = { version = "0.2", features = ["smol"] }
+//! ```
 
 mod assertions;
 
@@ -73,9 +68,7 @@ pub use test_conn::TestConn;
 
 pub mod methods;
 pub mod prelude {
-    /*!
-    useful stuff for testing trillium apps
-    */
+    //! useful stuff for testing trillium apps
     pub use crate::{
         assert_body, assert_body_contains, assert_headers, assert_not_handled, assert_ok,
         assert_response, assert_status, block_on, connector, init, methods::*,

--- a/testing/src/methods.rs
+++ b/testing/src/methods.rs
@@ -1,6 +1,4 @@
-/*!
-[`TestConn`](crate::TestConn) builders for http methods
-*/
+//! [`TestConn`](crate::TestConn) builders for http methods
 
 macro_rules! method {
     ($fn_name:ident, $method:ident) => {

--- a/testing/src/test_conn.rs
+++ b/testing/src/test_conn.rs
@@ -8,25 +8,21 @@ use trillium_http::{Conn as HttpConn, Synthetic};
 
 type SyntheticConn = HttpConn<Synthetic>;
 
-/**
-A wrapper around a [`trillium::Conn`] for testing
-
-Stability note: this may be replaced by an extension trait at some point.
-*/
+/// A wrapper around a [`trillium::Conn`] for testing
+///
+/// Stability note: this may be replaced by an extension trait at some point.
 #[derive(Debug)]
 pub struct TestConn(Conn);
 
 impl TestConn {
-    /**
-    constructs a new TestConn with the provided method, path, and body.
-    ```
-    use trillium_testing::{prelude::*, TestConn};
-    let mut conn = TestConn::build("get", "/", "body");
-    assert_eq!(conn.method(), Method::Get);
-    assert_eq!(conn.path(), "/");
-    assert_eq!(conn.take_request_body_string(), "body");
-    ```
-    */
+    /// constructs a new TestConn with the provided method, path, and body.
+    /// ```
+    /// use trillium_testing::{prelude::*, TestConn};
+    /// let mut conn = TestConn::build("get", "/", "body");
+    /// assert_eq!(conn.method(), Method::Get);
+    /// assert_eq!(conn.path(), "/");
+    /// assert_eq!(conn.take_request_body_string(), "body");
+    /// ```
     pub fn build<M>(method: M, path: impl Into<String>, body: impl Into<Synthetic>) -> Self
     where
         M: TryInto<Method>,
@@ -35,15 +31,12 @@ impl TestConn {
         Self(HttpConn::new_synthetic(method.try_into().unwrap(), path.into(), body).into())
     }
 
-    /**
-    chainable constructor to append a request header to the TestConn
-    ```
-    use trillium_testing::TestConn;
-    let conn = TestConn::build("get", "/", "body")
-        .with_request_header("some-header", "value");
-    assert_eq!(conn.request_headers().get_str("some-header"), Some("value"));
-    ```
-    */
+    /// chainable constructor to append a request header to the TestConn
+    /// ```
+    /// use trillium_testing::TestConn;
+    /// let conn = TestConn::build("get", "/", "body").with_request_header("some-header", "value");
+    /// assert_eq!(conn.request_headers().get_str("some-header"), Some("value"));
+    /// ```
 
     pub fn with_request_header(
         self,
@@ -57,22 +50,18 @@ impl TestConn {
         Self(inner.into())
     }
 
-    /**
-    chainable constructor to replace the request body. this is useful
-    when chaining with a [`trillium_testing::methods`](crate::methods)
-    builder, as they do not provide a way to specify the body.
-
-    ```
-    use trillium_testing::{methods::post, TestConn};
-    let mut conn = post("/").with_request_body("some body");
-    assert_eq!(conn.take_request_body_string(), "some body");
-
-    let mut conn = TestConn::build("post", "/", "some body")
-        .with_request_body("once told me");
-    assert_eq!(conn.take_request_body_string(), "once told me");
-
-    ```
-    */
+    /// chainable constructor to replace the request body. this is useful
+    /// when chaining with a [`trillium_testing::methods`](crate::methods)
+    /// builder, as they do not provide a way to specify the body.
+    ///
+    /// ```
+    /// use trillium_testing::{methods::post, TestConn};
+    /// let mut conn = post("/").with_request_body("some body");
+    /// assert_eq!(conn.take_request_body_string(), "some body");
+    ///
+    /// let mut conn = TestConn::build("post", "/", "some body").with_request_body("once told me");
+    /// assert_eq!(conn.take_request_body_string(), "once told me");
+    /// ```
     pub fn with_request_body(self, body: impl Into<Synthetic>) -> Self {
         let mut inner: SyntheticConn = self.into();
         inner.replace_body(body);
@@ -100,42 +89,38 @@ impl TestConn {
         self
     }
 
-    /**
-    blocks on running this conn against a handler and finalizes
-    response headers. also aliased as [`TestConn::on`]
-
-    ```
-    use trillium_testing::prelude::*;
-
-    async fn handler(conn: Conn) -> Conn {
-        conn.ok("hello trillium")
-    }
-
-    let conn = get("/").run(&handler);
-    assert_ok!(conn, "hello trillium", "content-length" => "14");
-    ```
-    */
+    /// blocks on running this conn against a handler and finalizes
+    /// response headers. also aliased as [`TestConn::on`]
+    ///
+    /// ```
+    /// use trillium_testing::prelude::*;
+    ///
+    /// async fn handler(conn: Conn) -> Conn {
+    ///     conn.ok("hello trillium")
+    /// }
+    ///
+    /// let conn = get("/").run(&handler);
+    /// assert_ok!(conn, "hello trillium", "content-length" => "14");
+    /// ```
     pub fn run(self, handler: &impl Handler) -> Self {
         crate::block_on(self.run_async(handler))
     }
 
-    /**
-    runs this conn against a handler and finalizes
-    response headers.
-
-    ```
-    use trillium_testing::prelude::*;
-
-    async fn handler(conn: Conn) -> Conn {
-        conn.ok("hello trillium")
-    }
-
-    block_on(async move {
-        let conn = get("/").run_async(&handler).await;
-        assert_ok!(conn, "hello trillium", "content-length" => "14");
-    });
-    ```
-    */
+    /// runs this conn against a handler and finalizes
+    /// response headers.
+    ///
+    /// ```
+    /// use trillium_testing::prelude::*;
+    ///
+    /// async fn handler(conn: Conn) -> Conn {
+    ///     conn.ok("hello trillium")
+    /// }
+    ///
+    /// block_on(async move {
+    ///     let conn = get("/").run_async(&handler).await;
+    ///     assert_ok!(conn, "hello trillium", "content-length" => "14");
+    /// });
+    /// ```
     pub async fn run_async(self, handler: &impl Handler) -> Self {
         let conn = handler.run(self.into()).await;
         let mut conn = handler.before_send(conn).await;
@@ -143,31 +128,27 @@ impl TestConn {
         Self(conn)
     }
 
-    /**
-    blocks on running this conn against a handler and finalizes
-    response headers. also aliased as [`TestConn::run`].
-
-    ```
-    use trillium_testing::prelude::*;
-
-    async fn handler(conn: Conn) -> Conn {
-        conn.ok("hello trillium")
-    }
-
-    let conn = get("/").on(&handler);
-    assert_ok!(conn, "hello trillium", "content-length" => "14");
-    ```
-    */
+    /// blocks on running this conn against a handler and finalizes
+    /// response headers. also aliased as [`TestConn::run`].
+    ///
+    /// ```
+    /// use trillium_testing::prelude::*;
+    ///
+    /// async fn handler(conn: Conn) -> Conn {
+    /// conn.ok("hello trillium")
+    /// }
+    ///
+    /// let conn = get("/").on(&handler);
+    /// assert_ok!(conn, "hello trillium", "content-length" => "14");
+    /// ```
 
     pub fn on(self, handler: &impl Handler) -> Self {
         self.run(handler)
     }
 
-    /**
-    Reads the response body to string and returns it, if set. This is
-    used internally to [`assert_body`] which is the preferred
-    interface
-    */
+    /// Reads the response body to string and returns it, if set. This is
+    /// used internally to [`assert_body`] which is the preferred
+    /// interface
     pub fn take_response_body_string(&mut self) -> Option<String> {
         if let Some(body) = self.take_response_body() {
             String::from_utf8(
@@ -181,9 +162,7 @@ impl TestConn {
         }
     }
 
-    /**
-    Reads the request body to string and returns it
-    */
+    /// Reads the request body to string and returns it
     pub fn take_request_body_string(&mut self) -> String {
         futures_lite::future::block_on(async {
             self.request_body().await.read_string().await.unwrap()

--- a/testing/src/test_transport.rs
+++ b/testing/src/test_transport.rs
@@ -109,23 +109,17 @@ struct CloseableCursorInner {
 pub struct CloseableCursor(RwLock<CloseableCursorInner>);
 
 impl CloseableCursor {
-    /**
-    the length of the content
-    */
+    /// the length of the content
     pub fn len(&self) -> usize {
         self.0.read().unwrap().data.len()
     }
 
-    /**
-    the current read position
-    */
+    /// the current read position
     pub fn cursor(&self) -> usize {
         self.0.read().unwrap().cursor
     }
 
-    /**
-    does what it says on the tin
-    */
+    /// does what it says on the tin
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -135,17 +129,13 @@ impl CloseableCursor {
         self.0.read().unwrap().data.clone()
     }
 
-    /**
-    have we read to the end of the available content
-    */
+    /// have we read to the end of the available content
     pub fn current(&self) -> bool {
         let inner = self.0.read().unwrap();
         inner.data.len() == inner.cursor
     }
 
-    /**
-    close this cursor, waking any pending polls
-    */
+    /// close this cursor, waking any pending polls
     pub fn close(&self) {
         let mut inner = self.0.write().unwrap();
         inner.closed = true;

--- a/testing/src/with_server.rs
+++ b/testing/src/with_server.rs
@@ -5,16 +5,14 @@ use trillium_http::transport::BoxedTransport;
 use trillium_server_common::RuntimeTrait;
 use url::Url;
 
-/**
-Starts a trillium handler bound to a random available port on
-localhost, run the async tests provided as the second
-argument, and then shut down the server. useful for full
-integration tests that actually exercise the tcp layer.
-
-See
-[`trillium_client::Conn`](https://docs.trillium.rs/trillium_client/struct.conn)
-for usage examples.
-**/
+/// Starts a trillium handler bound to a random available port on
+/// localhost, run the async tests provided as the second
+/// argument, and then shut down the server. useful for full
+/// integration tests that actually exercise the tcp layer.
+///
+/// See
+/// [`trillium_client::Conn`](https://docs.trillium.rs/trillium_client/struct.conn)
+/// for usage examples.
 pub fn with_server<H, Fun, Fut>(handler: H, tests: Fun)
 where
     H: Handler,

--- a/tokio/src/client.rs
+++ b/tokio/src/client.rs
@@ -10,9 +10,7 @@ use trillium_server_common::{
     Connector, Transport,
 };
 
-/**
-configuration for the tcp Connector
-*/
+/// configuration for the tcp Connector
 #[derive(Default, Debug, Clone, Copy)]
 pub struct ClientConfig {
     /// disable [nagle's algorithm](https://en.wikipedia.org/wiki/Nagle%27s_algorithm)

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -8,28 +8,23 @@
     nonstandard_style,
     unused_qualifications
 )]
-/*!
-# Trillium server adapter for tokio
-
-```rust,no_run
-# #[allow(clippy::needless_doctest_main)]
-fn main() {
-    trillium_tokio::run(|conn: trillium::Conn| async move {
-        conn.ok("hello tokio")
-    });
-}
-```
-
-```rust,no_run
-# #[allow(clippy::needless_doctest_main)]
-#[tokio::main]
-async fn main() {
-    trillium_tokio::run_async(|conn: trillium::Conn| async move {
-        conn.ok("hello tokio")
-    }).await;
-}
-```
-*/
+//! # Trillium server adapter for tokio
+//!
+//! ```rust,no_run
+//! # #[allow(clippy::needless_doctest_main)]
+//! fn main() {
+//!     trillium_tokio::run(|conn: trillium::Conn| async move { conn.ok("hello tokio") });
+//! }
+//! ```
+//!
+//! ```rust,no_run
+//! # #[allow(clippy::needless_doctest_main)]
+//! #[tokio::main]
+//! async fn main() {
+//!     trillium_tokio::run_async(|conn: trillium::Conn| async move { conn.ok("hello tokio") })
+//!         .await;
+//! }
+//! ```
 
 use trillium::Handler;
 pub use trillium_server_common::{Binding, Swansong};
@@ -46,68 +41,58 @@ pub use tokio_stream;
 mod transport;
 pub use transport::TokioTransport;
 
-/**
-# Runs a trillium handler in a sync context with default config
-
-Runs a trillium handler on the tokio runtime with
-default configuration. See [`crate::config`] for what the defaults are
-and how to override them
-
-
-This function will block the current thread until the server shuts
-down
-*/
+/// # Runs a trillium handler in a sync context with default config
+///
+/// Runs a trillium handler on the tokio runtime with
+/// default configuration. See [`crate::config`] for what the defaults are
+/// and how to override them
+///
+///
+/// This function will block the current thread until the server shuts
+/// down
 pub fn run(handler: impl Handler) {
     config().run(handler)
 }
 
-/**
-# Runs a trillium handler in an async context with default config
-
-Run the provided trillium handler on an already-running tokio runtime
-with default settings. The defaults are the same as [`crate::run`]. To
-customize these settings, see [`crate::config`].
-
-This function will poll pending until the server shuts down.
-
-*/
+/// # Runs a trillium handler in an async context with default config
+///
+/// Run the provided trillium handler on an already-running tokio runtime
+/// with default settings. The defaults are the same as [`crate::run`]. To
+/// customize these settings, see [`crate::config`].
+///
+/// This function will poll pending until the server shuts down.
 pub async fn run_async(handler: impl Handler) {
     config().run_async(handler).await
 }
 
-/**
-# Configures a server before running it
-
-## Defaults
-
-The default configuration is as follows:
-
-* port: the contents of the `PORT` env var or else 8080
-* host: the contents of the `HOST` env var or else "localhost"
-* signals handling and graceful shutdown: enabled on cfg(unix) systems
-* tcp nodelay: disabled
-* tls acceptor: none
-
-## Usage
-
-```rust
-let swansong = trillium_tokio::Swansong::new();
-# swansong.shut_down(); // stoppping the server immediately for the test
-trillium_tokio::config()
-    .with_port(0)
-    .with_host("127.0.0.1")
-    .without_signals()
-    .with_nodelay()
-    .with_acceptor(()) // see [`trillium_rustls`] and [`trillium_native_tls`]
-    .with_swansong(swansong)
-    .run(|conn: trillium::Conn| async move {
-        conn.ok("hello tokio")
-    });
-```
-
-See [`trillium_server_common::Config`] for more details
-
-*/
+/// # Configures a server before running it
+///
+/// ## Defaults
+///
+/// The default configuration is as follows:
+///
+/// port: the contents of the `PORT` env var or else 8080
+/// host: the contents of the `HOST` env var or else "localhost"
+/// signals handling and graceful shutdown: enabled on cfg(unix) systems
+/// tcp nodelay: disabled
+/// tls acceptor: none
+///
+/// ## Usage
+///
+/// ```rust
+/// let swansong = trillium_tokio::Swansong::new();
+/// # swansong.shut_down(); // stoppping the server immediately for the test
+/// trillium_tokio::config()
+///     .with_port(0)
+///     .with_host("127.0.0.1")
+///     .without_signals()
+///     .with_nodelay()
+///     .with_acceptor(()) // see [`trillium_rustls`] and [`trillium_native_tls`]
+///     .with_swansong(swansong)
+///     .run(|conn: trillium::Conn| async move { conn.ok("hello tokio") });
+/// ```
+///
+/// See [`trillium_server_common::Config`] for more details
 pub fn config() -> Config<()> {
     Config::new()
 }

--- a/trillium/src/conn.rs
+++ b/trillium/src/conn.rs
@@ -9,62 +9,59 @@ use trillium_http::{
     Body, HeaderName, HeaderValues, Headers, Method, ReceivedBody, Status, TypeSet,
 };
 
-/**
-# A Trillium HTTP connection.
-
-A Conn represents both the request and response of a http connection,
-as well as any application state that is associated with that
-connection.
-
-## `with_{attribute}` naming convention
-
-A convention that is used throughout trillium is that any interface
-that is named `with_{attribute}` will take ownership of the conn, set
-the attribute and return the conn, enabling chained calls like:
-
-```
-struct MyState(&'static str);
-async fn handler(mut conn: trillium::Conn) -> trillium::Conn {
-    conn.with_response_header("content-type", "text/plain")
-        .with_state(MyState("hello"))
-        .with_body("hey there")
-        .with_status(418)
-}
-
-use trillium_testing::prelude::*;
-
-assert_response!(
-    get("/").on(&handler),
-    Status::ImATeapot,
-    "hey there",
-    "content-type" => "text/plain"
-);
-```
-
-If you need to set a property on the conn without moving it,
-`set_{attribute}` associated functions will be your huckleberry, as is
-conventional in other rust projects.
-
-## State
-
-Every trillium Conn contains a state type which is a set that contains
-at most one element for each type. State is the primary way that
-handlers attach data to a conn as it passes through a tuple
-handler. State access should generally be implemented by libraries
-using a private type and exposed with a `ConnExt` trait. See [library
-patterns](https://trillium.rs/library_patterns.html#state) for more
-elaboration and examples.
-
-## In relation to [`trillium_http::Conn`]
-
-`trillium::Conn` is currently implemented as an abstraction on top of a
-[`trillium_http::Conn`]. In particular, `trillium::Conn` boxes the
-transport using a [`BoxedTransport`](trillium_http::transport::BoxedTransport)
-so that application code can be written without transport
-generics. See [`Transport`](trillium_http::transport::Transport) for further
-reading on this.
-
-*/
+/// # A Trillium HTTP connection.
+///
+/// A Conn represents both the request and response of a http connection,
+/// as well as any application state that is associated with that
+/// connection.
+///
+/// ## `with_{attribute}` naming convention
+///
+/// A convention that is used throughout trillium is that any interface
+/// that is named `with_{attribute}` will take ownership of the conn, set
+/// the attribute and return the conn, enabling chained calls like:
+///
+/// ```rust
+/// struct MyState(&'static str);
+/// async fn handler(mut conn: trillium::Conn) -> trillium::Conn {
+///     conn.with_response_header("content-type", "text/plain")
+///         .with_state(MyState("hello"))
+///         .with_body("hey there")
+///         .with_status(418)
+/// }
+///
+/// use trillium_testing::prelude::*;
+///
+/// assert_response!(
+///     get("/").on(&handler),
+///     Status::ImATeapot,
+///     "hey there",
+///     "content-type" => "text/plain"
+/// );
+/// ```
+///
+/// If you need to set a property on the conn without moving it,
+/// `set_{attribute}` associated functions will be your huckleberry, as is
+/// conventional in other rust projects.
+///
+/// ## State
+///
+/// Every trillium Conn contains a state type which is a set that contains
+/// at most one element for each type. State is the primary way that
+/// handlers attach data to a conn as it passes through a tuple
+/// handler. State access should generally be implemented by libraries
+/// using a private type and exposed with a `ConnExt` trait. See [library
+/// patterns](https://trillium.rs/library_patterns.html#state) for more
+/// elaboration and examples.
+///
+/// ## In relation to [`trillium_http::Conn`]
+///
+/// `trillium::Conn` is currently implemented as an abstraction on top of a
+/// [`trillium_http::Conn`]. In particular, `trillium::Conn` boxes the
+/// transport using a [`BoxedTransport`](trillium_http::transport::BoxedTransport)
+/// so that application code can be written without transport
+/// generics. See [`Transport`](trillium_http::transport::Transport) for further
+/// reading on this.
 
 pub struct Conn {
     inner: trillium_http::Conn<BoxedTransport>,
@@ -93,34 +90,30 @@ impl<T: Transport + 'static> From<trillium_http::Conn<T>> for Conn {
 }
 
 impl Conn {
-    /**
-    `Conn::ok` is a convenience function for the common pattern of
-    setting a body and a 200 status in one call. It is exactly
-    identical to `conn.with_status(200).with_body(body).halt()`
-    ```
-    use trillium::Conn;
-    use trillium_testing::prelude::*;
-    let mut conn = get("/").on(&|conn: Conn| async move { conn.ok("hello") });
-    assert_body!(&mut conn, "hello");
-    assert_status!(&conn, 200);
-    assert!(conn.is_halted());
-    ```
-     */
+    /// `Conn::ok` is a convenience function for the common pattern of
+    /// setting a body and a 200 status in one call. It is exactly
+    /// identical to `conn.with_status(200).with_body(body).halt()`
+    /// ```
+    /// use trillium::Conn;
+    /// use trillium_testing::prelude::*;
+    /// let mut conn = get("/").on(&|conn: Conn| async move { conn.ok("hello") });
+    /// assert_body!(&mut conn, "hello");
+    /// assert_status!(&conn, 200);
+    /// assert!(conn.is_halted());
+    /// ```
     #[must_use]
     pub fn ok(self, body: impl Into<Body>) -> Self {
         self.with_status(200).with_body(body).halt()
     }
 
-    /**
-    returns the response status for this `Conn`, if it has been set.
-    ```
-    use trillium_testing::prelude::*;
-    let mut conn = get("/").on(&());
-    assert!(conn.status().is_none());
-    conn.set_status(200);
-    assert_eq!(conn.status().unwrap(), Status::Ok);
-    ```
-     */
+    /// returns the response status for this `Conn`, if it has been set.
+    /// ```
+    /// use trillium_testing::prelude::*;
+    /// let mut conn = get("/").on(&());
+    /// assert!(conn.status().is_none());
+    /// conn.set_status(200);
+    /// assert_eq!(conn.status().unwrap(), Status::Ok);
+    /// ```
     pub fn status(&self) -> Option<Status> {
         self.inner.status()
     }
@@ -130,21 +123,17 @@ impl Conn {
         self.inner.set_status(status);
     }
 
-    /**
-    sets the response status for this `Conn` and returns it. note that
-    this does not set the halted status.
-
-    ```
-    use trillium_testing::prelude::*;
-    let conn = get("/").on(&|conn: Conn| async move {
-        conn.with_status(418)
-    });
-    let status = conn.status().unwrap();
-    assert_eq!(status, Status::ImATeapot);
-    assert_eq!(status, 418);
-    assert!(!conn.is_halted());
-    ```
-     */
+    /// sets the response status for this `Conn` and returns it. note that
+    /// this does not set the halted status.
+    ///
+    /// ```
+    /// use trillium_testing::prelude::*;
+    /// let conn = get("/").on(&|conn: Conn| async move { conn.with_status(418) });
+    /// let status = conn.status().unwrap();
+    /// assert_eq!(status, Status::ImATeapot);
+    /// assert_eq!(status, 418);
+    /// assert!(!conn.is_halted());
+    /// ```
 
     #[must_use]
     pub fn with_status(mut self, status: impl TryInto<Status>) -> Self {
@@ -152,20 +141,16 @@ impl Conn {
         self
     }
 
-    /**
-    Sets the response body from any `impl Into<Body>` and returns the
-    `Conn` for fluent chaining. Note that this does not set the response
-    status or halted. See [`Conn::ok`] for a function that does both
-    of those.
-
-    ```
-    use trillium_testing::prelude::*;
-    let conn = get("/").on(&|conn: Conn| async move {
-        conn.with_body("hello")
-    });
-    assert_eq!(conn.response_len(), Some(5));
-    ```
-    */
+    /// Sets the response body from any `impl Into<Body>` and returns the
+    /// `Conn` for fluent chaining. Note that this does not set the response
+    /// status or halted. See [`Conn::ok`] for a function that does both
+    /// of those.
+    ///
+    /// ```
+    /// use trillium_testing::prelude::*;
+    /// let conn = get("/").on(&|conn: Conn| async move { conn.with_body("hello") });
+    /// assert_eq!(conn.response_len(), Some(5));
+    /// ```
 
     #[must_use]
     pub fn with_body(mut self, body: impl Into<Body>) -> Self {
@@ -173,69 +158,61 @@ impl Conn {
         self
     }
 
-    /**
-    Sets the response body from any `impl Into<Body>`. Note that this does not set the response
-    status or halted.
-
-    ```
-    use trillium_testing::prelude::*;
-    let mut conn = get("/").on(&());
-    conn.set_body("hello");
-    assert_eq!(conn.response_len(), Some(5));
-    ```
-    */
+    /// Sets the response body from any `impl Into<Body>`. Note that this does not set the response
+    /// status or halted.
+    ///
+    /// ```
+    /// use trillium_testing::prelude::*;
+    /// let mut conn = get("/").on(&());
+    /// conn.set_body("hello");
+    /// assert_eq!(conn.response_len(), Some(5));
+    /// ```
     pub fn set_body(&mut self, body: impl Into<Body>) {
         self.inner.set_response_body(body);
     }
 
-    /**
-    Removes the response body from the `Conn`
-
-    ```
-    use trillium_testing::prelude::*;
-    let mut conn = get("/").on(&());
-
-    conn.set_body("hello");
-    let mut body = conn.take_response_body().unwrap();
-    assert_eq!(body.len(), Some(5));
-    assert_eq!(conn.response_len(), None);
-    ```
-    */
+    /// Removes the response body from the `Conn`
+    ///
+    /// ```
+    /// use trillium_testing::prelude::*;
+    /// let mut conn = get("/").on(&());
+    ///
+    /// conn.set_body("hello");
+    /// let mut body = conn.take_response_body().unwrap();
+    /// assert_eq!(body.len(), Some(5));
+    /// assert_eq!(conn.response_len(), None);
+    /// ```
     pub fn take_response_body(&mut self) -> Option<Body> {
         self.inner.take_response_body()
     }
 
-    /**
-    Borrows the response body from the `Conn`
-
-    ```
-    use trillium_testing::prelude::*;
-    let mut conn = get("/").on(&());
-
-    conn.set_body("hello");
-    let body = conn.response_body().unwrap();
-    assert_eq!(body.len(), Some(5));
-    assert!(body.is_static());
-    assert_eq!(body.static_bytes(), Some(&b"hello"[..]));
-    ```
-    */
+    /// Borrows the response body from the `Conn`
+    ///
+    /// ```
+    /// use trillium_testing::prelude::*;
+    /// let mut conn = get("/").on(&());
+    ///
+    /// conn.set_body("hello");
+    /// let body = conn.response_body().unwrap();
+    /// assert_eq!(body.len(), Some(5));
+    /// assert!(body.is_static());
+    /// assert_eq!(body.static_bytes(), Some(&b"hello"[..]));
+    /// ```
     pub fn response_body(&self) -> Option<&Body> {
         self.inner.response_body()
     }
 
-    /**
-    Attempts to retrieve a &T from the state set
-
-    ```
-    use trillium_testing::prelude::*;
-
-    struct Hello;
-    let mut conn = get("/").on(&());
-    assert!(conn.state::<Hello>().is_none());
-    conn.insert_state(Hello);
-    assert!(conn.state::<Hello>().is_some());
-    ```
-    */
+    /// Attempts to retrieve a &T from the state set
+    ///
+    /// ```
+    /// use trillium_testing::prelude::*;
+    ///
+    /// struct Hello;
+    /// let mut conn = get("/").on(&());
+    /// assert!(conn.state::<Hello>().is_none());
+    /// conn.insert_state(Hello);
+    /// assert!(conn.state::<Hello>().is_some());
+    /// ```
     pub fn state<T: Send + Sync + 'static>(&self) -> Option<&T> {
         self.inner.state().get()
     }
@@ -283,85 +260,73 @@ impl Conn {
         self.inner.state_mut().entry()
     }
 
-    /**
-    Returns a [`ReceivedBody`] that references this `Conn`. The `Conn`
-    retains all data and holds the singular transport, but the
-    [`ReceivedBody`] provides an interface to read body content.
-
-    See also: [`Conn::request_body_string`] for a convenience function
-    when the content is expected to be utf8.
-
-
-    # Examples
-
-    ```
-    use trillium_testing::prelude::*;
-    let mut conn = get("/").with_request_body("request body").on(&());
-
-    # trillium_testing::block_on(async {
-    let request_body = conn.request_body().await;
-    assert_eq!(request_body.content_length(), Some(12));
-    assert_eq!(request_body.read_string().await.unwrap(), "request body");
-    # });
-    ```
-    */
+    /// Returns a [`ReceivedBody`] that references this `Conn`. The `Conn`
+    /// retains all data and holds the singular transport, but the
+    /// [`ReceivedBody`] provides an interface to read body content.
+    ///
+    /// See also: [`Conn::request_body_string`] for a convenience function
+    /// when the content is expected to be utf8.
+    ///
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use trillium_testing::prelude::*;
+    /// let mut conn = get("/").with_request_body("request body").on(&());
+    ///
+    /// # trillium_testing::block_on(async {
+    /// let request_body = conn.request_body().await;
+    /// assert_eq!(request_body.content_length(), Some(12));
+    /// assert_eq!(request_body.read_string().await.unwrap(), "request body");
+    /// # });
+    /// ```
     pub async fn request_body(&mut self) -> ReceivedBody<'_, BoxedTransport> {
         self.inner.request_body().await
     }
 
-    /**
-
-    Convenience function to read the content of a request body as a `String`.
-
-    # Errors
-
-    This will return an error variant if either there is an IO failure
-    on the underlying transport or if the body content is not a utf8
-    string.
-
-    # Examples
-
-    ```
-    use trillium_testing::prelude::*;
-    let mut conn = get("/").with_request_body("request body").on(&());
-
-    # trillium_testing::block_on(async {
-    assert_eq!(conn.request_body_string().await.unwrap(), "request body");
-    # });
-    ```
-    */
+    /// Convenience function to read the content of a request body as a `String`.
+    ///
+    /// # Errors
+    ///
+    /// This will return an error variant if either there is an IO failure
+    /// on the underlying transport or if the body content is not a utf8
+    /// string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use trillium_testing::prelude::*;
+    /// let mut conn = get("/").with_request_body("request body").on(&());
+    ///
+    /// # trillium_testing::block_on(async {
+    /// assert_eq!(conn.request_body_string().await.unwrap(), "request body");
+    /// # });
+    /// ```
     #[allow(clippy::missing_errors_doc)] // this is a false positive
     pub async fn request_body_string(&mut self) -> trillium_http::Result<String> {
         self.request_body().await.read_string().await
     }
 
-    /**
-    if there is a response body for this conn and it has a known
-    fixed length, it is returned from this function
-
-    ```
-    use trillium_testing::prelude::*;
-    let mut conn = get("/").on(&|conn: trillium::Conn| async move {
-        conn.with_body("hello")
-    });
-
-    assert_eq!(conn.response_len(), Some(5));
-    ```
-    */
+    /// if there is a response body for this conn and it has a known
+    /// fixed length, it is returned from this function
+    ///
+    /// ```
+    /// use trillium_testing::prelude::*;
+    /// let mut conn = get("/").on(&|conn: trillium::Conn| async move { conn.with_body("hello") });
+    ///
+    /// assert_eq!(conn.response_len(), Some(5));
+    /// ```
     pub fn response_len(&self) -> Option<u64> {
         self.inner.response_body().and_then(Body::len)
     }
 
-    /**
-    returns the request method for this conn.
-    ```
-    use trillium_testing::prelude::*;
-    let mut conn = get("/").on(&());
-
-    assert_eq!(conn.method(), Method::Get);
-    ```
-
-    */
+    /// returns the request method for this conn.
+    /// ```
+    /// use trillium_testing::prelude::*;
+    /// let mut conn = get("/").on(&());
+    ///
+    /// assert_eq!(conn.method(), Method::Get);
+    /// ```
     pub fn method(&self) -> Method {
         self.inner.method()
     }
@@ -416,74 +381,63 @@ impl Conn {
             .insert(header_name, header_value);
     }
 
-    /**
-    returns the path for this request. note that this may not
-    represent the entire http request path if running nested
-    routers.
-    */
+    /// returns the path for this request. note that this may not
+    /// represent the entire http request path if running nested
+    /// routers.
     pub fn path(&self) -> &str {
         self.path.last().map_or_else(|| self.inner.path(), |p| &**p)
     }
 
-    /**
-    returns query part of the request path
-
-    ```
-    use trillium_testing::prelude::*;
-    let conn = get("/a/b?c&d=e").on(&());
-    assert_eq!(conn.querystring(), "c&d=e");
-
-    let conn = get("/a/b").on(&());
-    assert_eq!(conn.querystring(), "");
-    ```
-
-
-    # Parsing
-
-    Trillium does not include a querystring parsing library, as there is no universal standard for
-    querystring encodings of arrays, but several library options exist, inluding:
-
-    * [`QueryStrong`](https://docs.rs/querystrong/) (by the author of trillium)
-    * [`serde_qs`](https://docs.rs/serde_qs/)
-    * [`querystring`](https://docs.rs/querystring/)
-    * [`serde_querystring`](https://docs.rs/serde-querystring/latest/serde_querystring/)
-
-    */
+    /// returns query part of the request path
+    ///
+    /// ```
+    /// use trillium_testing::prelude::*;
+    /// let conn = get("/a/b?c&d=e").on(&());
+    /// assert_eq!(conn.querystring(), "c&d=e");
+    ///
+    /// let conn = get("/a/b").on(&());
+    /// assert_eq!(conn.querystring(), "");
+    /// ```
+    ///
+    ///
+    /// # Parsing
+    ///
+    /// Trillium does not include a querystring parsing library, as there is no universal standard
+    /// for querystring encodings of arrays, but several library options exist, inluding:
+    ///
+    /// [`QueryStrong`](https://docs.rs/querystrong/) (by the author of trillium)
+    /// [`serde_qs`](https://docs.rs/serde_qs/)
+    /// [`querystring`](https://docs.rs/querystring/)
+    /// [`serde_querystring`](https://docs.rs/serde-querystring/latest/serde_querystring/)
     pub fn querystring(&self) -> &str {
         self.inner.querystring()
     }
 
-    /**
-    sets the `halted` attribute of this conn, preventing later
-    processing in a given tuple handler. returns
-    the conn for fluent chaining
-
-    ```
-    use trillium_testing::prelude::*;
-    let mut conn = get("/").on(&|conn: trillium::Conn| async move {
-        conn.halt()
-    });
-
-    assert!(conn.is_halted());
-    ```
-    */
+    /// sets the `halted` attribute of this conn, preventing later
+    /// processing in a given tuple handler. returns
+    /// the conn for fluent chaining
+    ///
+    /// ```
+    /// use trillium_testing::prelude::*;
+    /// let mut conn = get("/").on(&|conn: trillium::Conn| async move { conn.halt() });
+    ///
+    /// assert!(conn.is_halted());
+    /// ```
     #[must_use]
     pub fn halt(mut self) -> Self {
         self.set_halted(true);
         self
     }
 
-    /**
-    sets the `halted` attribute of this conn. see [`Conn::halt`].
-
-    ```
-    use trillium_testing::prelude::*;
-    let mut conn = get("/").on(&());
-    assert!(!conn.is_halted());
-    conn.set_halted(true);
-    assert!(conn.is_halted());
-    ```
-    */
+    /// sets the `halted` attribute of this conn. see [`Conn::halt`].
+    ///
+    /// ```
+    /// use trillium_testing::prelude::*;
+    /// let mut conn = get("/").on(&());
+    /// assert!(!conn.is_halted());
+    /// conn.set_halted(true);
+    /// assert!(conn.is_halted());
+    /// ```
     pub fn set_halted(&mut self, halted: bool) {
         self.halted = halted;
     }
@@ -503,7 +457,7 @@ impl Conn {
         self.inner.is_secure()
     }
 
-    /// The [`Instant`] that the first header bytes for this conn were
+    /// The [`Instant`][std::time::Instant] that the first header bytes for this conn were
     /// received, before any processing or parsing has been performed.
     pub fn start_time(&self) -> std::time::Instant {
         self.inner.start_time()
@@ -540,7 +494,7 @@ impl Conn {
     ///
     /// # Panics
     ///
-    /// This will panic if you attempt to downcast to the wrong Transport type.
+    /// This will panic if you attempt to downcast to the wrong `Transport` type.
     pub fn into_inner<T: Transport>(self) -> trillium_http::Conn<T> {
         self.inner.map_transport(|t| {
             *t.downcast()

--- a/trillium/src/handler.rs
+++ b/trillium/src/handler.rs
@@ -1,152 +1,138 @@
 use crate::{Conn, Headers, Info, Status, Upgrade};
 use std::{borrow::Cow, future::Future};
 
-/**
-# The building block for Trillium applications.
-
-## Concept
-
-Many other frameworks have a notion of `middleware` and `endpoints`,
-in which the model is that a request passes through a router and then
-any number of middlewares, then a single endpoint that returns a
-response, and then passes a response back through the middleware
-stack.
-
-Because a Trillium Conn represents both a request and response, there
-is no distinction between middleware and endpoints, as all of these
-can be modeled as `Fn(Conn) -> Future<Output = Conn>`.
-
-## Implementing Handler
-
-The simplest handler is an async closure or
-async fn that receives a Conn and returns a Conn, and Handler has a
-blanket implementation for any such Fn.
-
-```
-// as a closure
-let handler = |conn: trillium::Conn| async move { conn.ok("trillium!") };
-
-use trillium_testing::prelude::*;
-assert_ok!(get("/").on(&handler), "trillium!");
-```
-
-```
-// as an async function
-async fn handler(conn: trillium::Conn) -> trillium::Conn {
-    conn.ok("trillium!")
-}
-use trillium_testing::prelude::*;
-assert_ok!(get("/").on(&handler), "trillium!");
-```
-
-The simplest implementation of Handler for a named type looks like this:
-```
-pub struct MyHandler;
-impl trillium::Handler for MyHandler {
-    async fn run(&self, conn: trillium::Conn) -> trillium::Conn {
-        conn
-    }
-}
-
-use trillium_testing::prelude::*;
-assert_not_handled!(get("/").on(&MyHandler)); // we did not halt or set a body status
-```
-
-See each of the function definitions below for advanced implementation.
-
-For most application code and even trillium-packaged framework code,
-`run` is the only trait function that needs to be implemented.
-
-*/
+/// # The building block for Trillium applications.
+///
+/// ## Concept
+///
+/// Many other frameworks have a notion of `middleware` and `endpoints`,
+/// in which the model is that a request passes through a router and then
+/// any number of middlewares, then a single endpoint that returns a
+/// response, and then passes a response back through the middleware
+/// stack.
+///
+/// Because a Trillium Conn represents both a request and response, there
+/// is no distinction between middleware and endpoints, as all of these
+/// can be modeled as `Fn(Conn) -> Future<Output = Conn>`.
+///
+/// ## Implementing Handler
+///
+/// The simplest handler is an async closure or
+/// async fn that receives a Conn and returns a Conn, and Handler has a
+/// blanket implementation for any such Fn.
+///
+/// ```
+/// // as a closure
+/// let handler = |conn: trillium::Conn| async move { conn.ok("trillium!") };
+///
+/// use trillium_testing::prelude::*;
+/// assert_ok!(get("/").on(&handler), "trillium!");
+/// ```
+///
+/// ```
+/// // as an async function
+/// async fn handler(conn: trillium::Conn) -> trillium::Conn {
+///     conn.ok("trillium!")
+/// }
+/// use trillium_testing::prelude::*;
+/// assert_ok!(get("/").on(&handler), "trillium!");
+/// ```
+///
+/// The simplest implementation of Handler for a named type looks like this:
+/// ```
+/// pub struct MyHandler;
+/// impl trillium::Handler for MyHandler {
+///     async fn run(&self, conn: trillium::Conn) -> trillium::Conn {
+///         conn
+///     }
+/// }
+///
+/// use trillium_testing::prelude::*;
+/// assert_not_handled!(get("/").on(&MyHandler)); // we did not halt or set a body status
+/// ```
+///
+/// See each of the function definitions below for advanced implementation.
+///
+/// For most application code and even trillium-packaged framework code,
+/// `run` is the only trait function that needs to be implemented.
 
 pub trait Handler: Send + Sync + 'static {
     /// Executes this handler, performing any modifications to the
     /// Conn that are desired.
     fn run(&self, conn: Conn) -> impl Future<Output = Conn> + Send;
 
-    /**
-    Performs one-time async set up on a mutable borrow of the
-    Handler before the server starts accepting requests. This
-    allows a Handler to be defined in synchronous code but perform
-    async setup such as establishing a database connection or
-    fetching some state from an external source. This is optional,
-    and chances are high that you do not need this.
-
-    It also receives a mutable borrow of the [`Info`] that represents
-    the current connection.
-
-    **stability note:** This may go away at some point. Please open an
-    **issue if you have a use case which requires it.
-    */
+    /// Performs one-time async set up on a mutable borrow of the
+    /// Handler before the server starts accepting requests. This
+    /// allows a Handler to be defined in synchronous code but perform
+    /// async setup such as establishing a database connection or
+    /// fetching some state from an external source. This is optional,
+    /// and chances are high that you do not need this.
+    ///
+    /// It also receives a mutable borrow of the [`Info`] that represents
+    /// the current connection.
+    ///
+    /// **stability note:** This may go away at some point. Please open an
+    /// issue if you have a use case which requires it.
     fn init(&mut self, _info: &mut Info) -> impl Future<Output = ()> + Send {
         std::future::ready(())
     }
 
-    /**
-    Performs any final modifications to this conn after all handlers
-    have been run. Although this is a slight deviation from the simple
-    conn->conn->conn chain represented by most Handlers, it provides
-    an easy way for libraries to effectively inject a second handler
-    into a response chain. This is useful for loggers that need to
-    record information both before and after other handlers have run,
-    as well as database transaction handlers and similar library code.
-
-    **❗IMPORTANT NOTE FOR LIBRARY AUTHORS:** Please note that this
-    will run __whether or not the conn has was halted before
-    [`Handler::run`] was called on a given conn__. This means that if
-    you want to make your `before_send` callback conditional on
-    whether `run` was called, you need to put a unit type into the
-    conn's state and check for that.
-
-    stability note: I don't love this for the exact reason that it
-    breaks the simplicity of the conn->conn->model, but it is
-    currently the best compromise between that simplicity and
-    convenience for the application author, who should not have to add
-    two Handlers to achieve an "around" effect.
-    */
+    /// Performs any final modifications to this conn after all handlers
+    /// have been run. Although this is a slight deviation from the simple
+    /// conn->conn->conn chain represented by most Handlers, it provides
+    /// an easy way for libraries to effectively inject a second handler
+    /// into a response chain. This is useful for loggers that need to
+    /// record information both before and after other handlers have run,
+    /// as well as database transaction handlers and similar library code.
+    ///
+    /// ❗IMPORTANT NOTE FOR LIBRARY AUTHORS:** Please note that this
+    /// will run __whether or not the conn has was halted before
+    /// [`Handler::run`] was called on a given conn__. This means that if
+    /// you want to make your `before_send` callback conditional on
+    /// whether `run` was called, you need to put a unit type into the
+    /// conn's state and check for that.
+    ///
+    /// stability note: I don't love this for the exact reason that it
+    /// breaks the simplicity of the conn->conn->model, but it is
+    /// currently the best compromise between that simplicity and
+    /// convenience for the application author, who should not have to add
+    /// two Handlers to achieve an "around" effect.
     fn before_send(&self, conn: Conn) -> impl Future<Output = Conn> + Send {
         std::future::ready(conn)
     }
 
-    /**
-    predicate function answering the question of whether this Handler
-    would like to take ownership of the negotiated Upgrade. If this
-    returns true, you must implement [`Handler::upgrade`]. The first
-    handler that responds true to this will receive ownership of the
-    [`trillium::Upgrade`][crate::Upgrade] in a subsequent call to [`Handler::upgrade`]
-    */
+    /// predicate function answering the question of whether this Handler
+    /// would like to take ownership of the negotiated Upgrade. If this
+    /// returns true, you must implement [`Handler::upgrade`]. The first
+    /// handler that responds true to this will receive ownership of the
+    /// [`trillium::Upgrade`][crate::Upgrade] in a subsequent call to [`Handler::upgrade`]
     fn has_upgrade(&self, upgrade: &Upgrade) -> bool {
         let _ = upgrade;
         false
     }
 
-    /**
-    This will only be called if the handler reponds true to
-    [`Handler::has_upgrade`] and will only be called once for this
-    upgrade. There is no return value, and this function takes
-    exclusive ownership of the underlying transport once this is
-    called. You can downcast the transport to whatever the source
-    transport type is and perform any non-http protocol communication
-    that has been negotiated. You probably don't want this unless
-    you're implementing something like websockets. Please note that
-    for many transports such as `TcpStreams`, dropping the transport
-    (and therefore the Upgrade) will hang up / disconnect.
-    */
+    /// This will only be called if the handler reponds true to
+    /// [`Handler::has_upgrade`] and will only be called once for this
+    /// upgrade. There is no return value, and this function takes
+    /// exclusive ownership of the underlying transport once this is
+    /// called. You can downcast the transport to whatever the source
+    /// transport type is and perform any non-http protocol communication
+    /// that has been negotiated. You probably don't want this unless
+    /// you're implementing something like websockets. Please note that
+    /// for many transports such as `TcpStreams`, dropping the transport
+    /// (and therefore the Upgrade) will hang up / disconnect.
     fn upgrade(&self, upgrade: Upgrade) -> impl Future<Output = ()> + Send {
         let _ = upgrade;
         async { unimplemented!("if has_upgrade returns true, you must also implement upgrade") }
     }
 
-    /**
-    Customize the name of your handler. This is used in Debug
-    implementations. The default is the type name of this handler.
-    */
+    /// Customize the name of your handler. This is used in Debug
+    /// implementations. The default is the type name of this handler.
     fn name(&self) -> Cow<'static, str> {
         std::any::type_name::<Self>().into()
     }
 }
 
-//
 // impl Handler for Box<dyn Handler> {
 //     async fn run(&self, conn: Conn) -> Conn {
 //         self.as_ref().run(conn).await

--- a/trillium/src/info.rs
+++ b/trillium/src/info.rs
@@ -6,12 +6,10 @@ use trillium_http::TypeSet;
 
 const DEFAULT_SERVER_DESCRIPTION: &str = concat!("trillium v", env!("CARGO_PKG_VERSION"));
 
-/**
-This struct represents information about the currently connected
-server.
-
-It is passed to [`Handler::init`](crate::Handler::init).
-*/
+/// This struct represents information about the currently connected
+/// server.
+///
+/// It is passed to [`Handler::init`](crate::Handler::init).
 
 #[derive(Debug)]
 pub struct Info {

--- a/trillium/src/lib.rs
+++ b/trillium/src/lib.rs
@@ -10,24 +10,21 @@
 #![warn(missing_docs, clippy::pedantic, clippy::nursery, clippy::cargo)]
 #![allow(clippy::must_use_candidate, clippy::module_name_repetitions)]
 
-/*!
-# Welcome to the `trillium` crate!
-
-This crate is the primary dependency for building a trillium app or
-library. It contains a handful of core types and reexports a few
-others that you will necessarily need, but otherwise tries to stay
-small and focused. This crate will hopefully be the most stable within
-the trillium ecosystem. That said, trillium is still pre 1.0 and
-should be expected to evolve over time.
-
-To get started with this crate, first take a look at [the
-guide](https://trillium.rs), then browse the docs for
-[`trillium::Conn`](crate::Conn).
-
-At a minimum to build a trillium app, you'll also need a trillium
-[runtime adapter](https://trillium.rs/overview/runtimes.html).
-
-*/
+//! # Welcome to the `trillium` crate!
+//!
+//! This crate is the primary dependency for building a trillium app or
+//! library. It contains a handful of core types and reexports a few
+//! others that you will necessarily need, but otherwise tries to stay
+//! small and focused. This crate will hopefully be the most stable within
+//! the trillium ecosystem. That said, trillium is still pre 1.0 and
+//! should be expected to evolve over time.
+//!
+//! To get started with this crate, first take a look at [the
+//! guide](https://trillium.rs), then browse the docs for
+//! [`trillium::Conn`](crate::Conn).
+//!
+//! At a minimum to build a trillium app, you'll also need a trillium
+//! [runtime adapter](https://trillium.rs/overview/runtimes.html).
 mod handler;
 pub use handler::Handler;
 
@@ -41,13 +38,11 @@ pub use trillium_http::{
     Method, Status, Swansong, TypeSet, Version,
 };
 
-/**
-# A HTTP protocol upgrade
-
-This exists to erase the generic transport for convenience using a
-[`BoxedTransport`](trillium_http::transport::BoxedTransport). See
-[`Upgrade`](trillium_http::Upgrade) for additional documentation
-*/
+/// # A HTTP protocol upgrade
+///
+/// This exists to erase the generic transport for convenience using a
+/// [`BoxedTransport`](trillium_http::transport::BoxedTransport). See
+/// [`Upgrade`](trillium_http::Upgrade) for additional documentation
 pub type Upgrade = trillium_http::Upgrade<trillium_http::transport::BoxedTransport>;
 
 mod macros;

--- a/trillium/src/macros.rs
+++ b/trillium/src/macros.rs
@@ -1,31 +1,22 @@
-/**
-# Unwraps an `Result::Ok` or returns the `Conn` with a 500 status.
-
-```
-use trillium_testing::prelude::*;
-use trillium::{Conn, conn_try};
-
-let handler = |mut conn: Conn| async move {
-  let request_body_string = conn_try!(conn.request_body_string().await, conn);
-  let u8: u8 = conn_try!(request_body_string.parse(), conn);
-  conn.ok(format!("received u8 as body: {}", u8))
-};
-
-assert_status!(
-    post("/").with_request_body("not u8").on(&handler),
-    500
-);
-
-assert_body!(
-    post("/").with_request_body("10").on(&handler),
-    "received u8 as body: 10"
-);
-
-
-```
-
-
-*/
+/// # Unwraps an `Result::Ok` or returns the `Conn` with a 500 status.
+///
+/// ```
+/// use trillium::{conn_try, Conn};
+/// use trillium_testing::prelude::*;
+///
+/// let handler = |mut conn: Conn| async move {
+///     let request_body_string = conn_try!(conn.request_body_string().await, conn);
+///     let u8: u8 = conn_try!(request_body_string.parse(), conn);
+///     conn.ok(format!("received u8 as body: {}", u8))
+/// };
+///
+/// assert_status!(post("/").with_request_body("not u8").on(&handler), 500);
+///
+/// assert_body!(
+///     post("/").with_request_body("10").on(&handler),
+///     "received u8 as body: 10"
+/// );
+/// ```
 #[macro_export]
 macro_rules! conn_try {
     ($expr:expr, $conn:expr) => {
@@ -39,31 +30,26 @@ macro_rules! conn_try {
     };
 }
 
-/**
-# Unwraps an `Option::Some` or returns the `Conn`.
-
-This is useful for gracefully exiting a `Handler` without
-returning an error.
-
-```
-use trillium_testing::prelude::*;
-use trillium::{Conn, conn_unwrap, State};
-
-#[derive(Copy, Clone)]
-struct MyState(&'static str);
-let handler = |conn: trillium::Conn| async move {
-  let important_state: MyState = *conn_unwrap!(conn.state(), conn);
-  conn.ok(important_state.0)
-};
-
-assert_not_handled!(get("/").on(&handler)); // we never reached the conn.ok line.
-
-assert_ok!(
-    get("/").on(&(State::new(MyState("hi")), handler)),
-    "hi"
-);
-```
-*/
+/// # Unwraps an `Option::Some` or returns the `Conn`.
+///
+/// This is useful for gracefully exiting a `Handler` without
+/// returning an error.
+///
+/// ```
+/// use trillium::{conn_unwrap, Conn, State};
+/// use trillium_testing::prelude::*;
+///
+/// #[derive(Copy, Clone)]
+/// struct MyState(&'static str);
+/// let handler = |conn: trillium::Conn| async move {
+///     let important_state: MyState = *conn_unwrap!(conn.state(), conn);
+///     conn.ok(important_state.0)
+/// };
+///
+/// assert_not_handled!(get("/").on(&handler)); // we never reached the conn.ok line.
+///
+/// assert_ok!(get("/").on(&(State::new(MyState("hi")), handler)), "hi");
+/// ```
 #[macro_export]
 macro_rules! conn_unwrap {
     ($option:expr, $conn:expr) => {
@@ -74,12 +60,10 @@ macro_rules! conn_unwrap {
     };
 }
 
-/**
-# A convenience macro for logging the contents of error variants.
-
-This is useful when there is no further action required to process the
-error path, but you still want to record that it transpired
-*/
+/// # A convenience macro for logging the contents of error variants.
+///
+/// This is useful when there is no further action required to process the
+/// error path, but you still want to record that it transpired
 #[macro_export]
 macro_rules! log_error {
     ($expr:expr) => {
@@ -95,56 +79,52 @@ macro_rules! log_error {
     };
 }
 
-/**
-# Macro for implementing Handler for simple newtypes that contain another handler.
-
-```
-use trillium::{delegate_handler, State, Conn, conn_unwrap};
-
-#[derive(Clone, Copy)]
-struct MyState(usize);
-struct MyHandler { handler: State<MyState> }
-delegate_handler!(MyHandler => handler);
-impl MyHandler {
-    fn new(n: usize) -> Self {
-        MyHandler { handler: State::new(MyState(n)) }
-    }
-}
-
-
-# use trillium_testing::prelude::*;
-
-let handler = (MyHandler::new(5), |conn: Conn| async move {
-    let MyState(n) = *conn_unwrap!(conn.state(), conn);
-    conn.ok(n.to_string())
-});
-assert_ok!(get("/").on(&handler), "5");
-```
-
-```
-use trillium::{delegate_handler, State, Conn, conn_unwrap};
-
-#[derive(Clone, Copy)]
-struct MyState(usize);
-struct MyHandler(State<MyState>);
-delegate_handler!(MyHandler);
-impl MyHandler {
-    fn new(n: usize) -> Self {
-        MyHandler(State::new(MyState(n)))
-    }
-}
-
-
-# use trillium_testing::prelude::*;
-
-let handler = (MyHandler::new(5), |conn: Conn| async move {
-    let MyState(n) = *conn_unwrap!(conn.state(), conn);
-    conn.ok(n.to_string())
-});
-assert_ok!(get("/").on(&handler), "5");
-```
-
-*/
+/// # Macro for implementing Handler for simple newtypes that contain another handler.
+///
+/// ```
+/// use trillium::{delegate_handler, State, Conn, conn_unwrap};
+///
+/// #[derive(Clone, Copy)]
+/// struct MyState(usize);
+/// struct MyHandler { handler: State<MyState> }
+/// delegate_handler!(MyHandler => handler);
+/// impl MyHandler {
+/// fn new(n: usize) -> Self {
+/// MyHandler { handler: State::new(MyState(n)) }
+/// }
+/// }
+///
+///
+/// # use trillium_testing::prelude::*;
+///
+/// let handler = (MyHandler::new(5), |conn: Conn| async move {
+/// let MyState(n) = *conn_unwrap!(conn.state(), conn);
+/// conn.ok(n.to_string())
+/// });
+/// assert_ok!(get("/").on(&handler), "5");
+/// ```
+///
+/// ```
+/// use trillium::{conn_unwrap, delegate_handler, Conn, State};
+///
+/// #[derive(Clone, Copy)]
+/// struct MyState(usize);
+/// struct MyHandler(State<MyState>);
+/// delegate_handler!(MyHandler);
+/// impl MyHandler {
+///     fn new(n: usize) -> Self {
+///         MyHandler(State::new(MyState(n)))
+///     }
+/// }
+///
+/// # use trillium_testing::prelude::*;
+///
+/// let handler = (MyHandler::new(5), |conn: Conn| async move {
+///     let MyState(n) = *conn_unwrap!(conn.state(), conn);
+///     conn.ok(n.to_string())
+/// });
+/// assert_ok!(get("/").on(&handler), "5");
+/// ```
 #[macro_export]
 macro_rules! delegate_handler {
     ($struct_name:ty) => {

--- a/trillium/src/state.rs
+++ b/trillium/src/state.rs
@@ -1,65 +1,61 @@
 use crate::{Conn, Handler};
 use std::fmt::{self, Debug, Formatter};
 
-/**
-# A handler for sharing state across an application.
-
-State is a handler that puts a clone of any `Clone + Send + Sync +
-'static` type into every conn's state map.
-
-```
-use std::sync::{atomic::{AtomicBool, Ordering}, Arc};
-use trillium::{Conn, State};
-use trillium_testing::prelude::*;
-
-
-#[derive(Clone, Default)] // Clone is mandatory
-struct MyFeatureFlag(Arc<AtomicBool>);
-
-impl MyFeatureFlag {
-    pub fn is_enabled(&self) -> bool {
-       self.0.load(Ordering::Relaxed)
-    }
-
-    pub fn toggle(&self) {
-       self.0.fetch_xor(true, Ordering::Relaxed);
-    }
-}
-
-let feature_flag = MyFeatureFlag::default();
-
-let handler = (
-    State::new(feature_flag.clone()),
-    |conn: Conn| async move {
-      if conn.state::<MyFeatureFlag>().unwrap().is_enabled() {
-          conn.ok("feature enabled")
-      } else {
-          conn.ok("not enabled")
-      }
-    }
-);
-
-assert!(!feature_flag.is_enabled());
-assert_ok!(get("/").on(&handler), "not enabled");
-assert_ok!(get("/").on(&handler), "not enabled");
-feature_flag.toggle();
-assert!(feature_flag.is_enabled());
-assert_ok!(get("/").on(&handler), "feature enabled");
-assert_ok!(get("/").on(&handler), "feature enabled");
-
-```
-
-Please note that as with the above contrived example, if your state
-needs to be mutable, you need to choose your own interior mutability
-with whatever cross thread synchronization mechanisms are appropriate
-for your application. There will be one clones of the contained T type
-in memory for each http connection, and any locks should be held as
-briefly as possible so as to minimize impact on other conns.
-
-**Stability note:** This is a common enough pattern that it currently
-exists in the public api, but may be removed at some point for
-simplicity.
-*/
+/// # A handler for sharing state across an application.
+///
+/// State is a handler that puts a clone of any `Clone + Send + Sync +
+/// 'static` type into every conn's state map.
+///
+/// ```
+/// use std::sync::{
+///     atomic::{AtomicBool, Ordering},
+///     Arc,
+/// };
+/// use trillium::{Conn, State};
+/// use trillium_testing::prelude::*;
+///
+/// #[derive(Clone, Default)] // Clone is mandatory
+/// struct MyFeatureFlag(Arc<AtomicBool>);
+///
+/// impl MyFeatureFlag {
+///     pub fn is_enabled(&self) -> bool {
+///         self.0.load(Ordering::Relaxed)
+///     }
+///
+///     pub fn toggle(&self) {
+///         self.0.fetch_xor(true, Ordering::Relaxed);
+///     }
+/// }
+///
+/// let feature_flag = MyFeatureFlag::default();
+///
+/// let handler = (State::new(feature_flag.clone()), |conn: Conn| async move {
+///     if conn.state::<MyFeatureFlag>().unwrap().is_enabled() {
+///         conn.ok("feature enabled")
+///     } else {
+///         conn.ok("not enabled")
+///     }
+/// });
+///
+/// assert!(!feature_flag.is_enabled());
+/// assert_ok!(get("/").on(&handler), "not enabled");
+/// assert_ok!(get("/").on(&handler), "not enabled");
+/// feature_flag.toggle();
+/// assert!(feature_flag.is_enabled());
+/// assert_ok!(get("/").on(&handler), "feature enabled");
+/// assert_ok!(get("/").on(&handler), "feature enabled");
+/// ```
+///
+/// Please note that as with the above contrived example, if your state
+/// needs to be mutable, you need to choose your own interior mutability
+/// with whatever cross thread synchronization mechanisms are appropriate
+/// for your application. There will be one clones of the contained T type
+/// in memory for each http connection, and any locks should be held as
+/// briefly as possible so as to minimize impact on other conns.
+///
+/// **Stability note:** This is a common enough pattern that it currently
+/// exists in the public api, but may be removed at some point for
+/// simplicity.
 
 pub struct State<T>(T);
 

--- a/websockets/src/json.rs
+++ b/websockets/src/json.rs
@@ -1,8 +1,6 @@
-/*!
-# websocket json adapter
-
-See the documentation for [`JsonWebSocketHandler`]
-*/
+//! # websocket json adapter
+//!
+//! See the documentation for [`JsonWebSocketHandler`]
 
 use crate::{WebSocket, WebSocketConn, WebSocketHandler};
 use async_tungstenite::tungstenite::{protocol::CloseFrame, Message};
@@ -16,111 +14,96 @@ use std::{
     task::{Context, Poll},
 };
 
-/**
-# Implement this trait to use websockets with a json handler
-
-JsonWebSocketHandler provides a small layer of abstraction on top of
-[`WebSocketHandler`], serializing and deserializing messages for
-you. This may eventually move to a crate of its own.
-
-## ℹ️ In order to use this trait, the `json` crate feature must be enabled.
-
-```
-use async_channel::{unbounded, Receiver, Sender};
-use serde::{Deserialize, Serialize};
-use std::pin::Pin;
-use trillium::log_error;
-use trillium_websockets::{json_websocket, JsonWebSocketHandler, WebSocketConn, Result};
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
-struct Response {
-    inbound_message: Inbound,
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
-struct Inbound {
-    message: String,
-}
-
-struct SomeJsonChannel;
-
-impl JsonWebSocketHandler for SomeJsonChannel {
-    type InboundMessage = Inbound;
-    type OutboundMessage = Response;
-    type StreamType = Pin<Box<Receiver<Self::OutboundMessage>>>;
-
-    async fn connect(&self, conn: &mut WebSocketConn) -> Self::StreamType {
-        let (s, r) = unbounded();
-        conn.insert_state(s);
-        Box::pin(r)
-    }
-
-    async fn receive_message(
-        &self,
-        inbound_message: Result<Self::InboundMessage>,
-        conn: &mut WebSocketConn,
-    ) {
-        if let Ok(inbound_message) = inbound_message {
-            log_error!(
-                conn.state::<Sender<Response>>()
-                    .unwrap()
-                    .send(Response { inbound_message })
-                    .await
-            );
-        }
-    }
-}
-
-// fn main() {
-//    trillium_smol::run(json_websocket(SomeJsonChannel));
-// }
-```
-
-*/
+/// # Implement this trait to use websockets with a json handler
+///
+/// JsonWebSocketHandler provides a small layer of abstraction on top of
+/// [`WebSocketHandler`], serializing and deserializing messages for
+/// you. This may eventually move to a crate of its own.
+///
+/// ## ℹ️ In order to use this trait, the `json` crate feature must be enabled.
+///
+/// ```
+/// use async_channel::{unbounded, Receiver, Sender};
+/// use serde::{Deserialize, Serialize};
+/// use std::pin::Pin;
+/// use trillium::log_error;
+/// use trillium_websockets::{json_websocket, JsonWebSocketHandler, Result, WebSocketConn};
+///
+/// #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+/// struct Response {
+///     inbound_message: Inbound,
+/// }
+///
+/// #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+/// struct Inbound {
+///     message: String,
+/// }
+///
+/// struct SomeJsonChannel;
+///
+/// impl JsonWebSocketHandler for SomeJsonChannel {
+///     type InboundMessage = Inbound;
+///     type OutboundMessage = Response;
+///     type StreamType = Pin<Box<Receiver<Self::OutboundMessage>>>;
+///
+///     async fn connect(&self, conn: &mut WebSocketConn) -> Self::StreamType {
+///         let (s, r) = unbounded();
+///         conn.insert_state(s);
+///         Box::pin(r)
+///     }
+///
+///     async fn receive_message(
+///         &self,
+///         inbound_message: Result<Self::InboundMessage>,
+///         conn: &mut WebSocketConn,
+///     ) {
+///         if let Ok(inbound_message) = inbound_message {
+///             log_error!(
+///                 conn.state::<Sender<Response>>()
+///                     .unwrap()
+///                     .send(Response { inbound_message })
+///                     .await
+///             );
+///         }
+///     }
+/// }
+///
+/// // fn main() {
+/// //    trillium_smol::run(json_websocket(SomeJsonChannel));
+/// // }
+/// ```
 #[allow(unused_variables)]
 pub trait JsonWebSocketHandler: Send + Sync + 'static {
-    /**
-    A type that can be deserialized from the json sent from the
-    connected clients
-    */
+    /// A type that can be deserialized from the json sent from the
+    /// connected clients
     type InboundMessage: DeserializeOwned + Send + 'static;
 
-    /**
-    A serializable type that will be sent in the StreamType and
-    received by the connected websocket clients
-    */
+    /// A serializable type that will be sent in the StreamType and
+    /// received by the connected websocket clients
     type OutboundMessage: Serialize + Send + 'static;
 
-    /**
-    A type that implements a stream of
-    [`Self::OutboundMessage`]s. This can be
-    futures_lite::stream::Pending if you never need to send an
-    outbound message.
-    */
+    /// A type that implements a stream of
+    /// [`Self::OutboundMessage`]s. This can be
+    /// futures_lite::stream::Pending if you never need to send an
+    /// outbound message.
     type StreamType: Stream<Item = Self::OutboundMessage> + Send + Sync + 'static;
 
-    /**
-    `connect` is called once for each upgraded websocket
-    connection, and returns a Self::StreamType.
-    */
+    /// `connect` is called once for each upgraded websocket
+    /// connection, and returns a Self::StreamType.
     fn connect(&self, conn: &mut WebSocketConn) -> impl Future<Output = Self::StreamType> + Send;
 
-    /**
-    `receive_message` is called once for each successfully deserialized
-    InboundMessage along with the websocket conn that it was received
-    from.
-    */
+    /// `receive_message` is called once for each successfully deserialized
+    /// InboundMessage along with the websocket conn that it was received
+    /// from.
     fn receive_message(
         &self,
         message: crate::Result<Self::InboundMessage>,
         conn: &mut WebSocketConn,
     ) -> impl Future<Output = ()> + Send;
 
-    /**
-    `disconnect` is called when websocket clients disconnect, along
-    with a CloseFrame, if one was provided. Implementing `disconnect`
-    is optional.
-    */
+    /// `disconnect` is called when websocket clients disconnect, along
+    /// with a CloseFrame, if one was provided. Implementing `disconnect`
+    /// is optional.
     fn disconnect(
         &self,
         conn: &mut WebSocketConn,
@@ -130,12 +113,10 @@ pub trait JsonWebSocketHandler: Send + Sync + 'static {
     }
 }
 
-/**
-A wrapper type for [`JsonWebSocketHandler`]s
-
-You do not need to interact with this type directly. Instead, use
-[`WebSocket::new_json`] or [`json_websocket`].
-*/
+/// A wrapper type for [`JsonWebSocketHandler`]s
+///
+/// You do not need to interact with this type directly. Instead, use
+/// [`WebSocket::new_json`] or [`json_websocket`].
 pub struct JsonHandler<T> {
     pub(crate) handler: T,
 }
@@ -167,10 +148,8 @@ impl<T> Debug for JsonHandler<T> {
 }
 
 pin_project_lite::pin_project! {
-    /**
-    A stream for internal use that attempts to serialize the items in the
-    wrapped stream to a [`Message::Text`]
-     */
+    /// A stream for internal use that attempts to serialize the items in the wrapped stream to a
+    /// [`Message::Text`]
     #[derive(Debug)]
     pub struct SerializedStream<T> {
         #[pin] inner: T
@@ -236,19 +215,15 @@ impl<T> WebSocket<JsonHandler<T>>
 where
     T: JsonWebSocketHandler,
 {
-    /**
-    Build a new trillium WebSocket handler from the provided
-    [`JsonWebSocketHandler`]
-     */
+    /// Build a new trillium WebSocket handler from the provided
+    /// [`JsonWebSocketHandler`]
     pub fn new_json(handler: T) -> Self {
         Self::new(JsonHandler::new(handler))
     }
 }
 
-/**
-builds a new trillium handler from the provided
-[`JsonWebSocketHandler`]. Alias for [`WebSocket::new_json`]
-*/
+/// builds a new trillium handler from the provided
+/// [`JsonWebSocketHandler`]. Alias for [`WebSocket::new_json`]
 pub fn json_websocket<T>(json_websocket_handler: T) -> WebSocket<JsonHandler<T>>
 where
     T: JsonWebSocketHandler,

--- a/websockets/src/lib.rs
+++ b/websockets/src/lib.rs
@@ -9,49 +9,47 @@
     unused_qualifications
 )]
 
-/*!
-# A websocket trillium handler
-
-There are three primary ways to use this crate
-
-## With an async function that receives a [`WebSocketConn`](crate::WebSocketConn)
-
-This is the simplest way to use trillium websockets, but does not
-provide any of the affordances that implementing the
-[`WebSocketHandler`] trait does. It is best for very simple websockets
-or for usages that require moving the WebSocketConn elsewhere in an
-application. The WebSocketConn is fully owned at this point, and will
-disconnect when dropped, not when the async function passed to
-`websocket` completes.
-
-```
-use futures_lite::stream::StreamExt;
-use trillium_websockets::{Message, WebSocketConn, websocket};
-
-let handler = websocket(|mut conn: WebSocketConn| async move {
-    while let Some(Ok(Message::Text(input))) = conn.next().await {
-        conn.send_string(format!("received your message: {}", &input)).await;
-    }
-});
-# // tests at tests/tests.rs for example simplicity
-```
-
-
-## Implementing [`WebSocketHandler`](crate::WebSocketHandler)
-
-[`WebSocketHandler`] provides support for sending outbound messages as a
-stream, and simplifies common patterns like executing async code on
-received messages.
-
-## Using [`JsonWebSocketHandler`](crate::JsonWebSocketHandler)
-
-[`JsonWebSocketHandler`] provides a thin serialization and
-deserialization layer on top of [`WebSocketHandler`] for this common
-use case.  See the [`JsonWebSocketHandler`] documentation for example
-usage. In order to use this trait, the `json` cargo feature must be
-enabled.
-
-*/
+//! # A websocket trillium handler
+//!
+//! There are three primary ways to use this crate
+//!
+//! ## With an async function that receives a [`WebSocketConn`](crate::WebSocketConn)
+//!
+//! This is the simplest way to use trillium websockets, but does not
+//! provide any of the affordances that implementing the
+//! [`WebSocketHandler`] trait does. It is best for very simple websockets
+//! or for usages that require moving the WebSocketConn elsewhere in an
+//! application. The WebSocketConn is fully owned at this point, and will
+//! disconnect when dropped, not when the async function passed to
+//! `websocket` completes.
+//!
+//! ```
+//! use futures_lite::stream::StreamExt;
+//! use trillium_websockets::{websocket, Message, WebSocketConn};
+//!
+//! let handler = websocket(|mut conn: WebSocketConn| async move {
+//!     while let Some(Ok(Message::Text(input))) = conn.next().await {
+//!         conn.send_string(format!("received your message: {}", &input))
+//!             .await;
+//!     }
+//! });
+//! # // tests at tests/tests.rs for example simplicity
+//! ```
+//!
+//!
+//! ## Implementing [`WebSocketHandler`](crate::WebSocketHandler)
+//!
+//! [`WebSocketHandler`] provides support for sending outbound messages as a
+//! stream, and simplifies common patterns like executing async code on
+//! received messages.
+//!
+//! ## Using [`JsonWebSocketHandler`](crate::JsonWebSocketHandler)
+//!
+//! [`JsonWebSocketHandler`] provides a thin serialization and
+//! deserialization layer on top of [`WebSocketHandler`] for this common
+//! use case.  See the [`JsonWebSocketHandler`] documentation for example
+//! usage. In order to use this trait, the `json` cargo feature must be
+//! enabled.
 
 mod bidirectional_stream;
 mod websocket_connection;
@@ -110,10 +108,8 @@ mod json;
 #[cfg(feature = "json")]
 pub use json::{json_websocket, JsonHandler, JsonWebSocketHandler};
 
-/**
-The trillium handler.
-See crate-level docs for example usage.
-*/
+/// The trillium handler.
+/// See crate-level docs for example usage.
 #[derive(Debug)]
 pub struct WebSocket<H> {
     handler: H,
@@ -136,10 +132,8 @@ impl<H> DerefMut for WebSocket<H> {
     }
 }
 
-/**
-Builds a new trillium handler from the provided
-WebSocketHandler. Alias for [`WebSocket::new`]
-*/
+/// Builds a new trillium handler from the provided
+/// WebSocketHandler. Alias for [`WebSocket::new`]
 pub fn websocket<H>(websocket_handler: H) -> WebSocket<H>
 where
     H: WebSocketHandler,

--- a/websockets/src/websocket_connection.rs
+++ b/websockets/src/websocket_connection.rs
@@ -16,16 +16,14 @@ use swansong::{Interrupt, Swansong};
 use trillium::{Headers, Method, TypeSet, Upgrade};
 use trillium_http::{transport::BoxedTransport, type_set::entry::Entry};
 
-/**
-A struct that represents an specific websocket connection.
-
-This can be thought of as a combination of a [`async_tungstenite::WebSocketStream`] and a
-[`trillium::Conn`], as it contains a combination of their fields and
-associated functions.
-
-The WebSocketConn implements `Stream<Item=Result<Message, Error>>`,
-and can be polled with `StreamExt::next`
- */
+/// A struct that represents an specific websocket connection.
+///
+/// This can be thought of as a combination of a [`async_tungstenite::WebSocketStream`] and a
+/// [`trillium::Conn`], as it contains a combination of their fields and
+/// associated functions.
+///
+/// The WebSocketConn implements `Stream<Item=Result<Message, Error>>`,
+/// and can be polled with `StreamExt::next`
 
 #[derive(Debug)]
 pub struct WebSocketConn {
@@ -130,18 +128,14 @@ impl WebSocketConn {
         self.peer_ip = peer_ip
     }
 
-    /**
-    retrieves the path part of the request url, up to and excluding
-    any query component
-     */
+    /// retrieves the path part of the request url, up to and excluding
+    /// any query component
     pub fn path(&self) -> &str {
         self.path.split('?').next().unwrap_or_default()
     }
 
-    /**
-    Retrieves the query component of the path, excluding `?`. Returns
-    an empty string if there is no query component.
-     */
+    /// Retrieves the query component of the path, excluding `?`. Returns
+    /// an empty string if there is no query component.
     pub fn querystring(&self) -> &str {
         self.path
             .split_once('?')
@@ -154,19 +148,15 @@ impl WebSocketConn {
         self.method
     }
 
-    /**
-    retrieve state from the state set that has been accumulated by
-    trillium handlers run on the [`trillium::Conn`] before it
-    became a websocket. see [`trillium::Conn::state`] for more
-    information
-     */
+    /// retrieve state from the state set that has been accumulated by
+    /// trillium handlers run on the [`trillium::Conn`] before it
+    /// became a websocket. see [`trillium::Conn::state`] for more
+    /// information
     pub fn state<T: Send + Sync + 'static>(&self) -> Option<&T> {
         self.state.get()
     }
 
-    /**
-    retrieve a mutable borrow of the state from the state set
-     */
+    /// retrieve a mutable borrow of the state from the state set
     pub fn state_mut<T: Send + Sync + 'static>(&mut self) -> Option<&mut T> {
         self.state.get_mut()
     }
@@ -178,12 +168,10 @@ impl WebSocketConn {
         self.state.insert(state)
     }
 
-    /**
-    take some type T out of the state set that has been
-    accumulated by trillium handlers run on the [`trillium::Conn`]
-    before it became a websocket. see [`trillium::Conn::take_state`]
-    for more information
-     */
+    /// take some type T out of the state set that has been
+    /// accumulated by trillium handlers run on the [`trillium::Conn`]
+    /// before it became a websocket. see [`trillium::Conn::take_state`]
+    /// for more information
     pub fn take_state<T: Send + Sync + 'static>(&mut self) -> Option<T> {
         self.state.take()
     }

--- a/websockets/src/websocket_handler.rs
+++ b/websockets/src/websocket_handler.rs
@@ -3,148 +3,146 @@ use async_tungstenite::tungstenite::{protocol::CloseFrame, Message};
 use futures_lite::stream::{Pending, Stream};
 use std::future::Future;
 
-/**
-# This is the trait that defines a handler for trillium websockets.
-
-There are several mutually-exclusive ways to use this trait, and it is
-intended to be flexible for different use cases. If the trait does not
-support your use case, please open a discussion and/or build a trait
-on top of this trait to add additional functionality.
-
-## Simple Example
-```
-use trillium_websockets::{Message, WebSocket, WebSocketConn, WebSocketHandler};
-use futures_lite::stream::{pending, Pending};
-
-struct EchoServer;
-impl WebSocketHandler for EchoServer {
-    type OutboundStream = Pending<Message>; // we don't use an outbound stream in this example
-
-    async fn connect(&self, conn: WebSocketConn) -> Option<(WebSocketConn, Self::OutboundStream)> {
-        Some((conn, pending()))
-    }
-
-    async fn inbound(&self, message: Message, conn: &mut WebSocketConn) {
-        let path = conn.path().to_string();
-        if let Message::Text(input) = message {
-            let reply = format!("received your message: {} at path {}", &input, &path);
-            conn.send_string(reply).await;
-        }
-    }
-}
-
-let handler = WebSocket::new(EchoServer);
-# // tests at tests/tests.rs for example simplicity
-```
-
-
-## Using [`WebSocketHandler::connect`] only
-
-If you have needs that are not supported by this trait, you can either
-pass an `Fn(WebSocketConn) -> impl Future<Output=()>` as a handler, or
-implement your own connect-only trait implementation that takes the
-WebSocketConn and returns None. The tcp connection will remain intact
-until the WebSocketConn is dropped, so you can store it in any data
-structure or move it between threads as needed.
-
-## Using Streams
-
-If you define an associated OutboundStream type and return it from
-`connect`, every message in that Stream will be sent to the connected
-websocket client. This is useful for sending messages that are
-triggered by other events in the application, using whatever channel
-mechanism is appropriate for your application. The websocket
-connection will be closed if the stream ends, yielding None.
-
-If you do not need to use streams, set `OutboundStream =
-futures_lite::stream::Pending<Message>` or a similar stream
-implementation that never yields. If associated type defaults were
-stable, we would use that.
-
-## Receiving client-sent messages
-
-Implement [`WebSocketHandler::inbound`] to receive client-sent
-messages. Currently inbound messages are not represented as a stream,
-but this may change in the future.
-
-## Holding data inside of the implementing type
-
-As this is a trait you implement for your own type, you can hold
-additional data or structs inside of your struct. There will be
-exactly one of these structs shared throughout the application, so
-async concurrency types can be used to mutate shared data.
-
-This example holds a shared BroadcastChannel that is cloned for each
-OutboundStream. Any message that a connected clients sends is
-broadcast to every other connected client.
-
-Importantly, this means that the dispatch and fanout of messages is
-managed entirely by your implementation. For an opinionated layer on
-top of this, see the trillium-channels crate.
-
-```
-use broadcaster::BroadcastChannel;
-use trillium_websockets::{Message, WebSocket, WebSocketConn, WebSocketHandler};
-
-struct EchoServer {
-    channel: BroadcastChannel<Message>,
-}
-impl EchoServer {
-    fn new() -> Self {
-        Self {
-            channel: BroadcastChannel::new(),
-        }
-    }
-}
-
-impl WebSocketHandler for EchoServer {
-    type OutboundStream = BroadcastChannel<Message>;
-
-    async fn connect(&self, conn: WebSocketConn) -> Option<(WebSocketConn, Self::OutboundStream)> {
-        Some((conn, self.channel.clone()))
-    }
-
-    async fn inbound(&self, message: Message, _conn: &mut WebSocketConn) {
-        if let Message::Text(input) = message {
-            let message = Message::text(format!("received message: {}", &input));
-            trillium::log_error!(self.channel.send(&message).await);
-        }
-    }
-}
-
-// fn main() {
-//     trillium_smol::run(WebSocket::new(EchoServer::new()));
-// }
-
-```
-
-*/
+/// # This is the trait that defines a handler for trillium websockets.
+///
+/// There are several mutually-exclusive ways to use this trait, and it is
+/// intended to be flexible for different use cases. If the trait does not
+/// support your use case, please open a discussion and/or build a trait
+/// on top of this trait to add additional functionality.
+///
+/// ## Simple Example
+/// ```
+/// use futures_lite::stream::{pending, Pending};
+/// use trillium_websockets::{Message, WebSocket, WebSocketConn, WebSocketHandler};
+///
+/// struct EchoServer;
+/// impl WebSocketHandler for EchoServer {
+///     type OutboundStream = Pending<Message>;
+///
+///     // we don't use an outbound stream in this example
+///
+///     async fn connect(
+///         &self,
+///         conn: WebSocketConn,
+///     ) -> Option<(WebSocketConn, Self::OutboundStream)> {
+///         Some((conn, pending()))
+///     }
+///
+///     async fn inbound(&self, message: Message, conn: &mut WebSocketConn) {
+///         let path = conn.path().to_string();
+///         if let Message::Text(input) = message {
+///             let reply = format!("received your message: {} at path {}", &input, &path);
+///             conn.send_string(reply).await;
+///         }
+///     }
+/// }
+///
+/// let handler = WebSocket::new(EchoServer);
+/// # // tests at tests/tests.rs for example simplicity
+/// ```
+///
+///
+/// ## Using [`WebSocketHandler::connect`] only
+///
+/// If you have needs that are not supported by this trait, you can either
+/// pass an `Fn(WebSocketConn) -> impl Future<Output=()>` as a handler, or
+/// implement your own connect-only trait implementation that takes the
+/// WebSocketConn and returns None. The tcp connection will remain intact
+/// until the WebSocketConn is dropped, so you can store it in any data
+/// structure or move it between threads as needed.
+///
+/// ## Using Streams
+///
+/// If you define an associated OutboundStream type and return it from
+/// `connect`, every message in that Stream will be sent to the connected
+/// websocket client. This is useful for sending messages that are
+/// triggered by other events in the application, using whatever channel
+/// mechanism is appropriate for your application. The websocket
+/// connection will be closed if the stream ends, yielding None.
+///
+/// If you do not need to use streams, set `OutboundStream =
+/// futures_lite::stream::Pending<Message>` or a similar stream
+/// implementation that never yields. If associated type defaults were
+/// stable, we would use that.
+///
+/// ## Receiving client-sent messages
+///
+/// Implement [`WebSocketHandler::inbound`] to receive client-sent
+/// messages. Currently inbound messages are not represented as a stream,
+/// but this may change in the future.
+///
+/// ## Holding data inside of the implementing type
+///
+/// As this is a trait you implement for your own type, you can hold
+/// additional data or structs inside of your struct. There will be
+/// exactly one of these structs shared throughout the application, so
+/// async concurrency types can be used to mutate shared data.
+///
+/// This example holds a shared BroadcastChannel that is cloned for each
+/// OutboundStream. Any message that a connected clients sends is
+/// broadcast to every other connected client.
+///
+/// Importantly, this means that the dispatch and fanout of messages is
+/// managed entirely by your implementation. For an opinionated layer on
+/// top of this, see the trillium-channels crate.
+///
+/// ```
+/// use broadcaster::BroadcastChannel;
+/// use trillium_websockets::{Message, WebSocket, WebSocketConn, WebSocketHandler};
+///
+/// struct EchoServer {
+///     channel: BroadcastChannel<Message>,
+/// }
+/// impl EchoServer {
+///     fn new() -> Self {
+///         Self {
+///             channel: BroadcastChannel::new(),
+///         }
+///     }
+/// }
+///
+/// impl WebSocketHandler for EchoServer {
+///     type OutboundStream = BroadcastChannel<Message>;
+///
+///     async fn connect(
+///         &self,
+///         conn: WebSocketConn,
+///     ) -> Option<(WebSocketConn, Self::OutboundStream)> {
+///         Some((conn, self.channel.clone()))
+///     }
+///
+///     async fn inbound(&self, message: Message, _conn: &mut WebSocketConn) {
+///         if let Message::Text(input) = message {
+///             let message = Message::text(format!("received message: {}", &input));
+///             trillium::log_error!(self.channel.send(&message).await);
+///         }
+///     }
+/// }
+///
+/// // fn main() {
+/// //    trillium_smol::run(WebSocket::new(EchoServer::new()));
+/// // }
+/// ```
 #[allow(unused_variables)]
 pub trait WebSocketHandler: Send + Sync + Sized + 'static {
-    /**
-    A [`Stream`] type that represents [`Message`]s to be sent to this
-    client. It is built in your implementation code, in
-    [`WebSocketHandler::connect`]. Use `Pending<Message>` or another
-    stream that never returns if you do not need to use this aspect of
-    the trait.
-    */
+    /// A [`Stream`] type that represents [`Message`]s to be sent to this
+    /// client. It is built in your implementation code, in
+    /// [`WebSocketHandler::connect`]. Use `Pending<Message>` or another
+    /// stream that never returns if you do not need to use this aspect of
+    /// the trait.
     type OutboundStream: Stream<Item = Message> + Send + Sync + 'static;
 
-    /**
-    This interface is the only mandatory function in
-    WebSocketHandler. It receives an owned WebSocketConn and
-    optionally returns it along with an `OutboundStream`
-    type.
-     */
+    /// This interface is the only mandatory function in
+    /// WebSocketHandler. It receives an owned WebSocketConn and
+    /// optionally returns it along with an `OutboundStream`
+    /// type.
     fn connect(
         &self,
         conn: WebSocketConn,
     ) -> impl Future<Output = Option<(WebSocketConn, Self::OutboundStream)>> + Send;
 
-    /**
-    This interface function is called once with every message received
-    from a connected websocket client.
-    */
+    /// This interface function is called once with every message received
+    /// from a connected websocket client.
     fn inbound(
         &self,
         message: Message,
@@ -153,12 +151,10 @@ pub trait WebSocketHandler: Send + Sync + Sized + 'static {
         async {}
     }
 
-    /**
-    This interface function is called once with every outbound message
-    in the OutboundStream. You likely do not need to implement this,
-    but if you do, you must call `conn.send(message).await` or the
-    message will not be sent.
-    */
+    /// This interface function is called once with every outbound message
+    /// in the OutboundStream. You likely do not need to implement this,
+    /// but if you do, you must call `conn.send(message).await` or the
+    /// message will not be sent.
     fn send(
         &self,
         message: Message,
@@ -167,11 +163,9 @@ pub trait WebSocketHandler: Send + Sync + Sized + 'static {
         async { conn.send(message).await }
     }
 
-    /**
-    This interface function is called with the websocket conn and, in
-    the case of a clean disconnect, the [`CloseFrame`] if one is sent
-    available.
-    */
+    /// This interface function is called with the websocket conn and, in
+    /// the case of a clean disconnect, the [`CloseFrame`] if one is sent
+    /// available.
     fn disconnect(
         &self,
         conn: &mut WebSocketConn,


### PR DESCRIPTION
motivation: rust's tooling generally doesn't work as well with `/** */` because fewer people use it. In this case, I discovered that rustfmt's `format_code_in_doc_comments` ignores `/** */` comments. I've run into enough other bugs with `/** */` that it's time to just adopt the "normalized" uglier style