### PR TITLE
fix(client): correctly set version to http/1.1 when falling back from hinted http/3

### DIFF
--- a/client/src/conn/shared.rs
+++ b/client/src/conn/shared.rs
@@ -39,13 +39,16 @@ impl Conn {
             _ => {}
         }
 
-        if let Some(h3) = self.h3.clone()
-            && self
+        if let Some(h3) = self.h3.clone() {
+            if self
                 .try_exec_h3(&h3, self.http_version == Version::Http3)
                 .await?
-        {
-            self.update_alt_svc_from_response(&h3);
-            return Ok(());
+            {
+                self.update_alt_svc_from_response(&h3);
+                return Ok(());
+            } else {
+                self.http_version = Version::Http1_1;
+            }
         }
 
         self.exec_h1().await

--- a/client/tests/h3_hinted_downgrade.rs
+++ b/client/tests/h3_hinted_downgrade.rs
@@ -1,0 +1,31 @@
+use trillium_client::{Client, Version};
+use trillium_quinn::ClientQuicConfig;
+use trillium_testing::{harness, test};
+
+#[test(harness)]
+async fn h3_hinted_downgrades() {
+    let server = trillium_smol::config()
+        .with_port(0)
+        .spawn(|conn: trillium::Conn| async move {
+            let version = conn.http_version();
+            conn.ok(version.as_str())
+        });
+
+    let socket_addr = server.info().await.tcp_socket_addr().copied().unwrap();
+
+    let client = Client::new_with_quic(
+        trillium_smol::ClientConfig::default(),
+        ClientQuicConfig::with_webpki_roots(),
+    )
+    .with_base(socket_addr);
+
+    let mut conn = client
+        .get("/")
+        .with_http_version(Version::Http3)
+        .await
+        .unwrap();
+    assert_eq!(conn.response_body().await.unwrap(), "HTTP/1.1");
+    assert_eq!(conn.status().unwrap(), 200);
+    assert_eq!(conn.http_version(), Version::Http1_1);
+    server.shut_down().await;
+}


### PR DESCRIPTION
When a client conn was constructed with a version hint like `client.get("/").with_http_version(Version::Http3)` AND we are unable to reach a h3 server at the address, we previously fell back to http/1.1 and generated the following invalid http/1.1 request:

```http
GET / HTTP/3
```

With this fix, we correctly send:

```http
GET / HTTP/1.1
```

Note that this bug did not apply to non-hinted alt-svc upgrades.
