### PR TITLE
update rustls-pemfile and rustls-platform-verifier

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -28,8 +28,8 @@ features = ["logging"]
 
 [dependencies]
 log = "0.4.21"
-rustls-pemfile = { version = "2.1.1", optional = true }
-rustls-platform-verifier = { version = "0.3.2", optional = true }
+rustls-pemfile = { version = "2.2.0", optional = true }
+rustls-platform-verifier = { version = "0.5.1", optional = true }
 trillium-server-common = { path = "../server-common", version = "0.5.2" }
 webpki-roots = { version = "0.26", optional = true }
 


### PR DESCRIPTION
Besides the inherent virtue of updating these dependencies, this helps Janus resolve a build failure resulting from updating `rustls`. The detailed analysis is [here](https://github.com/divviup/janus/pull/3734) but the short version is that feature unification was enabling `rustls-webpki/std` so long as `rustls-platform-verifier` and `rustls` used the same version of `rustls-webpki`.

I think https://github.com/rustls/rustls-platform-verifier/issues/164 is the relevant upstream issue, but even if the `rustls` project does something about this, I think `trillium-rustls` still has to move to newer versions of these dependencies.