### PR TITLE
docs: add a note to indicate that KnownHeaderName's u8 representation…

### DIFF
--- a/http/src/headers/known_header_name.rs
+++ b/http/src/headers/known_header_name.rs
@@ -36,10 +36,12 @@ macro_rules! known_headers {
         ),+
     ) => {
 
-        /// A short nonehaustive enum of headers that trillium can
-        /// represent as a u8. Use a `KnownHeaderName` variant instead
-        /// of a &'static str anywhere possible, as it allows trillium
-        /// to skip parsing the header entirely.
+        /// A short non-exhaustive enum of headers that trillium represents as an enum.
+        ///
+        /// Use a `KnownHeaderName` variant instead of a &'static str anywhere possible, as it
+        /// allows trillium to skip parsing the header entirely.
+        ///
+        /// Please do not rely on the u8 representation being stable between releases.
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
         #[non_exhaustive]
         #[repr(u8)]


### PR DESCRIPTION
… is not considered stable for semver purposes