### PR TITLE
Parse URL path with `RelativePath` instead of `Path`

### DIFF
--- a/static/src/handler.rs
+++ b/static/src/handler.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use std::path::{Path, PathBuf};
 use trillium::{async_trait, conn_unwrap, Conn, Handler};
+use relative_path::RelativePath;
 
 /**
 trillium handler to serve static files from the filesystem
@@ -31,11 +32,10 @@ impl StaticFileHandler {
             url_path,
             file_path.to_str().unwrap()
         );
-        for segment in Path::new(url_path) {
+        for segment in RelativePath::new(url_path) {
             match segment.to_str() {
-                Some("/") => {}
-                Some(".") => {}
-                Some("..") => {
+                "." => {}
+                ".." => {
                     file_path.pop();
                 }
                 _ => {


### PR DESCRIPTION
The `Path` parses input strings in a platform-specific way. On Windows, it converts the forward slash ("/") into a backslash ("\\"). However, when using `Path` to parse a URL path, which always uses the forward slash as a component separator, this conversion can lead to issues. Specifically, when compiled on Windows, this can result in backslashes appearing in path components.

We could simply add the backslash to the path segment matcheing to be handled the same way as a forward slash. However, this solution is not platform-independent, as a backslash might be a valid path component and directory name on a non-Windows platform. Instead, we should use the `RelativePath` to parse URL paths, as it consistently uses the forward slash. Additionally, we can simplify our path component matching to just "." and ".." because `RelativePath` does not emit path separators like the `Path` does.