### PR TITLE
wip: missing handler

### DIFF
--- a/api/examples/missing_handler.rs
+++ b/api/examples/missing_handler.rs
@@ -1,0 +1,68 @@
+use serde::{Deserialize, Serialize};
+use trillium::{Conn, Status};
+use trillium_api::{Body, Halt, Result, State, api, missing_handler};
+use trillium_logger::logger;
+use trillium_router::router;
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Post {
+    user_name: String,
+    id: Option<usize>,
+    title: String,
+    body: String,
+}
+
+async fn save_post(
+    _conn: &mut Conn,
+    (State(user), post): (State<User>, Result<Body<Post>>),
+) -> Result<Body<Post>> {
+    post.map(|mut post| {
+        post.id = Some(10);
+        post.user_name = user.name;
+        post
+    })
+}
+
+async fn save_post_alternative(
+    _conn: &mut Conn,
+    (State(user), mut post): (State<User>, Body<Post>),
+) -> Body<Post> {
+    post.id = Some(10);
+    post.user_name = user.name;
+    post
+}
+
+async fn get_post(_conn: &mut Conn, State(user): State<User>) -> Body<Post> {
+    Body(Post {
+        user_name: user.name.to_string(),
+        id: Some(10),
+        title: "post title".into(),
+        body: "body".into(),
+    })
+}
+
+#[derive(Clone)]
+struct User {
+    name: String,
+}
+
+async fn very_securely_set_user(conn: &mut Conn, _: ()) -> Option<State<User>> {
+    conn.request_headers().get_str("x-username").map(|name| {
+        State(User {
+            name: name.to_string(),
+        })
+    })
+}
+
+fn main() {
+    env_logger::init();
+    trillium_smol::run((
+        logger(),
+        missing_handler((Status::InternalServerError, Halt)),
+        api(very_securely_set_user),
+        router()
+            .post("/", api(save_post))
+            .get("/", api(get_post))
+            .put("/", api(save_post_alternative)),
+    ));
+}

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -72,3 +72,6 @@ pub mod recipes {}
 #[cfg(test)]
 #[doc = include_str!("../README.md")]
 mod readme {}
+
+mod missing_handler;
+pub use missing_handler::missing_handler;

--- a/api/src/missing_handler.rs
+++ b/api/src/missing_handler.rs
@@ -1,0 +1,140 @@
+use std::{
+    any::Any,
+    borrow::Cow,
+    fmt::{self, Debug, Formatter},
+    future::Future,
+    pin::Pin,
+    sync::{Arc, OnceLock},
+};
+use trillium::{Conn, Handler, Info, Upgrade};
+
+trait ObjectSafeHandler: Any + Send + Sync + 'static {
+    #[must_use]
+    fn run<'handler, 'fut>(
+        &'handler self,
+        conn: Conn,
+    ) -> Pin<Box<dyn Future<Output = Conn> + Send + 'fut>>
+    where
+        'handler: 'fut,
+        Self: 'fut;
+    #[must_use]
+    fn before_send<'handler, 'fut>(
+        &'handler self,
+        conn: Conn,
+    ) -> Pin<Box<dyn Future<Output = Conn> + Send + 'fut>>
+    where
+        'handler: 'fut,
+        Self: 'fut;
+    fn has_upgrade(&self, upgrade: &Upgrade) -> bool;
+    #[must_use]
+    fn upgrade<'handler, 'fut>(
+        &'handler self,
+        upgrade: Upgrade,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'fut>>
+    where
+        'handler: 'fut,
+        Self: 'fut;
+    fn name(&self) -> Cow<'static, str>;
+}
+impl<H: Handler> ObjectSafeHandler for H {
+    fn run<'handler, 'fut>(
+        &'handler self,
+        conn: Conn,
+    ) -> Pin<Box<dyn Future<Output = Conn> + Send + 'fut>>
+    where
+        'handler: 'fut,
+        Self: 'fut,
+    {
+        Box::pin(async move { Handler::run(self, conn).await })
+    }
+
+    fn before_send<'handler, 'fut>(
+        &'handler self,
+        conn: Conn,
+    ) -> Pin<Box<dyn Future<Output = Conn> + Send + 'fut>>
+    where
+        'handler: 'fut,
+        Self: 'fut,
+    {
+        Box::pin(async move { Handler::before_send(self, conn).await })
+    }
+
+    fn has_upgrade(&self, upgrade: &Upgrade) -> bool {
+        Handler::has_upgrade(self, upgrade)
+    }
+
+    fn upgrade<'handler, 'fut>(
+        &'handler self,
+        upgrade: Upgrade,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'fut>>
+    where
+        'handler: 'fut,
+        Self: 'fut,
+    {
+        Box::pin(async move {
+            Handler::upgrade(self, upgrade).await;
+        })
+    }
+
+    fn name(&self) -> Cow<'static, str> {
+        Handler::name(self)
+    }
+}
+
+pub(crate) static DEFAULT_MISSING_HANDLER: OnceLock<MissingHandler> = OnceLock::new();
+
+/// A type-erased handler that gets called whenever a FromConn is None.
+#[derive(Clone)]
+pub struct MissingHandler(Arc<dyn ObjectSafeHandler>);
+impl Debug for MissingHandler {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("BoxedHandler").field(&self.0.name()).finish()
+    }
+}
+
+/// Set the missing handler for this application
+pub fn missing_handler(handler: impl Handler) -> impl Handler {
+    struct MissingHandlerSetter<H>(Option<H>);
+    impl<H: Handler> Handler for MissingHandlerSetter<H> {
+        async fn run(&self, conn: Conn) -> Conn {
+            conn
+        }
+
+        async fn init(&mut self, info: &mut Info) {
+            if let Some(mut handler) = self.0.take() {
+                handler.init(info).await;
+                info.insert_shared_state(MissingHandler(Arc::new(handler)));
+            }
+        }
+    }
+
+    MissingHandlerSetter(Some(handler))
+}
+
+impl MissingHandler {
+    pub(crate) fn new(handler: impl Handler) -> Self {
+        Self(Arc::new(handler))
+    }
+}
+
+impl Handler for MissingHandler {
+    async fn run(&self, conn: Conn) -> Conn {
+        self.0.run(conn).await
+    }
+
+    async fn before_send(&self, conn: Conn) -> Conn {
+        self.0.before_send(conn).await
+    }
+
+    fn has_upgrade(&self, upgrade: &Upgrade) -> bool {
+        self.0.has_upgrade(upgrade)
+    }
+
+    async fn upgrade(&self, upgrade: Upgrade) {
+        self.0.upgrade(upgrade).await;
+    }
+
+    fn name(&self) -> Cow<'static, str> {
+        self.0.name()
+    }
+}

--- a/api/src/try_from_conn.rs
+++ b/api/src/try_from_conn.rs
@@ -1,6 +1,6 @@
 #[cfg(any(feature = "serde_json", feature = "sonic-rs"))]
 use crate::ApiConnExt;
-use crate::FromConn;
+use crate::{FromConn, missing_handler::DEFAULT_MISSING_HANDLER};
 use std::future::Future;
 use trillium::{BoxedHandler, Conn, Handler};
 
@@ -42,10 +42,20 @@ impl TryFromConn for sonic_rs::Value {
 }
 
 impl<T: FromConn> TryFromConn for T {
-    type Error = ();
+    type Error = crate::missing_handler::MissingHandler;
 
     async fn try_from_conn(conn: &mut Conn) -> Result<Self, Self::Error> {
-        Self::from_conn(conn).await.ok_or(())
+        match Self::from_conn(conn).await {
+            Some(t) => Ok(t),
+            None => Err(
+                match conn.shared_state::<crate::missing_handler::MissingHandler>() {
+                    Some(mh) => mh.clone(),
+                    None => DEFAULT_MISSING_HANDLER
+                        .get_or_init(|| crate::missing_handler::MissingHandler::new(()))
+                        .clone(),
+                },
+            ),
+        }
     }
 }
 


### PR DESCRIPTION
A possible but awkward way of addressing #688, but as mentioned in that issue, the correct solution is probably to implement this in applications and make the current behavior clearly documented.

This sort of opinionated behavior probably indicates that State should be removed from trillium-api entirely and instead lean on derive macros