### PR TITLE
Require rustls-platform-verifier 0.3.2 to avoid multiple crypto backends

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -29,7 +29,7 @@ features = ["logging"]
 [dependencies]
 log = "0.4.21"
 rustls-pemfile = { version = "2.1.1", optional = true }
-rustls-platform-verifier = { version = "0.3.1", optional = true }
+rustls-platform-verifier = { version = "0.3.2", optional = true }
 trillium-server-common = { path = "../server-common", version = "0.5.2" }
 webpki-roots = { version = "0.26", optional = true }
 


### PR DESCRIPTION
rustls-platform-verifier 0.3.2 fixes a dependency issue leading
trillium-rustls to have *both* aws-lc-rs and ring in its dependencies,
even if only depending on aws-lc-rs.

Fixes: https://github.com/trillium-rs/trillium/issues/664