### PR TITLE
Update core_concepts.md

### DIFF
--- a/docs/src/overview/core_concepts.md
+++ b/docs/src/overview/core_concepts.md
@@ -24,7 +24,7 @@ run with only the following dependencies:
 ```toml
 [dependencies]
 trillium = "0.2"
-trillium-smol = "0.2"
+trillium-smol = "0.4"
 ```
 
 If we `cargo run` this example, we can then visit


### PR DESCRIPTION
Changed trillium-smol from 0.2 to 0.4

The example did not compile for me with trillium-smol 0.2. I noticed the latest version is 0.4. Changing it to 0.4 made it compile and run as advertised.