### PR TITLE
feat(api): derive macros for TryFromConn and Handler

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,8 +48,14 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.9.1
 
+      - uses: taiki-e/cache-cargo-install-action@v3
+        with:
+          tool: cargo-expand
+
       - name: Run tests
         uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: --cfg=macrotest
         with:
           command: test
           args: --workspace ${{ matrix.extra_features && format('--features {0}', matrix.extra_features) || '' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
         "api",
+        "api-macros",
         "docs-check",
         "askama",
         "async-std",

--- a/api-macros/CHANGELOG.md
+++ b/api-macros/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0-rc.1] - unreleased
+
+### Added
+- Initial release. Provides `#[derive(TryFromConn)]` and `#[derive(Handler)]` for `trillium-api`, configured via `#[api(state | json | body, [clone,] [err = Type])]`.

--- a/api-macros/Cargo.toml
+++ b/api-macros/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "trillium-api-macros"
+version = "0.1.0-rc.1"
+authors = ["Jacob Rothstein <hi@jbr.me>"]
+edition = "2024"
+description = "proc-macro derives for trillium-api"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/trillium-rs/trillium"
+readme = "README.md"
+keywords = ["trillium", "framework", "async"]
+categories = ["web-programming::http-server", "web-programming"]
+
+[lib]
+proc-macro = true
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(macrotest)"] }
+
+
+[dependencies]
+proc-macro2 = "1.0.106"
+quote = "1.0.45"
+syn = { version = "2.0.117", features = ["full"] }
+
+[dev-dependencies]
+trillium = { path = "../trillium" }
+trillium-api = { path = "../api", features = ["url", "forms", "sonic-rs"] }
+trillium-testing = { path = "../testing" }
+serde = { version = "1.0.228", features = ["derive"] }
+macrotest = "1.1.0"
+rustversion = "1.0.21"
+trybuild = "1.0.106"
+runtime-macros = "1.1.1"

--- a/api-macros/README.md
+++ b/api-macros/README.md
@@ -1,0 +1,15 @@
+# trillium-api-macros
+
+Proc-macro derives for [`trillium-api`](https://docs.rs/trillium-api).
+
+Provides `#[derive(TryFromConn)]` and `#[derive(Handler)]` configured by an `#[api(...)]` attribute, so that user types can act as extractors and/or handlers without hand-written impls.
+
+```rust,ignore
+use trillium_api::{TryFromConn, Handler};
+
+#[derive(Clone, TryFromConn, Handler)]
+#[api(state, clone)]
+struct CurrentUser { /* ... */ }
+```
+
+See the `trillium-api` crate docs for usage. This crate is re-exported from `trillium-api`; depend on `trillium-api` rather than this crate directly.

--- a/api-macros/src/attributes.rs
+++ b/api-macros/src/attributes.rs
@@ -1,0 +1,145 @@
+use proc_macro2::Span;
+use syn::{
+    Attribute, Error, Expr, ExprAssign, ExprLit, ExprPath, Lit, LitBool, Meta, Type, parse::Parser,
+    punctuated::Punctuated, spanned::Spanned, token::Comma,
+};
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Source {
+    State,
+    Json,
+    Body,
+}
+
+impl Source {
+    fn from_ident(ident: &str) -> Option<Self> {
+        match ident {
+            "state" => Some(Self::State),
+            "json" => Some(Self::Json),
+            "body" => Some(Self::Body),
+            _ => None,
+        }
+    }
+}
+
+pub struct ApiAttributes {
+    pub(crate) source: Source,
+    pub(crate) source_span: Span,
+    pub(crate) clone: bool,
+    pub(crate) err: Option<Type>,
+}
+
+impl ApiAttributes {
+    pub(crate) fn from_attrs(attrs: &[Attribute]) -> syn::Result<Self> {
+        let attr = attrs
+            .iter()
+            .find(|a| a.path().is_ident("api"))
+            .ok_or_else(|| {
+                Error::new(
+                    Span::call_site(),
+                    "missing required `#[api(...)]` attribute (state | json | body)",
+                )
+            })?;
+
+        let Meta::List(list) = &attr.meta else {
+            return Err(Error::new(attr.span(), "expected `#[api(...)]`"));
+        };
+
+        let exprs = Punctuated::<Expr, Comma>::parse_terminated.parse2(list.tokens.clone())?;
+
+        let mut source: Option<(Source, Span)> = None;
+        let mut clone = false;
+        let mut err: Option<Type> = None;
+
+        for expr in &exprs {
+            match expr {
+                Expr::Path(ExprPath { path, .. }) => {
+                    let ident = path.require_ident()?.to_string();
+                    if let Some(s) = Source::from_ident(&ident) {
+                        if let Some((_, prev)) = source {
+                            let mut e = Error::new(path.span(), "extraction source already set");
+                            e.combine(Error::new(prev, "previously set here"));
+                            return Err(e);
+                        }
+                        source = Some((s, path.span()));
+                    } else if ident == "clone" {
+                        clone = true;
+                    } else {
+                        return Err(Error::new(
+                            path.span(),
+                            format!(
+                                "unrecognized `#[api]` key `{ident}` — expected one of: state, \
+                                 json, body, clone, err"
+                            ),
+                        ));
+                    }
+                }
+
+                Expr::Assign(ExprAssign { left, right, .. }) => {
+                    let lhs = match &**left {
+                        Expr::Path(ExprPath { path, .. }) => path.require_ident()?.to_string(),
+                        _ => {
+                            return Err(Error::new(left.span(), "expected identifier"));
+                        }
+                    };
+                    match lhs.as_str() {
+                        "err" => {
+                            err = Some(expr_to_type(right)?);
+                        }
+                        "clone" => match &**right {
+                            Expr::Lit(ExprLit {
+                                lit: Lit::Bool(LitBool { value, .. }),
+                                ..
+                            }) => {
+                                clone = *value;
+                            }
+                            _ => {
+                                return Err(Error::new(
+                                    right.span(),
+                                    "`clone` expects a bool literal",
+                                ));
+                            }
+                        },
+                        other => {
+                            return Err(Error::new(
+                                left.span(),
+                                format!("unrecognized `#[api]` key `{other}`"),
+                            ));
+                        }
+                    }
+                }
+
+                _ => {
+                    return Err(Error::new(expr.span(), "unrecognized `#[api]` entry"));
+                }
+            }
+        }
+
+        let (source, source_span) = source.ok_or_else(|| {
+            Error::new(
+                attr.span(),
+                "`#[api(...)]` requires one of: `state`, `json`, `body`",
+            )
+        })?;
+
+        Ok(Self {
+            source,
+            source_span,
+            clone,
+            err,
+        })
+    }
+}
+
+fn expr_to_type(expr: &Expr) -> syn::Result<Type> {
+    match expr {
+        Expr::Path(ExprPath { path, qself, .. }) => Ok(Type::Path(syn::TypePath {
+            qself: qself.clone(),
+            path: path.clone(),
+        })),
+        _ => Err(Error::new(
+            expr.span(),
+            "`err = ...` expects a type path (e.g. `err = my::ErrorHandler`)",
+        )),
+    }
+}

--- a/api-macros/src/coverage_tests.rs
+++ b/api-macros/src/coverage_tests.rs
@@ -1,0 +1,41 @@
+use proc_macro2::TokenStream;
+
+#[test]
+fn code_coverage() {
+    use std::{
+        env,
+        fs::{self, File},
+        path::Path,
+    };
+
+    let tests_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
+    let paths = vec![tests_dir.join("expand"), tests_dir.join("ui")];
+
+    for path in paths {
+        for file in fs::read_dir(path).unwrap() {
+            let direntry = file.unwrap();
+            let path = direntry.path();
+            if path.extension().is_some_and(|x| x == "rs")
+                && !path.to_string_lossy().contains(".expanded")
+            {
+                let file = File::open(&path).unwrap();
+                let tfc: &dyn Fn(TokenStream) -> TokenStream =
+                    &crate::try_from_conn::derive_internal;
+                let h: &dyn Fn(TokenStream) -> TokenStream = &crate::handler::derive_internal;
+
+                runtime_macros::emulate_derive_macro_expansion(
+                    file,
+                    &[
+                        ("trillium_api_macros::TryFromConn", tfc),
+                        ("trillimm_api_macros::Handler", h),
+                        ("trillium_api::TryFromConn", tfc),
+                        ("trillimm_api::Handler", h),
+                        ("TryFromConn", tfc),
+                        ("Handler", h),
+                    ],
+                )
+                .unwrap();
+            }
+        }
+    }
+}

--- a/api-macros/src/handler.rs
+++ b/api-macros/src/handler.rs
@@ -1,0 +1,67 @@
+use crate::attributes::{ApiAttributes, Source};
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{DeriveInput, Error};
+
+pub fn derive(input: TokenStream) -> TokenStream {
+    derive_internal(input.into()).into()
+}
+
+pub fn derive_internal(input: TokenStream2) -> TokenStream2 {
+    match syn::parse2(input) {
+        Ok(di) => expand(&di).unwrap_or_else(Error::into_compile_error),
+        Err(e) => e.into_compile_error(),
+    }
+}
+
+fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    let attrs = ApiAttributes::from_attrs(&input.attrs)?;
+
+    let name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let body = match attrs.source {
+        Source::State => quote! {
+            conn.with_state(<Self as ::core::clone::Clone>::clone(self))
+        },
+        Source::Json => quote! {
+            ::trillium_api::ApiConnExt::with_json(conn, &*self)
+        },
+        Source::Body => quote! {
+            match ::trillium_api::ApiConnExt::serialize(&mut conn, &*self).await {
+                ::core::result::Result::Ok(()) => conn,
+                ::core::result::Result::Err(e) => conn.with_state(e).halt(),
+            }
+        },
+    };
+
+    let run = match attrs.source {
+        Source::Body => quote! {
+            async fn run(&self, mut conn: ::trillium::Conn) -> ::trillium::Conn {
+                #body
+            }
+
+            async fn before_send(&self, mut conn: ::trillium::Conn) -> ::trillium::Conn {
+                if let ::core::option::Option::Some(error) =
+                    conn.take_state::<::trillium_api::Error>()
+                {
+                    ::trillium::Handler::before_send(&error, conn).await
+                } else {
+                    conn
+                }
+            }
+        },
+        _ => quote! {
+            async fn run(&self, conn: ::trillium::Conn) -> ::trillium::Conn {
+                #body
+            }
+        },
+    };
+
+    Ok(quote! {
+        impl #impl_generics ::trillium::Handler for #name #ty_generics #where_clause {
+            #run
+        }
+    })
+}

--- a/api-macros/src/lib.rs
+++ b/api-macros/src/lib.rs
@@ -1,0 +1,64 @@
+#![forbid(unsafe_code)]
+#![deny(
+    clippy::dbg_macro,
+    missing_copy_implementations,
+    rustdoc::missing_crate_level_docs,
+    missing_debug_implementations,
+    nonstandard_style,
+    unused_qualifications
+)]
+#![warn(missing_docs, clippy::nursery, clippy::cargo)]
+#![allow(
+    clippy::must_use_candidate,
+    clippy::module_name_repetitions,
+    clippy::option_if_let_else
+)]
+#![doc = include_str!("../README.md")]
+
+mod attributes;
+#[cfg(test)]
+mod coverage_tests;
+mod handler;
+mod try_from_conn;
+
+/// Derives [`trillium_api::TryFromConn`] for a struct.
+///
+/// The struct must carry an `#[api(...)]` attribute selecting the extraction strategy:
+///
+/// - `state` — extract `Self` from conn state via `take_state`
+/// - `state, clone` — extract a clone of `Self` from conn state, leaving it in place
+/// - `json` — deserialize `Self` from a JSON request body
+/// - `body` — deserialize `Self` from the request body using content negotiation
+///
+/// `err = Type` overrides the associated `Error` type. The provided type must implement `Default`,
+/// and (for `json` / `body`) the original error is discarded via `map_err`.
+///
+/// # Examples
+///
+/// ```
+/// use trillium_api::{Halt, TryFromConn};
+///
+/// #[derive(Clone, TryFromConn)]
+/// #[api(state, clone, err = Halt)]
+/// struct CurrentUser {
+///     name: String,
+/// }
+/// ```
+#[proc_macro_derive(TryFromConn, attributes(api))]
+pub fn derive_try_from_conn(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    try_from_conn::derive(input)
+}
+
+/// Derives [`trillium::Handler`] for a struct, where the handler implementation reflects an
+/// `#[api(...)]` strategy:
+///
+/// - `state` — `conn.with_state(self.clone())` (requires `Self: Clone`)
+/// - `json` — `conn.with_json(&*self)` (requires `Self: Serialize`)
+/// - `body` — content-negotiated `conn.serialize(&*self)` (requires `Self: Serialize`)
+///
+/// This is a different `Handler` derive than the field-delegating one in `trillium-macros`; pick
+/// whichever fits the use case. (When both crates' derives are imported, alias one of them.)
+#[proc_macro_derive(Handler, attributes(api))]
+pub fn derive_handler(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    handler::derive(input)
+}

--- a/api-macros/src/try_from_conn.rs
+++ b/api-macros/src/try_from_conn.rs
@@ -1,0 +1,95 @@
+use crate::attributes::{ApiAttributes, Source};
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{DeriveInput, Error};
+
+pub fn derive(input: TokenStream) -> TokenStream {
+    derive_internal(input.into()).into()
+}
+
+pub fn derive_internal(input: TokenStream2) -> TokenStream2 {
+    match syn::parse2(input) {
+        Ok(di) => expand(&di).unwrap_or_else(Error::into_compile_error),
+        Err(e) => e.into_compile_error(),
+    }
+}
+
+fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    let attrs = ApiAttributes::from_attrs(&input.attrs)?;
+    let name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let (error_ty, body) = match attrs.source {
+        Source::State => {
+            let take = if attrs.clone {
+                quote! { conn.state::<Self>().cloned() }
+            } else {
+                quote! { conn.take_state::<Self>() }
+            };
+            match &attrs.err {
+                Some(err) => (
+                    quote!(#err),
+                    quote! {
+                        #take.ok_or_else(<#err as ::core::default::Default>::default)
+                    },
+                ),
+                None => (quote!(()), quote! { #take.ok_or(()) }),
+            }
+        }
+
+        Source::Json => {
+            if attrs.clone {
+                return Err(Error::new(
+                    attrs.source_span,
+                    "`clone` is only meaningful with `state`",
+                ));
+            }
+            let call = quote! {
+                ::trillium_api::ApiConnExt::deserialize_json::<Self>(conn).await
+            };
+            match &attrs.err {
+                Some(err) => (
+                    quote!(#err),
+                    quote! {
+                        #call.map_err(|_| <#err as ::core::default::Default>::default())
+                    },
+                ),
+                None => (quote!(::trillium_api::Error), call),
+            }
+        }
+
+        Source::Body => {
+            if attrs.clone {
+                return Err(Error::new(
+                    attrs.source_span,
+                    "`clone` is only meaningful with `state`",
+                ));
+            }
+            let call = quote! {
+                ::trillium_api::ApiConnExt::deserialize::<Self>(conn).await
+            };
+            match &attrs.err {
+                Some(err) => (
+                    quote!(#err),
+                    quote! {
+                        #call.map_err(|_| <#err as ::core::default::Default>::default())
+                    },
+                ),
+                None => (quote!(::trillium_api::Error), call),
+            }
+        }
+    };
+
+    Ok(quote! {
+        impl #impl_generics ::trillium_api::TryFromConn for #name #ty_generics #where_clause {
+            type Error = #error_ty;
+
+            async fn try_from_conn(
+                conn: &mut ::trillium::Conn,
+            ) -> ::core::result::Result<Self, Self::Error> {
+                #body
+            }
+        }
+    })
+}

--- a/api-macros/tests/expand/expand_01_state.expanded.rs
+++ b/api-macros/tests/expand/expand_01_state.expanded.rs
@@ -1,0 +1,12 @@
+#[api(state)]
+struct CurrentUser {
+    name: String,
+}
+impl ::trillium_api::TryFromConn for CurrentUser {
+    type Error = ();
+    async fn try_from_conn(
+        conn: &mut ::trillium::Conn,
+    ) -> ::core::result::Result<Self, Self::Error> {
+        conn.take_state::<Self>().ok_or(())
+    }
+}

--- a/api-macros/tests/expand/expand_01_state.rs
+++ b/api-macros/tests/expand/expand_01_state.rs
@@ -1,0 +1,5 @@
+#[derive(trillium_api::TryFromConn)]
+#[api(state)]
+struct CurrentUser {
+    name: String,
+}

--- a/api-macros/tests/expand/expand_02_state_clone.expanded.rs
+++ b/api-macros/tests/expand/expand_02_state_clone.expanded.rs
@@ -1,0 +1,21 @@
+#[api(state, clone)]
+struct CurrentUser {
+    name: String,
+}
+#[automatically_derived]
+impl ::core::clone::Clone for CurrentUser {
+    #[inline]
+    fn clone(&self) -> CurrentUser {
+        CurrentUser {
+            name: ::core::clone::Clone::clone(&self.name),
+        }
+    }
+}
+impl ::trillium_api::TryFromConn for CurrentUser {
+    type Error = ();
+    async fn try_from_conn(
+        conn: &mut ::trillium::Conn,
+    ) -> ::core::result::Result<Self, Self::Error> {
+        conn.state::<Self>().cloned().ok_or(())
+    }
+}

--- a/api-macros/tests/expand/expand_02_state_clone.rs
+++ b/api-macros/tests/expand/expand_02_state_clone.rs
@@ -1,0 +1,5 @@
+#[derive(Clone, trillium_api::TryFromConn)]
+#[api(state, clone)]
+struct CurrentUser {
+    name: String,
+}

--- a/api-macros/tests/expand/expand_03_state_err.expanded.rs
+++ b/api-macros/tests/expand/expand_03_state_err.expanded.rs
@@ -1,0 +1,24 @@
+struct ServerError;
+#[automatically_derived]
+impl ::core::default::Default for ServerError {
+    #[inline]
+    fn default() -> ServerError {
+        ServerError {}
+    }
+}
+impl trillium::Handler for ServerError {
+    async fn run(&self, conn: trillium::Conn) -> trillium::Conn {
+        conn.with_status(trillium::Status::InternalServerError).halt()
+    }
+}
+#[api(state, err = ServerError)]
+struct RequiredState(u32);
+impl ::trillium_api::TryFromConn for RequiredState {
+    type Error = ServerError;
+    async fn try_from_conn(
+        conn: &mut ::trillium::Conn,
+    ) -> ::core::result::Result<Self, Self::Error> {
+        conn.take_state::<Self>()
+            .ok_or_else(<ServerError as ::core::default::Default>::default)
+    }
+}

--- a/api-macros/tests/expand/expand_03_state_err.rs
+++ b/api-macros/tests/expand/expand_03_state_err.rs
@@ -1,0 +1,11 @@
+#[derive(Default)]
+struct ServerError;
+impl trillium::Handler for ServerError {
+    async fn run(&self, conn: trillium::Conn) -> trillium::Conn {
+        conn.with_status(trillium::Status::InternalServerError).halt()
+    }
+}
+
+#[derive(trillium_api::TryFromConn)]
+#[api(state, err = ServerError)]
+struct RequiredState(u32);

--- a/api-macros/tests/expand/expand_04_json.expanded.rs
+++ b/api-macros/tests/expand/expand_04_json.expanded.rs
@@ -1,0 +1,234 @@
+use serde::{Deserialize, Serialize};
+#[api(json)]
+struct Greeting {
+    hello: String,
+}
+#[doc(hidden)]
+#[allow(
+    non_upper_case_globals,
+    unused_attributes,
+    unused_qualifications,
+    clippy::absolute_paths,
+)]
+const _: () = {
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
+    extern crate serde as _serde;
+    #[automatically_derived]
+    impl _serde::Serialize for Greeting {
+        fn serialize<__S>(
+            &self,
+            __serializer: __S,
+        ) -> _serde::__private228::Result<__S::Ok, __S::Error>
+        where
+            __S: _serde::Serializer,
+        {
+            let mut __serde_state = _serde::Serializer::serialize_struct(
+                __serializer,
+                "Greeting",
+                false as usize + 1,
+            )?;
+            _serde::ser::SerializeStruct::serialize_field(
+                &mut __serde_state,
+                "hello",
+                &self.hello,
+            )?;
+            _serde::ser::SerializeStruct::end(__serde_state)
+        }
+    }
+};
+#[doc(hidden)]
+#[allow(
+    non_upper_case_globals,
+    unused_attributes,
+    unused_qualifications,
+    clippy::absolute_paths,
+)]
+const _: () = {
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
+    extern crate serde as _serde;
+    #[automatically_derived]
+    impl<'de> _serde::Deserialize<'de> for Greeting {
+        fn deserialize<__D>(
+            __deserializer: __D,
+        ) -> _serde::__private228::Result<Self, __D::Error>
+        where
+            __D: _serde::Deserializer<'de>,
+        {
+            #[allow(non_camel_case_types)]
+            #[doc(hidden)]
+            enum __Field {
+                __field0,
+                __ignore,
+            }
+            #[doc(hidden)]
+            struct __FieldVisitor;
+            #[automatically_derived]
+            impl<'de> _serde::de::Visitor<'de> for __FieldVisitor {
+                type Value = __Field;
+                fn expecting(
+                    &self,
+                    __formatter: &mut _serde::__private228::Formatter,
+                ) -> _serde::__private228::fmt::Result {
+                    _serde::__private228::Formatter::write_str(
+                        __formatter,
+                        "field identifier",
+                    )
+                }
+                fn visit_u64<__E>(
+                    self,
+                    __value: u64,
+                ) -> _serde::__private228::Result<Self::Value, __E>
+                where
+                    __E: _serde::de::Error,
+                {
+                    match __value {
+                        0u64 => _serde::__private228::Ok(__Field::__field0),
+                        _ => _serde::__private228::Ok(__Field::__ignore),
+                    }
+                }
+                fn visit_str<__E>(
+                    self,
+                    __value: &str,
+                ) -> _serde::__private228::Result<Self::Value, __E>
+                where
+                    __E: _serde::de::Error,
+                {
+                    match __value {
+                        "hello" => _serde::__private228::Ok(__Field::__field0),
+                        _ => _serde::__private228::Ok(__Field::__ignore),
+                    }
+                }
+                fn visit_bytes<__E>(
+                    self,
+                    __value: &[u8],
+                ) -> _serde::__private228::Result<Self::Value, __E>
+                where
+                    __E: _serde::de::Error,
+                {
+                    match __value {
+                        b"hello" => _serde::__private228::Ok(__Field::__field0),
+                        _ => _serde::__private228::Ok(__Field::__ignore),
+                    }
+                }
+            }
+            #[automatically_derived]
+            impl<'de> _serde::Deserialize<'de> for __Field {
+                #[inline]
+                fn deserialize<__D>(
+                    __deserializer: __D,
+                ) -> _serde::__private228::Result<Self, __D::Error>
+                where
+                    __D: _serde::Deserializer<'de>,
+                {
+                    _serde::Deserializer::deserialize_identifier(
+                        __deserializer,
+                        __FieldVisitor,
+                    )
+                }
+            }
+            #[doc(hidden)]
+            struct __Visitor<'de> {
+                marker: _serde::__private228::PhantomData<Greeting>,
+                lifetime: _serde::__private228::PhantomData<&'de ()>,
+            }
+            #[automatically_derived]
+            impl<'de> _serde::de::Visitor<'de> for __Visitor<'de> {
+                type Value = Greeting;
+                fn expecting(
+                    &self,
+                    __formatter: &mut _serde::__private228::Formatter,
+                ) -> _serde::__private228::fmt::Result {
+                    _serde::__private228::Formatter::write_str(
+                        __formatter,
+                        "struct Greeting",
+                    )
+                }
+                #[inline]
+                fn visit_seq<__A>(
+                    self,
+                    mut __seq: __A,
+                ) -> _serde::__private228::Result<Self::Value, __A::Error>
+                where
+                    __A: _serde::de::SeqAccess<'de>,
+                {
+                    let __field0 = match _serde::de::SeqAccess::next_element::<
+                        String,
+                    >(&mut __seq)? {
+                        _serde::__private228::Some(__value) => __value,
+                        _serde::__private228::None => {
+                            return _serde::__private228::Err(
+                                _serde::de::Error::invalid_length(
+                                    0usize,
+                                    &"struct Greeting with 1 element",
+                                ),
+                            );
+                        }
+                    };
+                    _serde::__private228::Ok(Greeting { hello: __field0 })
+                }
+                #[inline]
+                fn visit_map<__A>(
+                    self,
+                    mut __map: __A,
+                ) -> _serde::__private228::Result<Self::Value, __A::Error>
+                where
+                    __A: _serde::de::MapAccess<'de>,
+                {
+                    let mut __field0: _serde::__private228::Option<String> = _serde::__private228::None;
+                    while let _serde::__private228::Some(__key) = _serde::de::MapAccess::next_key::<
+                        __Field,
+                    >(&mut __map)? {
+                        match __key {
+                            __Field::__field0 => {
+                                if _serde::__private228::Option::is_some(&__field0) {
+                                    return _serde::__private228::Err(
+                                        <__A::Error as _serde::de::Error>::duplicate_field("hello"),
+                                    );
+                                }
+                                __field0 = _serde::__private228::Some(
+                                    _serde::de::MapAccess::next_value::<String>(&mut __map)?,
+                                );
+                            }
+                            _ => {
+                                let _ = _serde::de::MapAccess::next_value::<
+                                    _serde::de::IgnoredAny,
+                                >(&mut __map)?;
+                            }
+                        }
+                    }
+                    let __field0 = match __field0 {
+                        _serde::__private228::Some(__field0) => __field0,
+                        _serde::__private228::None => {
+                            _serde::__private228::de::missing_field("hello")?
+                        }
+                    };
+                    _serde::__private228::Ok(Greeting { hello: __field0 })
+                }
+            }
+            #[doc(hidden)]
+            const FIELDS: &'static [&'static str] = &["hello"];
+            _serde::Deserializer::deserialize_struct(
+                __deserializer,
+                "Greeting",
+                FIELDS,
+                __Visitor {
+                    marker: _serde::__private228::PhantomData::<Greeting>,
+                    lifetime: _serde::__private228::PhantomData,
+                },
+            )
+        }
+    }
+};
+impl ::trillium_api::TryFromConn for Greeting {
+    type Error = ::trillium_api::Error;
+    async fn try_from_conn(
+        conn: &mut ::trillium::Conn,
+    ) -> ::core::result::Result<Self, Self::Error> {
+        ::trillium_api::ApiConnExt::deserialize_json::<Self>(conn).await
+    }
+}
+impl ::trillium::Handler for Greeting {
+    async fn run(&self, conn: ::trillium::Conn) -> ::trillium::Conn {
+        ::trillium_api::ApiConnExt::with_json(conn, &*self)
+    }
+}

--- a/api-macros/tests/expand/expand_04_json.rs
+++ b/api-macros/tests/expand/expand_04_json.rs
@@ -1,0 +1,7 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, trillium_api::TryFromConn, trillium_api::Handler)]
+#[api(json)]
+struct Greeting {
+    hello: String,
+}

--- a/api-macros/tests/expand/expand_05_body.expanded.rs
+++ b/api-macros/tests/expand/expand_05_body.expanded.rs
@@ -1,0 +1,248 @@
+use serde::{Deserialize, Serialize};
+#[api(body)]
+struct Echo {
+    payload: String,
+}
+#[doc(hidden)]
+#[allow(
+    non_upper_case_globals,
+    unused_attributes,
+    unused_qualifications,
+    clippy::absolute_paths,
+)]
+const _: () = {
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
+    extern crate serde as _serde;
+    #[automatically_derived]
+    impl _serde::Serialize for Echo {
+        fn serialize<__S>(
+            &self,
+            __serializer: __S,
+        ) -> _serde::__private228::Result<__S::Ok, __S::Error>
+        where
+            __S: _serde::Serializer,
+        {
+            let mut __serde_state = _serde::Serializer::serialize_struct(
+                __serializer,
+                "Echo",
+                false as usize + 1,
+            )?;
+            _serde::ser::SerializeStruct::serialize_field(
+                &mut __serde_state,
+                "payload",
+                &self.payload,
+            )?;
+            _serde::ser::SerializeStruct::end(__serde_state)
+        }
+    }
+};
+#[doc(hidden)]
+#[allow(
+    non_upper_case_globals,
+    unused_attributes,
+    unused_qualifications,
+    clippy::absolute_paths,
+)]
+const _: () = {
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
+    extern crate serde as _serde;
+    #[automatically_derived]
+    impl<'de> _serde::Deserialize<'de> for Echo {
+        fn deserialize<__D>(
+            __deserializer: __D,
+        ) -> _serde::__private228::Result<Self, __D::Error>
+        where
+            __D: _serde::Deserializer<'de>,
+        {
+            #[allow(non_camel_case_types)]
+            #[doc(hidden)]
+            enum __Field {
+                __field0,
+                __ignore,
+            }
+            #[doc(hidden)]
+            struct __FieldVisitor;
+            #[automatically_derived]
+            impl<'de> _serde::de::Visitor<'de> for __FieldVisitor {
+                type Value = __Field;
+                fn expecting(
+                    &self,
+                    __formatter: &mut _serde::__private228::Formatter,
+                ) -> _serde::__private228::fmt::Result {
+                    _serde::__private228::Formatter::write_str(
+                        __formatter,
+                        "field identifier",
+                    )
+                }
+                fn visit_u64<__E>(
+                    self,
+                    __value: u64,
+                ) -> _serde::__private228::Result<Self::Value, __E>
+                where
+                    __E: _serde::de::Error,
+                {
+                    match __value {
+                        0u64 => _serde::__private228::Ok(__Field::__field0),
+                        _ => _serde::__private228::Ok(__Field::__ignore),
+                    }
+                }
+                fn visit_str<__E>(
+                    self,
+                    __value: &str,
+                ) -> _serde::__private228::Result<Self::Value, __E>
+                where
+                    __E: _serde::de::Error,
+                {
+                    match __value {
+                        "payload" => _serde::__private228::Ok(__Field::__field0),
+                        _ => _serde::__private228::Ok(__Field::__ignore),
+                    }
+                }
+                fn visit_bytes<__E>(
+                    self,
+                    __value: &[u8],
+                ) -> _serde::__private228::Result<Self::Value, __E>
+                where
+                    __E: _serde::de::Error,
+                {
+                    match __value {
+                        b"payload" => _serde::__private228::Ok(__Field::__field0),
+                        _ => _serde::__private228::Ok(__Field::__ignore),
+                    }
+                }
+            }
+            #[automatically_derived]
+            impl<'de> _serde::Deserialize<'de> for __Field {
+                #[inline]
+                fn deserialize<__D>(
+                    __deserializer: __D,
+                ) -> _serde::__private228::Result<Self, __D::Error>
+                where
+                    __D: _serde::Deserializer<'de>,
+                {
+                    _serde::Deserializer::deserialize_identifier(
+                        __deserializer,
+                        __FieldVisitor,
+                    )
+                }
+            }
+            #[doc(hidden)]
+            struct __Visitor<'de> {
+                marker: _serde::__private228::PhantomData<Echo>,
+                lifetime: _serde::__private228::PhantomData<&'de ()>,
+            }
+            #[automatically_derived]
+            impl<'de> _serde::de::Visitor<'de> for __Visitor<'de> {
+                type Value = Echo;
+                fn expecting(
+                    &self,
+                    __formatter: &mut _serde::__private228::Formatter,
+                ) -> _serde::__private228::fmt::Result {
+                    _serde::__private228::Formatter::write_str(
+                        __formatter,
+                        "struct Echo",
+                    )
+                }
+                #[inline]
+                fn visit_seq<__A>(
+                    self,
+                    mut __seq: __A,
+                ) -> _serde::__private228::Result<Self::Value, __A::Error>
+                where
+                    __A: _serde::de::SeqAccess<'de>,
+                {
+                    let __field0 = match _serde::de::SeqAccess::next_element::<
+                        String,
+                    >(&mut __seq)? {
+                        _serde::__private228::Some(__value) => __value,
+                        _serde::__private228::None => {
+                            return _serde::__private228::Err(
+                                _serde::de::Error::invalid_length(
+                                    0usize,
+                                    &"struct Echo with 1 element",
+                                ),
+                            );
+                        }
+                    };
+                    _serde::__private228::Ok(Echo { payload: __field0 })
+                }
+                #[inline]
+                fn visit_map<__A>(
+                    self,
+                    mut __map: __A,
+                ) -> _serde::__private228::Result<Self::Value, __A::Error>
+                where
+                    __A: _serde::de::MapAccess<'de>,
+                {
+                    let mut __field0: _serde::__private228::Option<String> = _serde::__private228::None;
+                    while let _serde::__private228::Some(__key) = _serde::de::MapAccess::next_key::<
+                        __Field,
+                    >(&mut __map)? {
+                        match __key {
+                            __Field::__field0 => {
+                                if _serde::__private228::Option::is_some(&__field0) {
+                                    return _serde::__private228::Err(
+                                        <__A::Error as _serde::de::Error>::duplicate_field(
+                                            "payload",
+                                        ),
+                                    );
+                                }
+                                __field0 = _serde::__private228::Some(
+                                    _serde::de::MapAccess::next_value::<String>(&mut __map)?,
+                                );
+                            }
+                            _ => {
+                                let _ = _serde::de::MapAccess::next_value::<
+                                    _serde::de::IgnoredAny,
+                                >(&mut __map)?;
+                            }
+                        }
+                    }
+                    let __field0 = match __field0 {
+                        _serde::__private228::Some(__field0) => __field0,
+                        _serde::__private228::None => {
+                            _serde::__private228::de::missing_field("payload")?
+                        }
+                    };
+                    _serde::__private228::Ok(Echo { payload: __field0 })
+                }
+            }
+            #[doc(hidden)]
+            const FIELDS: &'static [&'static str] = &["payload"];
+            _serde::Deserializer::deserialize_struct(
+                __deserializer,
+                "Echo",
+                FIELDS,
+                __Visitor {
+                    marker: _serde::__private228::PhantomData::<Echo>,
+                    lifetime: _serde::__private228::PhantomData,
+                },
+            )
+        }
+    }
+};
+impl ::trillium_api::TryFromConn for Echo {
+    type Error = ::trillium_api::Error;
+    async fn try_from_conn(
+        conn: &mut ::trillium::Conn,
+    ) -> ::core::result::Result<Self, Self::Error> {
+        ::trillium_api::ApiConnExt::deserialize::<Self>(conn).await
+    }
+}
+impl ::trillium::Handler for Echo {
+    async fn run(&self, mut conn: ::trillium::Conn) -> ::trillium::Conn {
+        match ::trillium_api::ApiConnExt::serialize(&mut conn, &*self).await {
+            ::core::result::Result::Ok(()) => conn,
+            ::core::result::Result::Err(e) => conn.with_state(e).halt(),
+        }
+    }
+    async fn before_send(&self, mut conn: ::trillium::Conn) -> ::trillium::Conn {
+        if let ::core::option::Option::Some(error) = conn
+            .take_state::<::trillium_api::Error>()
+        {
+            ::trillium::Handler::before_send(&error, conn).await
+        } else {
+            conn
+        }
+    }
+}

--- a/api-macros/tests/expand/expand_05_body.rs
+++ b/api-macros/tests/expand/expand_05_body.rs
@@ -1,0 +1,7 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, trillium_api::TryFromConn, trillium_api::Handler)]
+#[api(body)]
+struct Echo {
+    payload: String,
+}

--- a/api-macros/tests/expand/expand_06_handler_state.expanded.rs
+++ b/api-macros/tests/expand/expand_06_handler_state.expanded.rs
@@ -1,0 +1,18 @@
+#[api(state)]
+struct CurrentUser {
+    name: String,
+}
+#[automatically_derived]
+impl ::core::clone::Clone for CurrentUser {
+    #[inline]
+    fn clone(&self) -> CurrentUser {
+        CurrentUser {
+            name: ::core::clone::Clone::clone(&self.name),
+        }
+    }
+}
+impl ::trillium::Handler for CurrentUser {
+    async fn run(&self, conn: ::trillium::Conn) -> ::trillium::Conn {
+        conn.with_state(<Self as ::core::clone::Clone>::clone(self))
+    }
+}

--- a/api-macros/tests/expand/expand_06_handler_state.rs
+++ b/api-macros/tests/expand/expand_06_handler_state.rs
@@ -1,0 +1,5 @@
+#[derive(Clone, trillium_api::Handler)]
+#[api(state)]
+struct CurrentUser {
+    name: String,
+}

--- a/api-macros/tests/expand/expand_07_combined.expanded.rs
+++ b/api-macros/tests/expand/expand_07_combined.expanded.rs
@@ -1,0 +1,26 @@
+#[api(state, clone)]
+struct CurrentUser {
+    name: String,
+}
+#[automatically_derived]
+impl ::core::clone::Clone for CurrentUser {
+    #[inline]
+    fn clone(&self) -> CurrentUser {
+        CurrentUser {
+            name: ::core::clone::Clone::clone(&self.name),
+        }
+    }
+}
+impl ::trillium_api::TryFromConn for CurrentUser {
+    type Error = ();
+    async fn try_from_conn(
+        conn: &mut ::trillium::Conn,
+    ) -> ::core::result::Result<Self, Self::Error> {
+        conn.state::<Self>().cloned().ok_or(())
+    }
+}
+impl ::trillium::Handler for CurrentUser {
+    async fn run(&self, conn: ::trillium::Conn) -> ::trillium::Conn {
+        conn.with_state(<Self as ::core::clone::Clone>::clone(self))
+    }
+}

--- a/api-macros/tests/expand/expand_07_combined.rs
+++ b/api-macros/tests/expand/expand_07_combined.rs
@@ -1,0 +1,8 @@
+// Combined derive: TryFromConn + Handler with `state, clone`.
+// `clone` is consumed by TryFromConn; `Handler` ignores it.
+
+#[derive(Clone, trillium_api::TryFromConn, trillium_api::Handler)]
+#[api(state, clone)]
+struct CurrentUser {
+    name: String,
+}

--- a/api-macros/tests/integration.rs
+++ b/api-macros/tests/integration.rs
@@ -1,0 +1,129 @@
+use serde::{Deserialize, Serialize};
+use trillium::{Conn, Status};
+use trillium_api::{Handler, TryFromConn, api};
+use trillium_testing::{TestResult, TestServer, harness, json, test};
+
+#[derive(Clone, TryFromConn, Handler)]
+#[api(state, clone)]
+struct CurrentUser {
+    name: String,
+}
+
+#[derive(Default, Debug)]
+struct ServerError;
+impl Handler for ServerError {
+    async fn run(&self, conn: Conn) -> Conn {
+        conn.with_status(Status::InternalServerError).halt()
+    }
+}
+
+#[derive(TryFromConn)]
+#[api(state, err = ServerError)]
+struct RequiredState(#[allow(dead_code)] u32);
+
+#[derive(Serialize, Deserialize, Handler)]
+#[api(json)]
+struct Greeting {
+    hello: String,
+}
+
+#[derive(Serialize, Deserialize, TryFromConn)]
+#[api(json)]
+struct Submitted {
+    name: String,
+}
+
+#[derive(Serialize, Deserialize, TryFromConn, Handler)]
+#[api(body)]
+struct Echo {
+    payload: String,
+}
+
+#[test(harness)]
+async fn state_clone_extracts_self_type_handler_writes_back() -> TestResult {
+    let app = TestServer::new((
+        |conn: Conn| async move { conn.with_state(CurrentUser { name: "ada".into() }) },
+        api(async |_conn: &mut Conn, user: CurrentUser| user),
+    ))
+    .await;
+
+    app.get("/")
+        .await
+        .assert_state_with(|CurrentUser { name }| assert_eq!(name, "ada"));
+
+    Ok(())
+}
+
+#[test(harness)]
+async fn missing_state_runs_default_err_handler() -> TestResult {
+    let app = TestServer::new(api(async |_conn: &mut Conn, _: RequiredState| "ok")).await;
+
+    app.get("/")
+        .await
+        .assert_status(Status::InternalServerError);
+    Ok(())
+}
+
+#[test(harness)]
+async fn json_handler_serializes_self() -> TestResult {
+    let app = TestServer::new(api(async |_conn: &mut Conn, _: ()| Greeting {
+        hello: "world".into(),
+    }))
+    .await;
+
+    app.get("/")
+        .await
+        .assert_ok()
+        .assert_header("content-type", "application/json")
+        .assert_body(r#"{"hello":"world"}"#);
+
+    Ok(())
+}
+
+#[test(harness)]
+async fn json_extractor_deserializes_request_body() -> TestResult {
+    let app = TestServer::new(api(async |_conn: &mut Conn, s: Submitted| Greeting {
+        hello: s.name,
+    }))
+    .await;
+
+    app.post("/")
+        .with_json_body(&json!({"name": "ada"}))
+        .await
+        .assert_ok()
+        .assert_json_body(&json!({"hello": "ada"}));
+    Ok(())
+}
+
+#[test(harness)]
+async fn body_roundtrips_via_content_negotiation() -> TestResult {
+    let app = TestServer::new(api(async |_conn: &mut Conn, e: Echo| e)).await;
+
+    app.post("/")
+        .with_request_header("accept", "application/json")
+        .with_json_body(&json!({"payload": "hi"}))
+        .await
+        .assert_ok()
+        .assert_header("content-type", "application/json")
+        .assert_body(r#"{"payload":"hi"}"#);
+
+    app.post("/")
+        .with_request_header("accept", "application/x-www-form-urlencoded")
+        .with_request_header("content-type", "application/x-www-form-urlencoded")
+        .with_body("payload=hi")
+        .await
+        .assert_ok()
+        .assert_header("content-type", "application/x-www-form-urlencoded")
+        .assert_body("payload=hi");
+
+    app.post("/")
+        .with_request_header("accept", "application/json")
+        .with_request_header("content-type", "application/x-www-form-urlencoded")
+        .with_body("payload=hi")
+        .await
+        .assert_ok()
+        .assert_header("content-type", "application/json")
+        .assert_body(r#"{"payload":"hi"}"#);
+
+    Ok(())
+}

--- a/api-macros/tests/test.rs
+++ b/api-macros/tests/test.rs
@@ -1,0 +1,28 @@
+#[test]
+#[cfg_attr(
+    not(macrotest),
+    ignore = "to run macrotests in an environment with `cargo expand` enable \
+              `RUSTFLAGS=\"--cfg=macrotest\"`"
+)]
+fn macrotest() {
+    println!("`MACROTEST=overwrite cargo test` to accept");
+    macrotest::expand("tests/expand/expand_*.rs");
+}
+
+#[rustversion::stable]
+#[test]
+fn ui_tests() {
+    ui_tests_impl()
+}
+
+#[rustversion::not(stable)]
+#[test]
+#[ignore = "to run ui tests, use the stable toolchain"]
+fn ui_tests() {
+    ui_tests_impl()
+}
+
+fn ui_tests_impl() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/api-macros/tests/ui/clone_on_json.rs
+++ b/api-macros/tests/ui/clone_on_json.rs
@@ -1,0 +1,7 @@
+#[derive(trillium_api::TryFromConn)]
+#[api(json, clone)]
+struct Bad {
+    payload: String,
+}
+
+fn main() {}

--- a/api-macros/tests/ui/clone_on_json.stderr
+++ b/api-macros/tests/ui/clone_on_json.stderr
@@ -1,0 +1,5 @@
+error: `clone` is only meaningful with `state`
+ --> tests/ui/clone_on_json.rs:2:7
+  |
+2 | #[api(json, clone)]
+  |       ^^^^

--- a/api-macros/tests/ui/missing_source.rs
+++ b/api-macros/tests/ui/missing_source.rs
@@ -1,0 +1,6 @@
+#[derive(trillium_api::TryFromConn)]
+struct NoAttr {
+    name: String,
+}
+
+fn main() {}

--- a/api-macros/tests/ui/missing_source.stderr
+++ b/api-macros/tests/ui/missing_source.stderr
@@ -1,0 +1,7 @@
+error: missing required `#[api(...)]` attribute (state | json | body)
+ --> tests/ui/missing_source.rs:1:10
+  |
+1 | #[derive(trillium_api::TryFromConn)]
+  |          ^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `trillium_api::TryFromConn` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/api-macros/tests/ui/unknown_key.rs
+++ b/api-macros/tests/ui/unknown_key.rs
@@ -1,0 +1,7 @@
+#[derive(trillium_api::TryFromConn)]
+#[api(state, oops)]
+struct Bad {
+    name: String,
+}
+
+fn main() {}

--- a/api-macros/tests/ui/unknown_key.stderr
+++ b/api-macros/tests/ui/unknown_key.stderr
@@ -1,0 +1,5 @@
+error: unrecognized `#[api]` key `oops` — expected one of: state, json, body, clone, err
+ --> tests/ui/unknown_key.rs:2:14
+  |
+2 | #[api(state, oops)]
+  |              ^^^^

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `#[derive(TryFromConn)]` and `#[derive(Handler)]` (re-exported from the new `trillium-api-macros` crate) — generate `TryFromConn` / `Handler` impls from `#[api(state | json | body, [clone,] [err = Type])]`. Note that `trillium_api::Handler` is the derive macro and shadows the `trillium::Handler` trait when both are imported, mirroring the serde pattern.
+
 ## [0.3.0] - 2026-04-08
 
 ### Changed

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -28,6 +28,7 @@ serde_urlencoded = { version = "0.7.1", optional = true }
 sonic-rs = { version = "0.5.8", optional = true }
 thiserror = "2.0.18"
 trillium = { path = "../trillium", version = "1.0.0-rc.1" }
+trillium-api-macros = { version = "0.1.0-rc.1", path = "../api-macros" }
 trillium-macros = { version = "0.1.0-rc.1", path = "../macros" }
 url = { version = "2.5.8", optional = true }
 

--- a/api/docs/extractors.md
+++ b/api/docs/extractors.md
@@ -6,12 +6,94 @@ infallible cousin [`FromConn`](crate::FromConn)). Before your handler
 function runs, the extractor pulls typed data out of the
 [`Conn`](trillium::Conn).
 
+The recommended way to make your own types into extractors is the
+[`#[derive(TryFromConn)]`](crate::TryFromConn) macro — see
+[`extractors::deriving`](crate::extractors::deriving) for the full
+reference.
+
+## Deriving extractors on your own types
+
+If your type is already a regular Rust struct (often a `serde::Deserialize`
+domain type or a clonable handle to shared state), the simplest path is to
+let the derive write the `TryFromConn` impl for you:
+
+```rust
+use trillium::Conn;
+use trillium_api::{api, TryFromConn};
+use serde::Deserialize;
+
+#[derive(Deserialize, TryFromConn)]
+#[api(json)]
+struct NewPost {
+    title: String,
+}
+
+async fn create(_conn: &mut Conn, input: NewPost) -> String {
+    format!("created: {}", input.title)
+}
+# use trillium_testing::TestServer;
+# trillium_testing::block_on(async {
+#     let app = TestServer::new(api(create)).await;
+#     app.post("/")
+#         .with_request_header("content-type", "application/json")
+#         .with_body(r#"{"title":"hello"}"#)
+#         .await
+#         .assert_ok()
+#         .assert_body("created: hello");
+# });
+```
+
+The `#[api(...)]` attribute selects how the type is extracted:
+
+- `#[api(json)]` — JSON request body
+- `#[api(body)]` — request body with content-type negotiation
+- `#[api(state)]` — pulled out of conn state via
+  [`take_state`](trillium::Conn::take_state)
+- `#[api(state, clone)]` — same, but cloning rather than taking
+- `#[api(state, err = MyHandler)]` — run `MyHandler::default()` as a handler
+  if the state is missing
+
+The companion [`#[derive(Handler)]`](trillium::Handler) macro generates a
+`Handler` impl symmetrically — `#[api(json)]` writes JSON, `#[api(state)]`
+writes into state, `#[api(body)]` serializes with content-type negotiation:
+
+```rust
+use trillium_api::{api, Handler, TryFromConn};
+use trillium::Conn;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, TryFromConn, Handler)]
+#[api(body)]
+struct Echo {
+    payload: String,
+}
+
+/// Reads `Echo` from the request body, returns the same value as the response.
+async fn echo(_conn: &mut Conn, e: Echo) -> Echo {
+    e
+}
+# use trillium_testing::TestServer;
+# trillium_testing::block_on(async {
+#     let app = TestServer::new(api(echo)).await;
+#     app.post("/")
+#         .with_request_header("content-type", "application/json")
+#         .with_request_header("accept", "application/json")
+#         .with_body(r#"{"payload":"hi"}"#)
+#         .await
+#         .assert_ok()
+#         .assert_body(r#"{"payload":"hi"}"#);
+# });
+```
+
+See [`extractors::deriving`](crate::extractors::deriving) for the full set
+of options and the generated code shape.
+
 ## No extraction
 
 Use `()` when you don't need anything from the request:
 
 ```rust
-use trillium_api::{api, Json};
+use trillium_api::api;
 use trillium::Conn;
 
 async fn health(_conn: &mut Conn, _: ()) -> &'static str {
@@ -24,99 +106,7 @@ async fn health(_conn: &mut Conn, _: ()) -> &'static str {
 # });
 ```
 
-## Body deserialization
-
-[`Body<T>`](crate::Body) deserializes the request body using content-type
-negotiation (JSON or form-urlencoded). [`Json<T>`](crate::Json)
-deserializes JSON only, rejecting other content types.
-
-```rust
-use trillium_api::{api, Body, Json};
-use trillium::Conn;
-use serde::Deserialize;
-
-#[derive(Deserialize)]
-struct NewPost { title: String }
-
-/// Accepts JSON or form-urlencoded (cargo-feature dependent)
-async fn with_body(_conn: &mut Conn, Body(post): Body<NewPost>) -> String {
-    format!("created: {}", post.title)
-}
-
-/// Accepts JSON only — returns 415 Unsupported Media Type for other content types
-async fn with_json(_conn: &mut Conn, Json(post): Json<NewPost>) -> String {
-    format!("created: {}", post.title)
-}
-
-# use trillium_testing::TestServer;
-# use trillium::Status;
-# trillium_testing::block_on(async {
-#     // Body accepts form-urlencoded
-#     let app = TestServer::new(api(with_body)).await;
-#     app.post("/")
-#         .with_request_header("content-type", "application/x-www-form-urlencoded")
-#         .with_body("title=hello")
-#         .await
-#         .assert_ok()
-#         .assert_body("created: hello");
-#
-#     // Json rejects form-urlencoded
-#     let app = TestServer::new(api(with_json)).await;
-#     app.post("/")
-#         .with_request_header("content-type", "application/x-www-form-urlencoded")
-#         .with_body("title=hello")
-#         .await
-#         .assert_status(Status::UnsupportedMediaType);
-# });
-```
-
-You can also extract the body as a raw `String` or `Vec<u8>`:
-
-```rust
-use trillium_api::api;
-use trillium::Conn;
-
-async fn raw_body(_conn: &mut Conn, body: String) {
-    // `body` is the request body as a string
-}
-```
-
-## State
-
-[`State<T>`](crate::State) extracts a `T` from the conn's state set.
-This is how you access shared application state (database handles,
-configuration, etc.) that was injected earlier in the handler chain.
-
-```rust
-use trillium_api::{api, Json, State};
-use trillium::Conn;
-
-#[derive(Clone, Debug)]
-struct AppConfig { name: String }
-
-async fn show_config(
-    _conn: &mut Conn,
-    State(config): State<AppConfig>,
-) -> Json<String> {
-    Json(config.name)
-}
-
-# use trillium_testing::TestServer;
-# trillium_testing::block_on(async {
-#     let app = TestServer::new((
-#         trillium::State::new(AppConfig { name: "my app".into() }),
-#         api(show_config),
-#     )).await;
-#     app.get("/").await.assert_ok().assert_body(r#""my app""#);
-# });
-```
-
-Note: `State<T>` calls [`Conn::take_state`](trillium::Conn::take_state),
-which *removes* the value from the conn. If the type is not present, the
-extractor returns `None`, which means your api handler is not called and
-the conn passes through unmodified (default 404).
-
-## Request metadata
+## Built-in request metadata
 
 Some trillium types implement [`FromConn`](crate::FromConn) directly:
 
@@ -134,6 +124,17 @@ async fn inspect(_conn: &mut Conn, (method, headers): (Method, Headers)) -> Stri
 # });
 ```
 
+You can also extract the body as a raw `String` or `Vec<u8>`:
+
+```rust
+use trillium_api::api;
+use trillium::Conn;
+
+async fn raw_body(_conn: &mut Conn, body: String) {
+    // `body` is the request body as a string
+}
+```
+
 ## Tuple extraction
 
 Combine multiple extractors as a tuple (up to 12 elements). Extractors
@@ -141,14 +142,16 @@ run in order, left to right. If any one fails, the error handler for
 that extractor runs and subsequent extractors are skipped.
 
 ```rust
-use trillium_api::{api, Body, Json, State};
+use trillium_api::{api, Handler, TryFromConn, Json};
 use trillium::{Conn, Status};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, TryFromConn)]
+#[api(state, clone)]
 struct Db;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, TryFromConn)]
+#[api(json)]
 struct CreateItem { name: String }
 
 #[derive(Serialize)]
@@ -156,7 +159,7 @@ struct Item { id: u64, name: String }
 
 async fn create(
     _conn: &mut Conn,
-    (State(db), Body(input)): (State<Db>, Body<CreateItem>),
+    (db, input): (Db, CreateItem),
 ) -> (Status, Json<Item>) {
     let _ = db; // use the database...
     (Status::Created, Json(Item { id: 1, name: input.name }))
@@ -176,12 +179,51 @@ async fn create(
 A common pattern for complex handlers is to use a type alias:
 
 ```rust,ignore
-type CreateArgs = (State<Db>, Body<CreateItem>, State<AppConfig>);
+type CreateArgs = (Db, CreateItem, AppConfig);
 
-async fn create(_conn: &mut Conn, (db, body, config): CreateArgs) -> impl Handler {
+async fn create(_conn: &mut Conn, (db, input, config): CreateArgs) -> impl Handler {
     // ...
 }
 ```
+
+## Wrapper extractors for foreign types
+
+Sometimes you can't add `#[derive(TryFromConn)]` to a type — typically
+because it lives in another crate. The
+[`Body<T>`](crate::Body), [`Json<T>`](crate::Json), and
+[`State<T>`](crate::State) newtypes give you the same behavior as the
+derive without modifying the wrapped type:
+
+```rust
+use trillium_api::{api, Body, Json, State};
+use trillium::Conn;
+
+# #[derive(Clone, Debug)]
+# struct AppConfig { name: String }
+async fn show_config(
+    _conn: &mut Conn,
+    State(config): State<AppConfig>,
+) -> Json<String> {
+    Json(config.name)
+}
+# use trillium_testing::TestServer;
+# trillium_testing::block_on(async {
+#     let app = TestServer::new((
+#         trillium::State::new(AppConfig { name: "my app".into() }),
+#         api(show_config),
+#     )).await;
+#     app.get("/").await.assert_ok().assert_body(r#""my app""#);
+# });
+```
+
+`Body<T>` deserializes via content-type negotiation and serializes via
+`Accept`. `Json<T>` is JSON-only on both sides. `State<T>` calls
+[`take_state`](trillium::Conn::take_state), which removes the value from
+the conn — if it's missing, the api handler is not called and the conn
+passes through unmodified (default 404).
+
+For your own types, prefer the derive — it produces the same code without
+the newtype indirection at call sites.
 
 ## `Option` and `Result` as extractors
 

--- a/api/docs/extractors/custom.md
+++ b/api/docs/extractors/custom.md
@@ -1,5 +1,14 @@
 # Custom extractors
 
+For most cases, the
+[`#[derive(TryFromConn)]`](crate::TryFromConn) macro generates the
+extractor for you — see
+[`extractors::deriving`](crate::extractors::deriving). Reach for a
+hand-written impl when the derive doesn't fit: header sniffing, route
+parameter parsing, conditional or multi-step extraction (e.g. parse a
+route param, then look up a record in the database), or anywhere you
+need access to the `Conn` beyond what the derive's source modes provide.
+
 You can extract any type by implementing [`FromConn`](crate::FromConn)
 (infallible) or [`TryFromConn`](crate::TryFromConn) (fallible).
 

--- a/api/docs/extractors/deriving.md
+++ b/api/docs/extractors/deriving.md
@@ -1,0 +1,185 @@
+# Deriving `TryFromConn` and `Handler`
+
+For your own types, the [`#[derive(TryFromConn)]`](crate::TryFromConn) and
+[`#[derive(Handler)]`](trillium::Handler) macros generate the same impls
+you'd write by hand, configured by an `#[api(...)]` attribute on the struct.
+
+The two derives can be applied independently or together, and they share
+the same attribute — useful when a type plays both roles (e.g. a clonable
+state type that also writes itself back into state).
+
+## `#[api(state)]` — extract from / write to conn state
+
+By default, `state` *takes* the value out of the conn (matching
+[`State<T>`](crate::State)'s behavior):
+
+```rust
+use trillium::Conn;
+use trillium_api::{api, TryFromConn};
+
+#[derive(Clone, Debug, TryFromConn)]
+#[api(state)]
+struct Db;
+
+async fn show(_conn: &mut Conn, db: Db) -> String {
+    let _ = db;
+    "ok".into()
+}
+# use trillium_testing::TestServer;
+# trillium_testing::block_on(async {
+#     let app = TestServer::new((trillium::State::new(Db), api(show))).await;
+#     app.get("/").await.assert_ok();
+# });
+```
+
+Add `clone` to leave the value in conn state for downstream extractors:
+
+```rust
+use trillium::Conn;
+use trillium_api::{api, TryFromConn};
+
+#[derive(Clone, Debug, TryFromConn)]
+#[api(state, clone)]
+struct Db(/* ... */);
+```
+
+The associated `Error` type is `()` — when state is missing, the api
+handler is skipped (default 404). To run a custom handler in that case,
+use `err = SomeHandler` where `SomeHandler` implements both `Default` and
+`Handler`:
+
+```rust
+use trillium::{Conn, Handler, Status};
+use trillium_api::{api, TryFromConn};
+
+#[derive(Default)]
+struct ServerError;
+impl Handler for ServerError {
+    async fn run(&self, conn: Conn) -> Conn {
+        conn.with_status(Status::InternalServerError).halt()
+    }
+}
+
+#[derive(TryFromConn)]
+#[api(state, err = ServerError)]
+struct RequiredState(u32);
+```
+
+## `#[api(json)]` — JSON request body
+
+Deserializes from JSON only (rejects other content types). Requires
+`T: serde::de::DeserializeOwned`:
+
+```rust
+use trillium::Conn;
+use trillium_api::{api, TryFromConn};
+use serde::Deserialize;
+
+#[derive(Deserialize, TryFromConn)]
+#[api(json)]
+struct NewPost {
+    title: String,
+}
+
+async fn create(_conn: &mut Conn, post: NewPost) -> String {
+    format!("created: {}", post.title)
+}
+```
+
+The associated `Error` is [`Error`](crate::Error). To swap in your own
+error handler, use `err = MyError`:
+
+```rust
+# use trillium::{Conn, Handler};
+# use trillium_api::TryFromConn;
+# use serde::Deserialize;
+#[derive(Default)]
+struct BadRequest;
+impl Handler for BadRequest {
+    async fn run(&self, conn: Conn) -> Conn {
+        conn.with_status(400).halt()
+    }
+}
+
+#[derive(Deserialize, TryFromConn)]
+#[api(json, err = BadRequest)]
+struct StrictInput {
+    value: u32,
+}
+```
+
+The original error is discarded; if you need its detail, use `err`-less
+extraction and let the default `Error` handler render it.
+
+## `#[api(body)]` — content-negotiated body
+
+Like `json`, but uses the `Content-Type` header to choose the deserializer
+(JSON or form-urlencoded with the `forms` feature). Otherwise identical to
+`json` — same `Error` type, same `err = ...` override.
+
+## Pairing with `#[derive(Handler)]`
+
+The same `#[api(...)]` attribute drives both derives. Each does the
+symmetric thing:
+
+| `#[api(...)]` | `TryFromConn` does | `Handler` does |
+|---|---|---|
+| `state` | `take_state::<Self>()` | `with_state(self.clone())` (requires `Self: Clone`) |
+| `state, clone` | `state::<Self>().cloned()` | same as above |
+| `state, err = E` | `take_state::<Self>().ok_or_else(E::default)` | same as state |
+| `json` | `deserialize_json::<Self>(conn)` | `with_json(self)` (requires `Serialize`) |
+| `body` | `deserialize::<Self>(conn)` | content-negotiated `serialize(self)` (requires `Serialize`) |
+
+`clone` and `err` are silently ignored by the `Handler` derive — they're
+specifically for extraction.
+
+A complete round-tripping type:
+
+```rust
+use trillium::Conn;
+use trillium_api::{api, Handler, TryFromConn};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, TryFromConn, Handler)]
+#[api(body)]
+struct Echo {
+    payload: String,
+}
+
+async fn echo(_conn: &mut Conn, e: Echo) -> Echo {
+    e
+}
+# use trillium_testing::TestServer;
+# trillium_testing::block_on(async {
+#     let app = TestServer::new(api(echo)).await;
+#     app.post("/")
+#         .with_request_header("content-type", "application/json")
+#         .with_request_header("accept", "application/json")
+#         .with_body(r#"{"payload":"hi"}"#)
+#         .await
+#         .assert_ok()
+#         .assert_body(r#"{"payload":"hi"}"#);
+# });
+```
+
+## Note on `trillium_api::Handler`
+
+`trillium_api::Handler` is the derive macro from this crate; it shadows
+the `trillium::Handler` *trait* of the same name when both are imported.
+This mirrors how `serde::Serialize` works. If you need the trait in scope
+alongside the derive, import them separately:
+
+```rust,ignore
+use trillium::Handler;            // the trait
+use trillium_api::Handler as _;   // the derive macro is still callable
+```
+
+In practice you'll usually only need one of them in any given file, so
+the shadowing is rarely visible.
+
+## When the derive isn't enough
+
+The derive covers extraction from state, JSON, and content-negotiated
+bodies. For anything else — header sniffing, route parameter parsing,
+multi-step extraction with database lookups, conditional logic — write
+the impl by hand. See [`extractors::custom`](crate::extractors::custom).

--- a/api/docs/root.md
+++ b/api/docs/root.md
@@ -52,8 +52,9 @@ run on the conn, typically setting an error status.
 
 | Module | Topic |
 |--------|-------|
-| [`extractors`] | Pulling data out of requests — `Body`, `Json`, `State`, tuples |
-| [`extractors::custom`] | Writing your own `FromConn` / `TryFromConn` implementations |
+| [`extractors`] | Pulling data out of requests — typically via `#[derive(TryFromConn)]` on your own types |
+| [`extractors::deriving`] | The `#[derive(TryFromConn)]` and `#[derive(Handler)]` macros in depth |
+| [`extractors::custom`] | Hand-writing `FromConn` / `TryFromConn` when the derive isn't enough |
 | [`return_types`] | What you can return from an api handler |
 | [`error_handling`] | How extraction errors and `Result` return types work |
 | [`recipes`] | Patterns and ideas: middleware, type aliases, and more |

--- a/api/src/halt.rs
+++ b/api/src/halt.rs
@@ -2,7 +2,7 @@ use trillium::{Conn, Handler};
 
 /// a struct that halts the Conn handler sequence. see [`Conn::halt`]
 /// for more.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Halt;
 
 impl Handler for Halt {

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -34,6 +34,7 @@ pub use halt::Halt;
 #[cfg(any(feature = "serde_json", feature = "sonic-rs"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "serde_json", feature = "sonic-rs"))))]
 pub use json::Json;
+pub use trillium::Handler;
 
 #[cfg(all(feature = "serde_json", feature = "sonic-rs"))]
 compile_error!("cargo features \"serde_json\" and \"sonic-rs\" are mutually exclusive");
@@ -45,6 +46,7 @@ pub use serde_json::{Value, json};
 #[cfg_attr(docsrs, doc(cfg(feature = "sonic-rs")))]
 pub use sonic_rs::{Value, json};
 pub use state::State;
+pub use trillium_api_macros::{Handler, TryFromConn};
 pub use try_from_conn::TryFromConn;
 
 /// trait alias for a result with this crate's [`Error`]
@@ -53,6 +55,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[cfg(doc)]
 #[doc = include_str!("../docs/extractors.md")]
 pub mod extractors {
+    #[doc = include_str!("../docs/extractors/deriving.md")]
+    pub mod deriving {}
     #[doc = include_str!("../docs/extractors/custom.md")]
     pub mod custom {}
 }


### PR DESCRIPTION
An effort to address #688

There's likely further surface area that could be added eventually, such as:

```rust
#[derive(TryFromConn)]
struct CreatePost {
    #[api(state)]
    db: Db,

    #[api(body)]
    input: NewPostInput,

    #[api(header = "x-request-id")]
    request_id: String,

    #[api(param = "team_id")]
    team: TeamId,
}
```