### PR TITLE
feat!: Make `set_*` methods chainable by returning `&mut Self`

### DIFF
--- a/api/src/api_conn_ext.rs
+++ b/api/src/api_conn_ext.rs
@@ -172,7 +172,7 @@ impl ApiConnExt for Conn {
         match serde_json::to_string(&response) {
             Ok(body) => {
                 if self.status().is_none() {
-                    self.set_status(Status::Ok)
+                    self.set_status(Status::Ok);
                 }
 
                 self.response_headers_mut()
@@ -260,16 +260,16 @@ impl ApiConnExt for Conn {
 
         match accept {
             Some(AcceptableMime::Json) => {
-                self.set_body(serde_json::to_string(body)?);
-                self.response_headers_mut()
+                self.set_body(serde_json::to_string(body)?)
+                    .response_headers_mut()
                     .insert(ContentType, "application/json");
                 Ok(())
             }
 
             #[cfg(feature = "forms")]
             Some(AcceptableMime::Form) => {
-                self.set_body(serde_urlencoded::to_string(body)?);
-                self.response_headers_mut()
+                self.set_body(serde_urlencoded::to_string(body)?)
+                    .response_headers_mut()
                     .insert(ContentType, "application/x-www-form-urlencoded");
                 Ok(())
             }

--- a/api/tests/tests.rs
+++ b/api/tests/tests.rs
@@ -103,8 +103,8 @@ fn json_try_from_conn_checks_content_type() {
 }
 
 async fn error_handler(conn: &mut Conn, error: Error) {
-    conn.set_body(format!("my error format: {error:?}"));
-    conn.set_status(&error);
+    conn.set_body(format!("my error format: {error:?}"))
+        .set_status(&error);
 }
 
 fn app_with_error_handler() -> impl Handler {

--- a/trillium/src/conn.rs
+++ b/trillium/src/conn.rs
@@ -42,7 +42,8 @@ assert_response!(
 
 If you need to set a property on the conn without moving it,
 `set_{attribute}` associated functions will be your huckleberry, as is
-conventional in other rust projects.
+conventional in other rust projects. These methods accept `&mut self`,
+and they support chaining as well.
 
 ## State
 
@@ -125,8 +126,9 @@ impl Conn {
     }
 
     /// assigns a status to this response. see [`Conn::status`] for example usage
-    pub fn set_status(&mut self, status: impl TryInto<Status>) {
+    pub fn set_status(&mut self, status: impl TryInto<Status>) -> &mut Self {
         self.inner.set_status(status);
+        self
     }
 
     /**
@@ -183,8 +185,9 @@ impl Conn {
     assert_eq!(conn.response_len(), Some(5));
     ```
     */
-    pub fn set_body(&mut self, body: impl Into<Body>) {
+    pub fn set_body(&mut self, body: impl Into<Body>) -> &mut Self {
         self.inner.set_response_body(body);
+        self
     }
 
     /**
@@ -503,8 +506,9 @@ impl Conn {
     assert!(conn.is_halted());
     ```
     */
-    pub fn set_halted(&mut self, halted: bool) {
+    pub fn set_halted(&mut self, halted: bool) -> &mut Self {
         self.halted = halted;
+        self
     }
 
     /// retrieves the halted state of this conn.  see [`Conn::halt`].
@@ -573,8 +577,9 @@ impl Conn {
     }
 
     /// sets the remote ip address for this conn.
-    pub fn set_peer_ip(&mut self, peer_ip: Option<IpAddr>) {
+    pub fn set_peer_ip(&mut self, peer_ip: Option<IpAddr>) -> &mut Self {
         self.inner_mut().set_peer_ip(peer_ip);
+        self
     }
 
     /// for router implementations. pushes a route segment onto the path

--- a/websockets/src/websocket_connection.rs
+++ b/websockets/src/websocket_connection.rs
@@ -124,8 +124,9 @@ impl WebSocketConn {
     }
 
     /// Sets the peer ip for this conn
-    pub fn set_peer_ip(&mut self, peer_ip: Option<IpAddr>) {
-        self.peer_ip = peer_ip
+    pub fn set_peer_ip(&mut self, peer_ip: Option<IpAddr>) -> &mut Self {
+        self.peer_ip = peer_ip;
+        self
     }
 
     /**


### PR DESCRIPTION
This is convenient when working with a `&mut Conn`, such as when using
trillium-api.
