### PR TITLE
fix(http): h3 conformance work driven by kazu-yamamoto/h3spec

### DIFF
--- a/client/src/h3.rs
+++ b/client/src/h3.rs
@@ -234,7 +234,16 @@ fn spawn_inbound_bidi_streams(
             runtime.spawn(async move {
                 let result = h3
                     .clone()
-                    .process_inbound_bidi(transport, |conn| async move { conn }, stream_id)
+                    .process_inbound_bidi_with_reset(
+                        transport,
+                        |conn| async move { conn },
+                        stream_id,
+                        |t, code| {
+                            let raw = u64::from(code);
+                            t.stop(raw);
+                            t.reset(raw);
+                        },
+                    )
                     .await;
 
                 match result {
@@ -295,7 +304,22 @@ fn spawn_inbound_uni_streams(
             let dispatcher = dispatcher.clone();
 
             runtime.spawn(async move {
-                match h3.process_inbound_uni(recv).await {
+                // Connection-level protocol errors must close the QUIC connection
+                // before the recv stream drops; otherwise quinn's RecvStream::drop
+                // sends STOP_SENDING and the peer's RESET_STREAM response can race
+                // ahead, replacing our app error code with a transport-level code on
+                // the wire. The closure runs inside process_inbound_uni_with_close
+                // while the stream is still alive.
+                let close_connection = {
+                    let conn_for_close = conn_for_error.clone();
+                    move |code: H3ErrorCode| {
+                        conn_for_close.close(code.into(), code.reason().as_bytes());
+                    }
+                };
+                match h3
+                    .process_inbound_uni_with_close(recv, close_connection)
+                    .await
+                {
                     Ok(UniStreamResult::Handled) => {}
 
                     Ok(UniStreamResult::WebTransport {
@@ -326,7 +350,12 @@ fn spawn_inbound_uni_streams(
                     }
                     Err(error) => {
                         log::debug!("client H3 inbound uni stream error: {error}");
-                        if let H3Error::Protocol(code) = error {
+                        // Connection-level errors closed via the callback above
+                        // (Connection::close is idempotent); this branch covers I/O
+                        // errors plus stream-level errors that don't warrant close.
+                        if let H3Error::Protocol(code) = error
+                            && code.is_connection_error()
+                        {
                             conn_for_error.close(code.into(), code.reason().as_bytes());
                         }
                         h3.shut_down().await;

--- a/http/CHANGELOG.md
+++ b/http/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-05-06
+
+### Fixed
+
+[h3spec](https://github.com/kazu-yamamoto/h3spec) identified the following minor violations in trillium's h3 implementation, primarily focused on error handling. All of these are fixed in 1.1.1:
+
+- RFC 9114 §4.1.2 — stream-level errors (notably `H3_MESSAGE_ERROR`) MUST RST the bidi stream.
+- RFC 9114 §4.1.1 / §4.2 / §4.3.1 — malformed messages (duplicated pseudos, unknown pseudos, uppercase header bytes) are `H3_MESSAGE_ERROR`.
+- RFC 9114 §4.3.1 — schemes with mandatory authority component (http/https) require `:authority` or `Host` on non-`CONNECT` requests.
+- RFC 9114 §6.2.1 — first frame on the peer's control stream must be `SETTINGS`. Non-`SETTINGS` first frame OR a malformed first frame →
+  `H3_MISSING_SETTINGS`.
+- RFC 9114 §6.2.1 + RFC 9204 §4.2 — closure of control or QPACK streams is `H3_CLOSED_CRITICAL_STREAM`.
+- RFC 9114 §7.2.1 / §7.2.2 / §7.2.4 / §7.2.5 — control stream must reject `DATA`, `HEADERS`, `PUSH_PROMISE`, second `SETTINGS`, and the WebTransport
+  `0x41` signal as `H3_FRAME_UNEXPECTED`.
+- RFC 9114 §4.1 — first-frame decode failure on a request bidi stream is `H3_FRAME_UNEXPECTED`.
+- RFC 9204 §3.1 — invalid static-table index in a field-line representation is `QPACK_DECOMPRESSION_FAILED`.
+- RFC 9204 §4.1.3 — Set Dynamic Table Capacity exceeding the limit is `QPACK_ENCODER_STREAM_ERROR`.
+- RFC 9204 §4.4.3 — Insert Count Increment of 0 is `QPACK_DECODER_STREAM_ERROR`.
+- RFC 9204 §6 — QPACK errors are connection-level, not stream-level.
+- RFC 9114 §8.1 / RFC 9204 §6 — correct close error code on the wire.
+
 ## [1.1.0] - 2026-05-05
 
 This release adds http/2 support.

--- a/http/src/conn.rs
+++ b/http/src/conn.rs
@@ -41,11 +41,11 @@ pub(super) struct ValidatedRequest {
 ///
 /// Both protocols apply the same malformed-message rules to incoming requests:
 /// no `:status` pseudo, required `:method`, non-empty `:path` (or CONNECT default),
-/// `:scheme` required for non-CONNECT, `:authority` required for CONNECT, no
-/// `Host`/`:authority` mismatch, no [`H1_ONLY_HEADERS`], and `TE` restricted to
-/// `trailers`. Returns `None` on any violation; the caller maps to its
-/// protocol-specific error code (e.g. `H2ErrorCode::ProtocolError`,
-/// `H3ErrorCode::MessageError`) via `.ok_or(...)`.
+/// `:scheme` required for non-CONNECT, `:authority` required for CONNECT, `:authority`
+/// or `Host` required when `:scheme` is `http`/`https`, no `Host`/`:authority`
+/// mismatch, no [`H1_ONLY_HEADERS`], and `TE` restricted to `trailers`. Returns `None`
+/// on any violation; the caller maps to its protocol-specific error code (e.g.
+/// `H2ErrorCode::ProtocolError`, `H3ErrorCode::MessageError`) via `.ok_or(...)`.
 pub(super) fn validate_h2h3_request(
     mut field_section: FieldSection<'static>,
 ) -> Option<ValidatedRequest> {
@@ -93,6 +93,21 @@ pub(super) fn validate_h2h3_request(
         return None;
     }
 
+    // RFC 9114 §4.3.1 / RFC 9113 §8.3.1: when :scheme names a scheme with a mandatory
+    // authority component, the request MUST carry either :authority or a Host header.
+    // The spec gives "http" and "https" as the canonical examples; we also include "ws"
+    // and "wss" (RFC 6455 §3, same hierarchical-with-mandatory-authority shape) so the
+    // rule applies consistently if a non-standard sender uses those. Exotic schemes
+    // without mandatory authority (file, data, mailto, urn) are exempt; CONNECT is
+    // handled above.
+    if method != Method::Connect
+        && matches!(scheme.as_deref(), Some("http" | "https" | "ws" | "wss"))
+        && authority.is_none()
+        && request_headers.get_str(Host).is_none()
+    {
+        return None;
+    }
+
     match request_headers.get_str(KnownHeaderName::Te) {
         None | Some("trailers") => {}
         _ => return None,
@@ -125,6 +140,7 @@ use std::{
 mod h1;
 mod h2;
 mod h3;
+pub(crate) use h3::H3FirstFrame;
 
 /// A http connection
 ///

--- a/http/src/conn/h3.rs
+++ b/http/src/conn/h3.rs
@@ -2,7 +2,7 @@ use crate::{
     BufWriter, Buffer, Conn, Headers, KnownHeaderName, Method, ProtocolSession, Status, TypeSet,
     Version,
     after_send::AfterSend,
-    h3::{Frame, FrameStream, H3Connection, H3Error, H3ErrorCode, H3StreamResult},
+    h3::{Frame, FrameStream, H3Connection, H3Error, H3ErrorCode},
     headers::qpack::{FieldSection, PseudoHeaders},
     received_body::ReceivedBodyState,
 };
@@ -13,29 +13,55 @@ use std::{
     time::{Instant, SystemTime},
 };
 
+/// What `Conn::process_first_frame_h3` resolved a bidi stream's first frame to.
+///
+/// Split apart from the actual `Conn` construction so the orchestrating caller
+/// (`H3Connection::process_inbound_bidi_with_reset`) can apply a stream RST against
+/// the still-owned transport on the error path before constructing anything.
+pub(crate) enum H3FirstFrame {
+    /// First frame was HEADERS, decoded and validated.
+    Request {
+        validated: super::ValidatedRequest,
+        start_time: Instant,
+    },
+    /// First "frame" was the WebTransport 0x41 bidi-stream signal.
+    WebTransport { session_id: u64 },
+}
+
 impl<Transport> Conn<Transport>
 where
     Transport: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
 {
-    /// Parse the first frame on a bidi stream.
+    /// Read and classify the first frame on an H3 bidi stream.
     ///
-    /// Returns [`H3StreamResult::Request`] for normal H3 requests (HEADERS frame) or
-    /// [`H3StreamResult::WebTransport`] for WebTransport bidi streams (0x41 signal).
-    pub(crate) async fn new_h3(
-        h3_connection: Arc<H3Connection>,
-        mut transport: Transport,
-        mut buffer: Buffer,
+    /// On success returns either a [`H3FirstFrame::Request`] (HEADERS, decoded + validated)
+    /// or a [`H3FirstFrame::WebTransport`] (0x41 signal). On error the borrowed transport is
+    /// returned to the caller intact so it can issue a stream RST before propagating.
+    ///
+    /// RFC 9114 §4.1: the first frame on a request stream MUST be HEADERS (or — extension —
+    /// the WebTransport 0x41 signal). DATA, `CANCEL_PUSH`, etc. before HEADERS is
+    /// `H3_FRAME_UNEXPECTED`. A first-frame *decode* failure is also `H3_FRAME_UNEXPECTED`:
+    /// anything we can't recognize as HEADERS up-front is by definition out of place. I/O
+    /// errors pass through unchanged.
+    pub(crate) async fn process_first_frame_h3(
+        h3_connection: &H3Connection,
+        transport: &mut Transport,
+        buffer: &mut Buffer,
         stream_id: u64,
-    ) -> Result<H3StreamResult<Transport>, H3Error> {
+    ) -> Result<H3FirstFrame, H3Error> {
         log::trace!("H3 bidi stream {stream_id}: started");
         let start_time = Instant::now();
+        log::trace!("H3 bidi stream {stream_id}: waiting for first frame");
 
-        let mut frame_stream = FrameStream::new(&mut transport, &mut buffer);
-        let field_section = loop {
-            log::trace!("H3 bidi stream {stream_id}: waiting for next frame");
+        let field_section = {
+            let mut frame_stream = FrameStream::new(transport, buffer);
             let mut frame = frame_stream
                 .next()
-                .await?
+                .await
+                .map_err(|e| match e {
+                    H3Error::Protocol(_) => H3ErrorCode::FrameUnexpected.into(),
+                    io @ H3Error::Io(_) => io,
+                })?
                 .ok_or(H3ErrorCode::RequestIncomplete)?;
 
             match frame.frame() {
@@ -45,38 +71,32 @@ where
                     let result = h3_connection
                         .decode_field_section(encoded, stream_id)
                         .await
-                        .map_err(|e| {
+                        .inspect_err(|e| {
                             log::debug!("H3 bidi stream {stream_id}: HEADERS decode error: {e:?}");
-                            H3ErrorCode::MessageError
                         })?;
                     log::trace!("H3 bidi stream {stream_id}: HEADERS decoded:\n{result}");
-                    break result;
+                    result
                 }
 
                 Frame::WebTransport(session_id) => {
                     let session_id = *session_id;
-                    drop(frame); // release borrow on frame_stream
-                    return Ok(H3StreamResult::WebTransport {
-                        session_id,
-                        transport,
-                        buffer,
-                    });
+                    return Ok(H3FirstFrame::WebTransport { session_id });
                 }
 
                 other => {
-                    log::trace!("H3 bidi stream {stream_id}: skipping frame {other:?}");
+                    log::trace!("H3 bidi stream {stream_id}: unexpected first frame {other:?}");
+                    return Err(H3ErrorCode::FrameUnexpected.into());
                 }
             }
         };
 
-        Ok(H3StreamResult::Request(Self::build_h3(
-            h3_connection,
-            transport,
-            buffer,
-            field_section,
+        log::trace!("received:\n{field_section}");
+        let validated =
+            super::validate_h2h3_request(field_section).ok_or(H3ErrorCode::MessageError)?;
+        Ok(H3FirstFrame::Request {
+            validated,
             start_time,
-            stream_id,
-        )?))
+        })
     }
 
     fn max_peer_field_section_size(&self) -> Option<u64> {
@@ -148,16 +168,14 @@ where
         )
     }
 
-    fn build_h3(
+    pub(crate) fn build_h3(
         h3_connection: Arc<H3Connection>,
         transport: Transport,
         buffer: Buffer,
-        field_section: FieldSection<'static>,
+        validated: super::ValidatedRequest,
         start_time: Instant,
         stream_id: u64,
-    ) -> Result<Self, H3ErrorCode> {
-        log::trace!("received:\n{field_section}");
-
+    ) -> Self {
         let super::ValidatedRequest {
             method,
             path,
@@ -165,7 +183,7 @@ where
             scheme,
             protocol,
             request_headers,
-        } = super::validate_h2h3_request(field_section).ok_or(H3ErrorCode::MessageError)?;
+        } = validated;
 
         let response_headers = h3_connection
             .context()
@@ -176,7 +194,7 @@ where
 
         let request_body_state = ReceivedBodyState::new_h3();
 
-        Ok(Conn {
+        Conn {
             context: h3_connection.context(),
             transport,
             request_headers,
@@ -201,7 +219,7 @@ where
                 stream_id,
             },
             request_trailers: None,
-        })
+        }
     }
 
     /// Apply h3-flavored finalizations to the response headers: insert a Date header if absent,

--- a/http/src/h3/connection.rs
+++ b/http/src/h3/connection.rs
@@ -8,6 +8,7 @@ use super::{
 };
 use crate::{
     Buffer, Conn, HttpContext,
+    conn::H3FirstFrame,
     h3::{H3ErrorCode, MAX_BUFFER_SIZE},
     headers::qpack::{DecoderDynamicTable, EncoderDynamicTable, FieldSection},
 };
@@ -42,6 +43,17 @@ pub enum H3StreamResult<Transport> {
         /// Any bytes buffered after the session ID during stream negotiation.
         buffer: Buffer,
     },
+}
+
+/// Inner-loop result of [`H3Connection::process_inbound_uni_with_close`] before the recv
+/// stream is reattached. Decouples the inner async block (which only borrows the stream)
+/// from the caller-visible [`UniStreamResult`] (which returns the stream by value on
+/// non-`Handled` variants), so the function can keep ownership of `stream` long enough to
+/// fire its close callback before `stream` drops.
+enum UniInnerResult {
+    Handled,
+    WebTransport { session_id: u64, buffer: Buffer },
+    Unknown { stream_type: u64 },
 }
 
 /// The result of processing an HTTP/3 unidirectional stream.
@@ -212,9 +224,21 @@ impl H3Connection {
     /// [`H3StreamResult::WebTransport`] if the stream opens a WebTransport session rather than
     /// a standard HTTP/3 request.
     ///
+    /// On a stream-level protocol error (e.g. malformed pseudo-headers,
+    /// `H3_MESSAGE_ERROR`), this method drops the transport without resetting it. To honour
+    /// RFC 9114's stream-error MUSTs, callers should use [`process_inbound_bidi_with_reset`]
+    /// instead and pass a closure that issues a stream RST with the protocol error code.
+    ///
+    /// [`process_inbound_bidi_with_reset`]: Self::process_inbound_bidi_with_reset
+    ///
     /// # Errors
     ///
     /// Returns an `H3Error` in case of io error or http/3 semantic error.
+    #[deprecated(
+        since = "1.1.1",
+        note = "use `process_inbound_bidi_with_reset` so stream-level protocol errors RST the \
+                stream as required by RFC 9114 §4.1.2"
+    )]
     pub async fn process_inbound_bidi<Transport, Handler, Fut>(
         self: Arc<Self>,
         transport: Transport,
@@ -226,14 +250,71 @@ impl H3Connection {
         Handler: FnOnce(Conn<Transport>) -> Fut,
         Fut: Future<Output = Conn<Transport>>,
     {
+        self.process_inbound_bidi_with_reset(transport, handler, stream_id, |_, _| {})
+            .await
+    }
+
+    /// Process a single HTTP/3 request-response cycle on a bidirectional stream, calling
+    /// `reset` to issue a stream RST when a stream-level protocol error occurs.
+    ///
+    /// Identical to [`process_inbound_bidi`][Self::process_inbound_bidi] except that on any
+    /// `H3Error::Protocol(code)` produced by first-frame processing (HEADERS decode,
+    /// pseudo-header validation, etc.), `reset` is invoked with the still-owned transport and
+    /// the error code before the error is returned. This lets callers RST both the recv and
+    /// send halves of the bidi stream — required by RFC 9114 §4.1.2 for stream errors like
+    /// `H3_MESSAGE_ERROR`. I/O errors and successful runs do not invoke `reset`.
+    ///
+    /// `reset` is a `FnOnce` taking `(&mut Transport, H3ErrorCode)`. trillium-http does not
+    /// itself depend on any reset capability of the transport; callers wire up the actual
+    /// stream-RST mechanism (e.g. quinn's `RecvStream::stop` + `SendStream::reset`) inside
+    /// the closure.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `H3Error` in case of io error or http/3 semantic error.
+    pub async fn process_inbound_bidi_with_reset<Transport, Handler, Fut, Reset>(
+        self: Arc<Self>,
+        mut transport: Transport,
+        handler: Handler,
+        stream_id: u64,
+        reset: Reset,
+    ) -> Result<H3StreamResult<Transport>, H3Error>
+    where
+        Transport: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
+        Handler: FnOnce(Conn<Transport>) -> Fut,
+        Fut: Future<Output = Conn<Transport>>,
+        Reset: FnOnce(&mut Transport, H3ErrorCode),
+    {
         self.record_accepted_stream(stream_id);
         let _guard = self.swansong.guard();
-        let buffer = Vec::with_capacity(self.context.config.request_buffer_initial_len).into();
-        match Conn::new_h3(self, transport, buffer, stream_id).await? {
-            H3StreamResult::Request(conn) => Ok(H3StreamResult::Request(
-                handler(conn).await.send_h3().await?,
-            )),
-            wt @ H3StreamResult::WebTransport { .. } => Ok(wt),
+        let mut buffer: Buffer =
+            Vec::with_capacity(self.context.config.request_buffer_initial_len).into();
+
+        let outcome =
+            Conn::process_first_frame_h3(&self, &mut transport, &mut buffer, stream_id).await;
+
+        match outcome {
+            Ok(H3FirstFrame::Request {
+                validated,
+                start_time,
+            }) => {
+                let conn =
+                    Conn::build_h3(self, transport, buffer, validated, start_time, stream_id);
+                Ok(H3StreamResult::Request(
+                    handler(conn).await.send_h3().await?,
+                ))
+            }
+            Ok(H3FirstFrame::WebTransport { session_id }) => Ok(H3StreamResult::WebTransport {
+                session_id,
+                transport,
+                buffer,
+            }),
+            Err(error) => {
+                if let H3Error::Protocol(code) = &error {
+                    reset(&mut transport, *code);
+                }
+                Err(error)
+            }
         }
     }
 
@@ -384,28 +465,156 @@ impl H3Connection {
     /// Internal stream types (control, QPACK encoder/decoder) are handled automatically;
     /// application streams are returned via [`UniStreamResult`] for the caller to process.
     ///
+    /// On a connection-level protocol error, this method drops the recv stream before
+    /// the caller can react. Quinn's `RecvStream::drop` then sends `STOP_SENDING`, which
+    /// races against the caller's `connection.close` — if the peer responds with a
+    /// malformed `RESET_STREAM` (notably `final_offset = 0`) before our app close is
+    /// applied, the transport-level error overrides our app error code on the wire.
+    /// Use [`process_inbound_uni_with_close`] to thread the close call through the
+    /// function so it fires before the stream drops.
+    ///
+    /// [`process_inbound_uni_with_close`]: Self::process_inbound_uni_with_close
+    ///
     /// # Errors
     ///
     /// Returns a `H3Error` in case of io error or http/3 semantic error.
-    pub async fn process_inbound_uni<T>(&self, mut stream: T) -> Result<UniStreamResult<T>, H3Error>
+    #[deprecated(
+        since = "1.1.1",
+        note = "use `process_inbound_uni_with_close` so connection-level protocol errors close \
+                the QUIC connection before the recv stream drops, avoiding a `FINAL_SIZE_ERROR` \
+                race with the peer's response to STOP_SENDING"
+    )]
+    pub async fn process_inbound_uni<T>(&self, stream: T) -> Result<UniStreamResult<T>, H3Error>
     where
         T: AsyncRead + Unpin + Send,
     {
-        self.swansong
-            .interrupt(async move {
-                let mut buf = vec![0; 128];
-                let mut filled = 0;
+        self.process_inbound_uni_with_close(stream, |_| {}).await
+    }
 
-                // Read stream type varint (decode as raw u64 to handle unknown types)
-                let stream_type =
+    /// Handle an inbound unidirectional HTTP/3 stream from the peer, calling `on_close` to
+    /// close the QUIC connection if a connection-level protocol error is detected.
+    ///
+    /// Identical to [`process_inbound_uni`][Self::process_inbound_uni] except that on
+    /// any `H3Error::Protocol(code)` whose code is a connection-level error
+    /// (RFC 9114 §8.1, RFC 9204 §6), `on_close` is invoked with that code while the
+    /// recv stream is still alive. This lets callers send a `CONNECTION_CLOSE` before
+    /// the stream drops — if the close call sets quinn's `conn.error`, quinn's
+    /// `RecvStream::drop` skips `STOP_SENDING`, eliminating a peer race that otherwise
+    /// causes `FINAL_SIZE_ERROR` to override the app error code.
+    ///
+    /// `on_close` is a `FnOnce` taking `H3ErrorCode`. trillium-http does not itself
+    /// hold the QUIC connection; callers wire up the actual `connection.close()` call
+    /// inside the closure (e.g. quinn's `Connection::close`).
+    ///
+    /// # Errors
+    ///
+    /// Returns a `H3Error` in case of io error or http/3 semantic error.
+    pub async fn process_inbound_uni_with_close<T, OnClose>(
+        &self,
+        mut stream: T,
+        on_close: OnClose,
+    ) -> Result<UniStreamResult<T>, H3Error>
+    where
+        T: AsyncRead + Unpin + Send,
+        OnClose: FnOnce(H3ErrorCode),
+    {
+        let inner = self
+            .swansong
+            .interrupt(self.process_inbound_uni_inner(&mut stream))
+            .await
+            .unwrap_or(Ok(UniInnerResult::Handled)); // interrupted
+
+        match inner {
+            Ok(UniInnerResult::Handled) => Ok(UniStreamResult::Handled),
+            Ok(UniInnerResult::WebTransport { session_id, buffer }) => {
+                Ok(UniStreamResult::WebTransport {
+                    session_id,
+                    stream,
+                    buffer,
+                })
+            }
+            Ok(UniInnerResult::Unknown { stream_type }) => Ok(UniStreamResult::Unknown {
+                stream_type,
+                stream,
+            }),
+            Err(error) => {
+                // Fire `on_close` BEFORE returning so the caller's connection.close
+                // call sets quinn's `conn.error` while `stream` is still alive. When
+                // `stream` then drops at function return, quinn's `RecvStream::drop`
+                // skips STOP_SENDING — preventing the peer-RESET_STREAM race that
+                // otherwise replaces our app close code with FINAL_SIZE_ERROR.
+                if let H3Error::Protocol(code) = &error
+                    && code.is_connection_error()
+                {
+                    on_close(*code);
+                }
+                Err(error)
+            }
+        }
+    }
+
+    /// Inner-loop body of [`process_inbound_uni_with_close`][Self::process_inbound_uni_with_close].
+    /// Borrows `stream` so the outer function can keep ownership of it across the await,
+    /// which lets the caller's close callback fire before the recv stream drops.
+    async fn process_inbound_uni_inner<T>(&self, stream: &mut T) -> Result<UniInnerResult, H3Error>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        let mut buf = vec![0; 128];
+        let mut filled = 0;
+
+        // Read stream type varint (decode as raw u64 to handle unknown types)
+        let stream_type = read(&mut buf, &mut filled, stream, |data| {
+            match quic_varint::decode(data) {
+                Ok(ok) => Ok(Some(ok)),
+                Err(QuicVarIntError::UnexpectedEnd) => Ok(None),
+                // this branch is unreachable because u64 is always From<u64>
+                Err(QuicVarIntError::UnknownValue { bytes, value }) => Ok(Some((value, bytes))),
+            }
+        })
+        .await?;
+
+        match UniStreamType::try_from(stream_type) {
+            Ok(UniStreamType::Control) => {
+                log::trace!("H3 inbound uni: control stream");
+                self.run_inbound_control(&mut buf, &mut filled, stream)
+                    .await?;
+                Ok(UniInnerResult::Handled)
+            }
+
+            Ok(UniStreamType::QpackEncoder) => {
+                log::trace!("H3 inbound uni: QPACK encoder stream ({filled} bytes pre-read)");
+                let mut reader = Prepended {
+                    head: &buf[..filled],
+                    tail: stream,
+                };
+
+                log::trace!("QPACK encoder stream: started");
+                self.decoder_dynamic_table.run_reader(&mut reader).await?;
+
+                Ok(UniInnerResult::Handled)
+            }
+
+            Ok(UniStreamType::QpackDecoder) => {
+                log::trace!("H3 inbound uni: QPACK decoder stream ({filled} bytes pre-read)");
+                let mut reader = Prepended {
+                    head: &buf[..filled],
+                    tail: stream,
+                };
+                self.encoder_dynamic_table.run_reader(&mut reader).await?;
+                Ok(UniInnerResult::Handled)
+            }
+
+            Ok(UniStreamType::WebTransport) => {
+                log::trace!("H3 inbound uni: WebTransport stream");
+                let session_id =
                     read(
                         &mut buf,
                         &mut filled,
-                        &mut stream,
+                        stream,
                         |data| match quic_varint::decode(data) {
                             Ok(ok) => Ok(Some(ok)),
                             Err(QuicVarIntError::UnexpectedEnd) => Ok(None),
-                            // this branch is unreachable because u64 is always From<u64>
                             Err(QuicVarIntError::UnknownValue { bytes, value }) => {
                                 Ok(Some((value, bytes)))
                             }
@@ -413,87 +622,29 @@ impl H3Connection {
                     )
                     .await?;
 
-                match UniStreamType::try_from(stream_type) {
-                    Ok(UniStreamType::Control) => {
-                        log::trace!("H3 inbound uni: control stream");
-                        self.run_inbound_control(&mut buf, &mut filled, &mut stream)
-                            .await?;
-                        Ok(UniStreamResult::Handled)
-                    }
+                buf.truncate(filled);
 
-                    Ok(UniStreamType::QpackEncoder) => {
-                        log::trace!(
-                            "H3 inbound uni: QPACK encoder stream ({filled} bytes pre-read)"
-                        );
-                        let mut reader = Prepended {
-                            head: &buf[..filled],
-                            tail: stream,
-                        };
+                Ok(UniInnerResult::WebTransport {
+                    session_id,
+                    buffer: buf.into(),
+                })
+            }
 
-                        log::trace!("QPACK encoder stream: started");
-                        self.decoder_dynamic_table.run_reader(&mut reader).await?;
+            Ok(UniStreamType::Push) => {
+                // Push streams are server→client per RFC 9114 §4.6. Trillium does
+                // not support HTTP/3 push as initiator or recipient, so we hand
+                // these back as `Unknown` for the caller to dispose of identically
+                // to truly-unknown stream types — the explicit arm exists so trace
+                // output names "push stream" rather than a bare type id.
+                log::trace!("H3 inbound uni: push stream (push not supported)");
+                Ok(UniInnerResult::Unknown { stream_type })
+            }
 
-                        Ok(UniStreamResult::Handled)
-                    }
-
-                    Ok(UniStreamType::QpackDecoder) => {
-                        log::trace!(
-                            "H3 inbound uni: QPACK decoder stream ({filled} bytes pre-read)"
-                        );
-                        let mut reader = Prepended {
-                            head: &buf[..filled],
-                            tail: stream,
-                        };
-                        self.encoder_dynamic_table.run_reader(&mut reader).await?;
-                        Ok(UniStreamResult::Handled)
-                    }
-
-                    Ok(UniStreamType::WebTransport) => {
-                        log::trace!("H3 inbound uni: WebTransport stream");
-                        let session_id = read(&mut buf, &mut filled, &mut stream, |data| {
-                            match quic_varint::decode(data) {
-                                Ok(ok) => Ok(Some(ok)),
-                                Err(QuicVarIntError::UnexpectedEnd) => Ok(None),
-                                Err(QuicVarIntError::UnknownValue { bytes, value }) => {
-                                    Ok(Some((value, bytes)))
-                                }
-                            }
-                        })
-                        .await?;
-
-                        buf.truncate(filled);
-
-                        Ok(UniStreamResult::WebTransport {
-                            session_id,
-                            stream,
-                            buffer: buf.into(),
-                        })
-                    }
-
-                    Ok(UniStreamType::Push) => {
-                        // Push streams are server→client per RFC 9114 §4.6. Trillium does
-                        // not support HTTP/3 push as initiator or recipient, so we hand
-                        // these back as `Unknown` for the caller to dispose of identically
-                        // to truly-unknown stream types — the explicit arm exists so trace
-                        // output names "push stream" rather than a bare type id.
-                        log::trace!("H3 inbound uni: push stream (push not supported)");
-                        Ok(UniStreamResult::Unknown {
-                            stream_type,
-                            stream,
-                        })
-                    }
-
-                    Err(_) => {
-                        log::trace!("H3 inbound uni: unknown stream type {stream_type:#x}");
-                        Ok(UniStreamResult::Unknown {
-                            stream_type,
-                            stream,
-                        })
-                    }
-                }
-            })
-            .await
-            .unwrap_or(Ok(UniStreamResult::Handled)) // interrupted
+            Err(_) => {
+                log::trace!("H3 inbound uni: unknown stream type {stream_type:#x}");
+                Ok(UniInnerResult::Unknown { stream_type })
+            }
+        }
     }
 
     /// Handle the http/3 peer's inbound control stream.
@@ -512,14 +663,20 @@ impl H3Connection {
     where
         T: AsyncRead + Unpin + Send,
     {
-        // First frame must be SETTINGS (§6.2.1)
+        // First frame must be SETTINGS (§6.2.1). A non-SETTINGS first frame OR a malformed
+        // first frame whose payload doesn't decode are both H3_MISSING_SETTINGS. *But* if
+        // the first frame is a SETTINGS frame whose payload is itself invalid (e.g.
+        // forbidden HTTP/2 setting IDs per §7.2.4.1), that's H3_SETTINGS_ERROR — preserve.
         let settings = read(buf, filled, stream, |data| match Frame::decode(data) {
             Ok((Frame::Settings(s), consumed)) => Ok(Some((s, consumed))),
-            Ok(_) => Err(H3ErrorCode::FrameUnexpected),
             Err(FrameDecodeError::Incomplete) => Ok(None),
-            Err(FrameDecodeError::Error(code)) => Err(code),
+            Err(FrameDecodeError::Error(H3ErrorCode::SettingsError)) => {
+                Err(H3ErrorCode::SettingsError)
+            }
+            Ok(_) | Err(FrameDecodeError::Error(_)) => Err(H3ErrorCode::MissingSettings),
         })
-        .await?;
+        .await
+        .map_err(map_critical_stream_eof)?;
 
         log::trace!("H3 peer settings: {settings:?}");
 
@@ -543,7 +700,8 @@ impl H3Connection {
                     }
                 }))
                 .await
-                .transpose()?;
+                .transpose()
+                .map_err(map_critical_stream_eof)?;
 
             match frame {
                 None => {
@@ -555,10 +713,6 @@ impl H3Connection {
                     log::trace!("H3 control stream: peer sent GOAWAY(stream_id={id})");
                     self.swansong.shut_down();
                     return Ok(());
-                }
-
-                Some(Frame::Settings(_)) => {
-                    return Err(H3ErrorCode::FrameUnexpected.into());
                 }
 
                 Some(Frame::Unknown(n)) => {
@@ -583,11 +737,41 @@ impl H3Connection {
                         todo -= n;
                     }
                 }
-                other => {
-                    log::trace!("H3 control stream: ignoring {other:?}");
+
+                // RFC 9114 §7.2.4: a second SETTINGS frame is H3_FRAME_UNEXPECTED.
+                // RFC 9114 §7.2.1 / §7.2.2 / §7.2.5: DATA, HEADERS, and PUSH_PROMISE are
+                // not permitted on the control stream; same H3_FRAME_UNEXPECTED. The
+                // WebTransport bidi-signal (0x41) similarly has no business here.
+                Some(
+                    Frame::Settings(_)
+                    | Frame::Data(_)
+                    | Frame::Headers(_)
+                    | Frame::PushPromise { .. }
+                    | Frame::WebTransport(_),
+                ) => {
+                    return Err(H3ErrorCode::FrameUnexpected.into());
+                }
+
+                // CANCEL_PUSH and MAX_PUSH_ID are valid control-stream frames; we don't push,
+                // so we ignore them.
+                Some(Frame::CancelPush(_) | Frame::MaxPushId(_)) => {
+                    log::trace!("H3 control stream: ignoring {frame:?}");
                 }
             }
         }
+    }
+}
+
+/// Map an `UnexpectedEof` I/O error (the `read` helper's "stream FIN'd" signal) to
+/// `H3_CLOSED_CRITICAL_STREAM`. RFC 9114 §6.2.1 forbids closure of the control stream;
+/// closure of either QPACK side-channel is the same connection error per RFC 9204 §4.2.
+/// Other I/O errors and any protocol error are passed through unchanged.
+fn map_critical_stream_eof(error: H3Error) -> H3Error {
+    match error {
+        H3Error::Io(e) if e.kind() == ErrorKind::UnexpectedEof => {
+            H3ErrorCode::ClosedCriticalStream.into()
+        }
+        other => other,
     }
 }
 

--- a/http/src/h3/error.rs
+++ b/http/src/h3/error.rs
@@ -135,6 +135,9 @@ impl H3ErrorCode {
                 | Self::IdError
                 | Self::SettingsError
                 | Self::MissingSettings
+                | Self::QpackDecompressionFailed
+                | Self::QpackEncoderStreamError
+                | Self::QpackDecoderStreamError
         )
     }
 }

--- a/http/src/h3/settings.rs
+++ b/http/src/h3/settings.rs
@@ -89,7 +89,7 @@ impl std::fmt::Debug for H3Settings {
 impl From<&HttpConfig> for H3Settings {
     fn from(value: &HttpConfig) -> Self {
         Self {
-            max_field_section_size: Some(u64::from(value.max_header_list_size)),
+            max_field_section_size: Some(value.max_header_list_size),
             qpack_max_table_capacity: (value.dynamic_table_capacity > 0)
                 .then_some(value.dynamic_table_capacity as u64),
             qpack_blocked_streams: (value.h3_blocked_streams > 0)

--- a/http/src/headers/compression_error.rs
+++ b/http/src/headers/compression_error.rs
@@ -28,7 +28,18 @@ pub(crate) enum CompressionError {
 }
 
 impl From<CompressionError> for H3Error {
-    fn from(_: CompressionError) -> Self {
-        H3ErrorCode::QpackDecompressionFailed.into()
+    /// Most `CompressionError` variants are codec failures the QPACK layer must report as
+    /// `QPACK_DECOMPRESSION_FAILED` (RFC 9204 §6). `InvalidHeaderName` is the exception:
+    /// per RFC 9114 §4.2 / §4.3.1 a header name with uppercase chars or an unrecognized
+    /// pseudo-name is a *malformed-message* problem (the codec succeeded; the resulting
+    /// message is invalid), which is a stream-level `H3_MESSAGE_ERROR`.
+    fn from(error: CompressionError) -> Self {
+        match error {
+            CompressionError::InvalidHeaderName => H3ErrorCode::MessageError.into(),
+            CompressionError::Huffman(_)
+            | CompressionError::IntegerPrefix(_)
+            | CompressionError::InvalidStaticIndex(_)
+            | CompressionError::UnexpectedEnd => H3ErrorCode::QpackDecompressionFailed.into(),
+        }
     }
 }

--- a/http/src/headers/qpack/decoder_corpus_tests.rs
+++ b/http/src/headers/qpack/decoder_corpus_tests.rs
@@ -133,9 +133,15 @@ fn run_interop_file(out_path: &Path, qif_path: &Path, capacity: usize) {
         for record in &records {
             if record.stream_id == 0 {
                 let mut cursor = Cursor::new(&record.data[..]);
-                table.run_reader(&mut cursor).await.unwrap_or_else(|e| {
-                    panic!("encoder stream error in {}: {e}", out_path.display())
-                });
+                // Use process_instructions, not run_reader: bounded-slice EOF in tests is
+                // not a peer-FIN protocol violation, so we don't want the run_reader EOF→
+                // H3_CLOSED_CRITICAL_STREAM promotion (which also marks the table failed).
+                table
+                    .process_instructions(&mut cursor)
+                    .await
+                    .unwrap_or_else(|e| {
+                        panic!("encoder stream error in {}: {e}", out_path.display())
+                    });
             } else {
                 let table = Arc::clone(&table);
                 let stream_id = record.stream_id;

--- a/http/src/headers/qpack/decoder_dynamic_table/decode.rs
+++ b/http/src/headers/qpack/decoder_dynamic_table/decode.rs
@@ -39,9 +39,12 @@ impl DecoderDynamicTable {
         encoded: &[u8],
         stream_id: u64,
     ) -> Result<FieldSection<'static>, H3Error> {
-        let err = || H3ErrorCode::QpackDecompressionFailed;
+        let codec_err = || H3ErrorCode::QpackDecompressionFailed;
 
-        let (prefix, mut rest) = FieldSectionPrefix::parse(encoded).map_err(|_| err())?;
+        // FieldSectionPrefix parsing only fails on integer-prefix codec errors, never on
+        // the InvalidHeaderName branch — collapsing CompressionError variants to
+        // QpackDecompressionFailed is correct here.
+        let (prefix, mut rest) = FieldSectionPrefix::parse(encoded).map_err(|_| codec_err())?;
         let required_insert_count =
             self.decode_required_insert_count(prefix.encoded_required_insert_count)?;
         log::trace!(
@@ -56,11 +59,11 @@ impl DecoderDynamicTable {
             required_insert_count
                 .checked_sub(delta_base)
                 .and_then(|v| v.checked_sub(1))
-                .ok_or_else(err)?
+                .ok_or_else(codec_err)?
         } else {
             required_insert_count
                 .checked_add(delta_base)
-                .ok_or_else(err)?
+                .ok_or_else(codec_err)?
         };
 
         let mut pseudo_headers = PseudoHeaders::default();
@@ -74,7 +77,13 @@ impl DecoderDynamicTable {
         let mut malformed = false;
 
         while !rest.is_empty() {
-            let (instruction, rest_) = FieldLineInstruction::parse(rest).map_err(|_| err())?;
+            // Use `?` so `CompressionError::InvalidHeaderName` (e.g. unknown pseudo, uppercase
+            // chars) routes through `From<CompressionError> for H3Error` to MessageError per
+            // RFC 9114 §4.2 / §4.3.1; codec failures still surface as QpackDecompressionFailed.
+            // Aborting mid-section here is safe: HEADERS instructions only *read* from the
+            // dynamic table — they don't mutate it — so table state stays consistent with
+            // the encoder regardless of how many later instructions we skip.
+            let (instruction, rest_) = FieldLineInstruction::parse(rest)?;
             rest = rest_;
 
             let field_line =
@@ -222,7 +231,7 @@ fn entry_field_line(
     never_indexed: bool,
 ) -> Result<FieldLine, H3ErrorCode> {
     let err = || H3ErrorCode::QpackDecompressionFailed;
-    validate_value(&value).map_err(|()| err())?;
+    validate_value(&value).map_err(|_| err())?;
     let header_name = match name {
         EntryName::Known(k) => HeaderName::from(k),
         EntryName::UnknownStatic(s) => HeaderName::from(s),

--- a/http/src/headers/qpack/decoder_dynamic_table/reader.rs
+++ b/http/src/headers/qpack/decoder_dynamic_table/reader.rs
@@ -33,7 +33,19 @@ impl DecoderDynamicTable {
         &self,
         stream: &mut T,
     ) -> Result<(), H3Error> {
-        let result = self.run_reader_inner(stream).await;
+        // RFC 9204 §4.2: closure of the encoder stream is a connection error of type
+        // H3_CLOSED_CRITICAL_STREAM. process_instructions returns Ok on clean EOF; here we
+        // promote that to an error and fail the table. (Graceful server-side shutdown drops
+        // this future via swansong before reaching that arm; reaching it means the peer
+        // FIN'd their encoder stream while our connection was still alive.)
+        let result = match self.process_instructions(stream).await {
+            Ok(()) => {
+                log::debug!("QPACK encoder stream: peer closed (FIN) — H3_CLOSED_CRITICAL_STREAM");
+                Err(H3ErrorCode::ClosedCriticalStream.into())
+            }
+            Err(e) => Err(e),
+        };
+
         match &result {
             Err(H3Error::Protocol(code)) => {
                 log::debug!("QPACK encoder stream: protocol error: {code}");
@@ -45,15 +57,18 @@ impl DecoderDynamicTable {
                 self.fail(H3ErrorCode::QpackEncoderStreamError);
             }
 
-            Ok(()) => {
-                log::trace!("QPACK encoder stream: closed cleanly");
-            }
+            // unreachable given the EOF promotion above; defensively a no-op.
+            Ok(()) => {}
         }
 
         result
     }
 
-    async fn run_reader_inner<T>(&self, stream: &mut T) -> Result<(), H3Error>
+    /// Loop-body of [`run_reader`] separated for tests and corpus replay: parse and apply
+    /// peer instructions until clean EOF or error, but **do not** convert EOF into
+    /// `H3_CLOSED_CRITICAL_STREAM` and **do not** mark the table failed. Production wiring
+    /// goes through [`run_reader`], which does both per RFC 9204 §4.2.
+    pub(crate) async fn process_instructions<T>(&self, stream: &mut T) -> Result<(), H3Error>
     where
         T: AsyncRead + Unpin + Send,
     {
@@ -61,7 +76,6 @@ impl DecoderDynamicTable {
         while let Some(instruction) = parse(max_entry_size, stream).await? {
             self.apply(instruction)?;
         }
-        log::trace!("QPACK encoder stream: EOF");
         Ok(())
     }
 

--- a/http/src/headers/qpack/encoder_corpus_tests.rs
+++ b/http/src/headers/qpack/encoder_corpus_tests.rs
@@ -250,7 +250,10 @@ fn run_qif_at_config(
         classify_encoder_stream(&initial_ops, &mut wire);
         if !initial_ops.is_empty() {
             let mut cursor = Cursor::new(&initial_ops[..]);
-            future::block_on(decoder.run_reader(&mut cursor)).unwrap_or_else(|e| {
+            // Tests use process_instructions, not run_reader, to skip the
+            // EOF→H3_CLOSED_CRITICAL_STREAM promotion (run_reader's production semantics
+            // for an unexpected peer FIN).
+            future::block_on(decoder.process_instructions(&mut cursor)).unwrap_or_else(|e| {
                 panic!(
                     "{}: decoder rejected initial SetDynamicTableCapacity: {e}",
                     qif_path.display()
@@ -303,9 +306,9 @@ fn run_qif_at_config(
             }
             if !enc_ops.is_empty() {
                 let mut cursor = Cursor::new(&enc_ops[..]);
-                future::block_on(decoder.run_reader(&mut cursor)).unwrap_or_else(|e| {
+                future::block_on(decoder.process_instructions(&mut cursor)).unwrap_or_else(|e| {
                     panic!(
-                        "{}: group {global_index}: decoder run_reader failed: {e}",
+                        "{}: group {global_index}: decoder process_instructions failed: {e}",
                         qif_path.display()
                     )
                 });

--- a/http/src/headers/qpack/encoder_dynamic_table/reader.rs
+++ b/http/src/headers/qpack/encoder_dynamic_table/reader.rs
@@ -29,9 +29,20 @@ impl EncoderDynamicTable {
         T: AsyncRead + Unpin + Send,
     {
         log::trace!("QPACK decoder stream reader: started");
-        let result = process(stream, self).await;
+        // RFC 9204 §4.2: closure of the decoder stream is a connection error of type
+        // H3_CLOSED_CRITICAL_STREAM. process_instructions returns Ok on clean EOF; here we
+        // promote that to an error and mark the table failed. Graceful server-side
+        // shutdown drops this future via swansong before reaching that arm.
+        let result = match self.process_instructions(stream).await {
+            Ok(()) => {
+                log::debug!(
+                    "QPACK decoder stream reader: peer closed (FIN) — H3_CLOSED_CRITICAL_STREAM"
+                );
+                Err(H3ErrorCode::ClosedCriticalStream.into())
+            }
+            Err(e) => Err(e),
+        };
         match &result {
-            Ok(()) => log::trace!("QPACK decoder stream reader: clean EOF"),
             Err(H3Error::Protocol(code)) => {
                 log::debug!("QPACK decoder stream reader: protocol error: {code}");
                 self.fail(*code);
@@ -40,19 +51,25 @@ impl EncoderDynamicTable {
                 log::debug!("QPACK decoder stream reader: I/O error: {e}");
                 self.fail(H3ErrorCode::QpackDecoderStreamError);
             }
+            // unreachable given the EOF promotion above; defensively a no-op.
+            Ok(()) => {}
         }
         result
     }
-}
 
-async fn process<T>(stream: &mut T, table: &EncoderDynamicTable) -> Result<(), H3Error>
-where
-    T: AsyncRead + Unpin + Send,
-{
-    while let Some(instruction) = parse(stream).await? {
-        apply(table, instruction)?;
+    /// Loop-body of [`run_reader`] separated for tests and corpus replay: parse and apply
+    /// peer instructions until clean EOF or error, but **do not** convert EOF into
+    /// `H3_CLOSED_CRITICAL_STREAM` and **do not** mark the table failed. Production wiring
+    /// goes through [`run_reader`], which does both per RFC 9204 §4.2.
+    pub(crate) async fn process_instructions<T>(&self, stream: &mut T) -> Result<(), H3Error>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        while let Some(instruction) = parse(stream).await? {
+            apply(self, instruction)?;
+        }
+        Ok(())
     }
-    Ok(())
 }
 
 fn apply(table: &EncoderDynamicTable, instruction: DecoderInstruction) -> Result<(), H3Error> {
@@ -123,7 +140,7 @@ mod tests {
         push_section(&table, 4, 2, Some(0));
         // Section Ack for stream ID 4: 0x80 | 4 = 0x84
         let mut wire: &[u8] = &[0x84];
-        block_on(table.run_reader(&mut wire)).unwrap();
+        block_on(table.process_instructions(&mut wire)).unwrap();
         assert_eq!(table.known_received_count(), 2);
     }
 
@@ -132,7 +149,7 @@ mod tests {
         let table = make_table_with_two_entries();
         // ICI increment=1: 0x00 | 1 = 0x01
         let mut wire: &[u8] = &[0x01];
-        block_on(table.run_reader(&mut wire)).unwrap();
+        block_on(table.process_instructions(&mut wire)).unwrap();
         assert_eq!(table.known_received_count(), 1);
     }
 
@@ -142,7 +159,7 @@ mod tests {
         push_section(&table, 4, 2, Some(0));
         // Stream Cancel stream_id=4: 0x40 | 4 = 0x44
         let mut wire: &[u8] = &[0x44];
-        block_on(table.run_reader(&mut wire)).unwrap();
+        block_on(table.process_instructions(&mut wire)).unwrap();
         assert_eq!(table.known_received_count(), 0);
     }
 
@@ -152,7 +169,7 @@ mod tests {
         push_section(&table, 4, 1, Some(0));
         // Section Ack stream 4, then ICI +1: expects total known_received = 2.
         let mut wire: &[u8] = &[0x84, 0x01];
-        block_on(table.run_reader(&mut wire)).unwrap();
+        block_on(table.process_instructions(&mut wire)).unwrap();
         assert_eq!(table.known_received_count(), 2);
     }
 
@@ -164,7 +181,7 @@ mod tests {
         // Section Ack for stream 200 needs a multi-byte varint.
         // 7-bit prefix: first byte = 0x80 | 0x7F = 0xFF, then 200 - 127 = 73 = 0x49.
         let mut wire: &[u8] = &[0xFF, 0x49];
-        block_on(table.run_reader(&mut wire)).unwrap();
+        block_on(table.process_instructions(&mut wire)).unwrap();
         assert_eq!(table.known_received_count(), 2);
     }
 
@@ -179,10 +196,15 @@ mod tests {
     }
 
     #[test]
-    fn clean_eof_returns_ok() {
+    fn peer_eof_is_closed_critical_stream() {
+        // RFC 9204 §4.2: peer FIN on the decoder stream is H3_CLOSED_CRITICAL_STREAM.
         let table = EncoderDynamicTable::default();
         let mut wire: &[u8] = &[];
-        block_on(table.run_reader(&mut wire)).unwrap();
-        assert!(table.failed().is_none());
+        let err = block_on(table.run_reader(&mut wire)).unwrap_err();
+        assert!(matches!(
+            err,
+            H3Error::Protocol(H3ErrorCode::ClosedCriticalStream)
+        ));
+        assert_eq!(table.failed(), Some(H3ErrorCode::ClosedCriticalStream));
     }
 }

--- a/http/src/headers/qpack/encoder_dynamic_table/tests.rs
+++ b/http/src/headers/qpack/encoder_dynamic_table/tests.rs
@@ -198,11 +198,16 @@ fn parse_all(bytes: &[u8]) -> Vec<EncoderInstruction> {
 /// reconstruct the same entries on the peer side regardless of which §3.2 wire format was
 /// picked. The encoder's leading `SetDynamicTableCapacity` op primes the decoder — no
 /// side-channel capacity call is needed, matching how this flows on the wire in production.
+///
+/// We use `process_instructions` rather than `run_reader` so a bounded `&[u8]` doesn't
+/// trip the production-only "EOF = H3_CLOSED_CRITICAL_STREAM" promotion that `run_reader`
+/// applies (RFC 9204 §4.2 / §4.5). The instructions themselves are what these tests want
+/// to exercise.
 fn apply_ops_to_decoder(table: &EncoderDynamicTable, max_capacity: u64) -> DecoderDynamicTable {
     let bytes: Vec<u8> = table.drain_pending_ops().into_iter().flatten().collect();
     let decoder = DecoderDynamicTable::new(max_capacity as usize, 0);
     let mut stream = &bytes[..];
-    block_on(decoder.run_reader(&mut stream)).unwrap();
+    block_on(decoder.process_instructions(&mut stream)).unwrap();
     decoder
 }
 

--- a/http/src/headers/qpack/encoder_dynamic_table/tests/encode_refs.rs
+++ b/http/src/headers/qpack/encoder_dynamic_table/tests/encode_refs.rs
@@ -42,7 +42,9 @@ fn roundtrip(
     let bytes = encode(encoder, pseudo, headers, stream_id);
     let enc_ops: Vec<u8> = encoder.drain_pending_ops().into_iter().flatten().collect();
     let mut enc_stream = &enc_ops[..];
-    block_on(decoder.run_reader(&mut enc_stream)).unwrap();
+    // process_instructions, not run_reader: bounded-slice EOF in tests is not the
+    // peer-FIN protocol violation that run_reader promotes to H3_CLOSED_CRITICAL_STREAM.
+    block_on(decoder.process_instructions(&mut enc_stream)).unwrap();
     block_on(decoder.decode(&bytes, stream_id)).unwrap()
 }
 

--- a/http/src/headers/qpack/encoder_dynamic_table/writer.rs
+++ b/http/src/headers/qpack/encoder_dynamic_table/writer.rs
@@ -210,12 +210,17 @@ mod tests {
             stream.read_exact(&mut stream_type_byte).await.unwrap();
             assert_eq!(stream_type_byte[0], UniStreamType::QpackEncoder as u8);
 
-            // Feed the rest into process_encoder_stream against a decoder table.
+            // Feed the rest into process_instructions against a decoder table.
             let decoder_table = DecoderDynamicTable::new(4096, 0);
             // We have exactly two instructions queued; once they're consumed, closing the
-            // duplex lets process_encoder_stream see EOF and return Ok.
+            // duplex lets process_instructions see EOF and return Ok. (Use
+            // process_instructions, not run_reader: a peer-FIN-as-protocol-violation
+            // doesn't apply to this synthetic test wiring.)
             let processed = async {
-                decoder_table.run_reader(&mut stream).await.unwrap();
+                decoder_table
+                    .process_instructions(&mut stream)
+                    .await
+                    .unwrap();
             };
 
             // Wait long enough for the writer to emit both ops, then close so the reader exits.

--- a/http/src/headers/qpack/instruction.rs
+++ b/http/src/headers/qpack/instruction.rs
@@ -10,8 +10,10 @@
 //! Shared between submodules: the low-level wire-read helpers ([`read_first_byte`],
 //! [`read_varint`], [`read_exact`], [`read_string_with_huffman`], [`validate_value`]) and the
 //! §4.1.2 string encoder ([`encode_string`], also used by the §4.5 field-section emitter).
-//! Read helpers return `Result<_, ()>` — the per-direction `parse` function maps failure to
-//! the appropriate stream error code. Helpers log the original error before discarding it.
+//! Read helpers return `Result<_, ReadError>` — the per-direction `parse` function maps
+//! [`ReadError::Io`] to `H3Error::Io` and [`ReadError::Violation`] to the appropriate stream
+//! error code. Distinguishing the two matters because a connection-lost I/O error during a
+//! teardown read should not masquerade as a peer-side QPACK protocol violation.
 
 pub(in crate::headers) mod decoder;
 pub(in crate::headers) mod encoder;
@@ -19,32 +21,55 @@ pub(in crate::headers) mod field_section;
 
 use crate::headers::{huffman, integer_prefix};
 use futures_lite::io::{AsyncRead, AsyncReadExt};
+use std::io;
 
 // §4.1.2: H flag in a string literal with a 7-bit length prefix.
 const STRING_HUFFMAN_FLAG: u8 = 0x80;
 
+/// Failure mode of an instruction-stream read helper.
+///
+/// `Io` is reserved for connection-teardown I/O errors observed *between* instructions —
+/// see [`read_first_byte`]. Any other failure (mid-instruction read, length cap exceeded,
+/// huffman decode error, etc.) is a [`ReadError::Violation`] — caller maps it to the
+/// stream-specific protocol error code.
+#[derive(Debug)]
+pub(super) enum ReadError {
+    Io(io::Error),
+    Violation,
+}
+
+impl From<io::Error> for ReadError {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
 /// Read the first byte of an instruction, returning `None` on clean EOF.
 ///
 /// Clean EOF is not an error — the peer closed the stream (e.g. during connection teardown).
-/// Mid-instruction EOF (encountered by any other read helper) is an error.
+/// Surfacing other I/O errors here as [`ReadError::Io`] (rather than `Violation`) lets the
+/// caller distinguish "we lost the underlying connection" from "peer sent malformed
+/// QPACK"; otherwise every connection-tear-down read would log a bogus protocol violation.
+/// Mid-instruction EOF (encountered by any other read helper) is a `Violation`.
 pub(super) async fn read_first_byte(
     stream: &mut (impl AsyncRead + Unpin),
-) -> Result<Option<u8>, ()> {
+) -> Result<Option<u8>, ReadError> {
     let mut b = [0u8; 1];
     match stream.read(&mut b).await {
         Ok(0) => Ok(None),
         Ok(_) => Ok(Some(b[0])),
         Err(e) => {
             log::debug!("QPACK: read_first_byte io error: {e}");
-            Err(())
+            Err(ReadError::Io(e))
         }
     }
 }
 
-async fn read_byte(stream: &mut (impl AsyncRead + Unpin)) -> Result<u8, ()> {
+async fn read_byte(stream: &mut (impl AsyncRead + Unpin)) -> Result<u8, ReadError> {
     let mut b = [0u8; 1];
     stream.read_exact(&mut b).await.map_err(|e| {
         log::error!("QPACK: read_byte io error: {e:?}");
+        ReadError::Violation
     })?;
     Ok(b[0])
 }
@@ -56,7 +81,7 @@ pub(super) async fn read_varint(
     first: u8,
     prefix_size: u8,
     stream: &mut (impl AsyncRead + Unpin),
-) -> Result<usize, ()> {
+) -> Result<usize, ReadError> {
     let prefix_mask = u8::MAX >> (8 - prefix_size);
     let mut value = usize::from(first & prefix_mask);
     let mut shift = 0u32;
@@ -70,12 +95,14 @@ pub(super) async fn read_varint(
         let payload = usize::from(byte & 0x7F);
         let increment = payload.checked_shl(shift).ok_or_else(|| {
             log::error!("QPACK: varint checked_shl overflow (payload={payload}, shift={shift})");
+            ReadError::Violation
         })?;
 
         value = value.checked_add(increment).ok_or_else(|| {
             log::error!(
                 "QPACK: varint checked_add overflow (value={value}, increment={increment})"
             );
+            ReadError::Violation
         })?;
 
         shift += 7;
@@ -98,14 +125,15 @@ pub(super) async fn read_exact(
     len: usize,
     max: usize,
     stream: &mut (impl AsyncRead + Unpin),
-) -> Result<Vec<u8>, ()> {
+) -> Result<Vec<u8>, ReadError> {
     if len > max {
         log::error!("QPACK: read_exact len {len} exceeds max {max}");
-        return Err(());
+        return Err(ReadError::Violation);
     }
     let mut buf = vec![0u8; len];
     stream.read_exact(&mut buf).await.map_err(|e| {
         log::error!("QPACK: read_exact({len}) io error: {e:?}");
+        ReadError::Violation
     })?;
     Ok(buf)
 }
@@ -117,7 +145,7 @@ pub(super) async fn read_exact(
 pub(super) async fn read_string_with_huffman(
     max: usize,
     stream: &mut (impl AsyncRead + Unpin),
-) -> Result<Vec<u8>, ()> {
+) -> Result<Vec<u8>, ReadError> {
     let first = read_byte(stream).await?;
     let is_huffman = first & STRING_HUFFMAN_FLAG != 0;
     let len = read_varint(first, 7, stream).await?;
@@ -125,6 +153,7 @@ pub(super) async fn read_string_with_huffman(
     if is_huffman {
         huffman::decode(&raw).map_err(|e| {
             log::error!("QPACK: huffman string decode failed ({len} bytes): {e:?}");
+            ReadError::Violation
         })
     } else {
         Ok(raw)
@@ -132,9 +161,9 @@ pub(super) async fn read_string_with_huffman(
 }
 
 /// Reject values containing CR, LF, or NUL bytes — RFC 9114 §4.2 field-value sanitation.
-pub(super) fn validate_value(value: &[u8]) -> Result<(), ()> {
+pub(super) fn validate_value(value: &[u8]) -> Result<(), ReadError> {
     if memchr::memchr3(b'\r', b'\n', 0, value).is_some() {
-        Err(())
+        Err(ReadError::Violation)
     } else {
         Ok(())
     }

--- a/http/src/headers/qpack/instruction/decoder.rs
+++ b/http/src/headers/qpack/instruction/decoder.rs
@@ -12,7 +12,7 @@
 //! [`encoder_dynamic_table::EncoderDynamicTable`]: crate::headers::qpack::encoder_dynamic_table::EncoderDynamicTable
 //! [`decoder_dynamic_table::DecoderDynamicTable`]: crate::headers::qpack::decoder_dynamic_table::DecoderDynamicTable
 
-use super::{read_first_byte, read_varint};
+use super::{ReadError, read_first_byte, read_varint};
 use crate::{
     h3::{H3Error, H3ErrorCode},
     headers::integer_prefix,
@@ -42,18 +42,22 @@ pub(in crate::headers) enum DecoderInstruction {
 /// Parse the next decoder-stream instruction from `stream`.
 ///
 /// Returns `Ok(None)` on clean EOF between instructions. `Ok(Some(_))` is a parsed
-/// instruction; `Err` is an I/O or wire-format error mapped to `QpackDecoderStreamError`.
+/// instruction; `Err(H3Error::Io)` propagates an underlying transport I/O error
+/// (e.g. connection lost while we were polling for the next instruction);
+/// `Err(H3Error::Protocol(QpackDecoderStreamError))` is a wire-format violation by
+/// the peer.
 pub(in crate::headers) async fn parse(
     stream: &mut (impl AsyncRead + Unpin),
 ) -> Result<Option<DecoderInstruction>, H3Error> {
-    parse_inner(stream)
-        .await
-        .map_err(|()| H3ErrorCode::QpackDecoderStreamError.into())
+    parse_inner(stream).await.map_err(|e| match e {
+        ReadError::Io(io) => H3Error::Io(io),
+        ReadError::Violation => H3ErrorCode::QpackDecoderStreamError.into(),
+    })
 }
 
 async fn parse_inner(
     stream: &mut (impl AsyncRead + Unpin),
-) -> Result<Option<DecoderInstruction>, ()> {
+) -> Result<Option<DecoderInstruction>, ReadError> {
     let Some(first) = read_first_byte(stream).await? else {
         return Ok(None);
     };

--- a/http/src/headers/qpack/instruction/encoder.rs
+++ b/http/src/headers/qpack/instruction/encoder.rs
@@ -17,7 +17,7 @@
 //! [`encoder_dynamic_table::EncoderDynamicTable`]: crate::headers::qpack::encoder_dynamic_table::EncoderDynamicTable
 
 use super::{
-    encode_string, read_exact, read_first_byte, read_string_with_huffman, read_varint,
+    ReadError, encode_string, read_exact, read_first_byte, read_string_with_huffman, read_varint,
     validate_value,
 };
 use crate::{
@@ -81,20 +81,25 @@ pub(in crate::headers) enum EncoderInstruction {
 /// a peer from forcing a huge allocation via a single length prefix.
 ///
 /// Returns `Ok(None)` on clean EOF between instructions. `Ok(Some(_))` is a parsed
-/// instruction; `Err` is an I/O or wire-format error mapped to `QpackEncoderStreamError`.
+/// instruction; `Err(H3Error::Io)` propagates an underlying transport I/O error
+/// (e.g. connection lost while polling for the next instruction); `Err(Protocol(
+/// QpackEncoderStreamError))` is a wire-format violation by the peer.
 pub(in crate::headers) async fn parse(
     max_entry_size: usize,
     stream: &mut (impl AsyncRead + Unpin),
 ) -> Result<Option<EncoderInstruction>, H3Error> {
     parse_inner(max_entry_size, stream)
         .await
-        .map_err(|()| H3ErrorCode::QpackEncoderStreamError.into())
+        .map_err(|e| match e {
+            ReadError::Io(io) => H3Error::Io(io),
+            ReadError::Violation => H3ErrorCode::QpackEncoderStreamError.into(),
+        })
 }
 
 async fn parse_inner(
     max_entry_size: usize,
     stream: &mut (impl AsyncRead + Unpin),
-) -> Result<Option<EncoderInstruction>, ()> {
+) -> Result<Option<EncoderInstruction>, ReadError> {
     let Some(first) = read_first_byte(stream).await? else {
         return Ok(None);
     };
@@ -124,12 +129,14 @@ async fn parse_inner(
         let name_bytes = if is_huffman {
             huffman::decode(&name_bytes).map_err(|e| {
                 log::error!("QPACK encoder: huffman name decode failed: {e:?}");
+                ReadError::Violation
             })?
         } else {
             name_bytes
         };
         let name = EntryName::try_from(name_bytes).map_err(|()| {
             log::error!("QPACK encoder: invalid literal name");
+            ReadError::Violation
         })?;
         let value = read_string_with_huffman(max_entry_size, stream).await?;
         validate_value(&value)?;

--- a/http/src/received_body/h3_data.rs
+++ b/http/src/received_body/h3_data.rs
@@ -75,7 +75,7 @@ where
             self.buffer.ignore_front(consumed);
 
             if frame_type == H3BodyFrameType::Trailers
-                && remaining_in_frame > u64::from(self.max_header_list_size)
+                && remaining_in_frame > self.max_header_list_size
             {
                 return Ready(Err(io::Error::other(H3ErrorCode::MessageError)));
             }
@@ -108,7 +108,7 @@ where
                     buf: &mut buf[..leftover],
                     content_length: self.content_length,
                     max_len: self.max_len,
-                    max_trailer_size: u64::from(self.max_header_list_size),
+                    max_trailer_size: self.max_header_list_size,
                     connection: self.protocol_session.as_h3_borrowed(),
                     trailers_future: &mut self.h3_trailer_future,
                 }
@@ -138,7 +138,7 @@ where
                     buf: &mut buf[..bytes],
                     content_length: self.content_length,
                     max_len: self.max_len,
-                    max_trailer_size: u64::from(self.max_header_list_size),
+                    max_trailer_size: self.max_header_list_size,
                     connection: self.protocol_session.as_h3_borrowed(),
                     trailers_future: &mut self.h3_trailer_future,
                 }

--- a/server-common/src/h3.rs
+++ b/server-common/src/h3.rs
@@ -146,7 +146,15 @@ fn handle_bidi_stream<QC: QuicConnectionTrait>(
 
         let result = h3
             .clone()
-            .process_inbound_bidi(transport, handler_fn, stream_id)
+            .process_inbound_bidi_with_reset(transport, handler_fn, stream_id, |t, code| {
+                // RFC 9114 §4.1.2: stream-level protocol errors (notably H3_MESSAGE_ERROR)
+                // MUST RST the stream. We stop the recv side and reset the send side with
+                // the same code so the peer sees the error on whichever direction it's
+                // listening on.
+                let raw = u64::from(code);
+                t.stop(raw);
+                t.reset(raw);
+            })
             .await;
 
         match result {
@@ -207,7 +215,24 @@ fn spawn_inbound_uni_streams<QC: QuicConnectionTrait>(
                 (connection.clone(), h3.clone(), wt_dispatcher.clone());
 
             runtime.spawn(async move {
-                let result = h3.process_inbound_uni(recv).await;
+                // RFC 9114 §8.1 / RFC 9204 §6 connection-level errors must close the
+                // QUIC connection while the recv stream is still alive — otherwise
+                // quinn's RecvStream::drop sends STOP_SENDING, and the peer's malformed
+                // RESET_STREAM response can race ahead and override our app error code
+                // with FINAL_SIZE_ERROR on the wire. The closure fires inside
+                // process_inbound_uni_with_close before stream drops, so the close sets
+                // quinn's conn.error first and the drop becomes a no-op.
+                let close_connection = {
+                    let connection = connection.clone();
+                    let h3 = h3.clone();
+                    move |code: H3ErrorCode| {
+                        connection.close(code.into(), code.reason().as_bytes());
+                        h3.shut_down();
+                    }
+                };
+                let result = h3
+                    .process_inbound_uni_with_close(recv, close_connection)
+                    .await;
 
                 match result {
                     Ok(UniStreamResult::Handled) => {}
@@ -232,6 +257,9 @@ fn spawn_inbound_uni_streams<QC: QuicConnectionTrait>(
                     }
 
                     Err(error) => {
+                        // Connection-level protocol errors already fired the close
+                        // callback above; this call is a no-op for the close path
+                        // (idempotent) and still useful for logging plus I/O errors.
                         handle_h3_error(error, &connection, &h3);
                     }
                 }


### PR DESCRIPTION
### Fixed

[h3spec](https://github.com/kazu-yamamoto/h3spec) identified the following minor violations in trillium's h3 implementation, primarily focused on error handling. All of these are fixed in 1.1.1:

- RFC 9114 §4.1.2 — stream-level errors (notably `H3_MESSAGE_ERROR`) MUST RST the bidi stream.
- RFC 9114 §4.1.1 / §4.2 / §4.3.1 — malformed messages (duplicated pseudos, unknown pseudos, uppercase header bytes) are `H3_MESSAGE_ERROR`.
- RFC 9114 §4.3.1 — schemes with mandatory authority component (http/https) require `:authority` or `Host` on non-`CONNECT` requests.
- RFC 9114 §6.2.1 — first frame on the peer's control stream must be `SETTINGS`. Non-`SETTINGS` first frame OR a malformed first frame → `H3_MISSING_SETTINGS`.
- RFC 9114 §6.2.1 + RFC 9204 §4.2 — closure of control or QPACK streams is `H3_CLOSED_CRITICAL_STREAM`.
- RFC 9114 §7.2.1 / §7.2.2 / §7.2.4 / §7.2.5 — control stream must reject `DATA`, `HEADERS`, `PUSH_PROMISE`, second `SETTINGS`, and the WebTransport `0x41` signal as `H3_FRAME_UNEXPECTED`.
- RFC 9114 §4.1 — first-frame decode failure on a request bidi stream is `H3_FRAME_UNEXPECTED`.
- RFC 9204 §3.1 — invalid static-table index in a field-line representation is `QPACK_DECOMPRESSION_FAILED`.
- RFC 9204 §4.1.3 — Set Dynamic Table Capacity exceeding the limit is `QPACK_ENCODER_STREAM_ERROR`.
- RFC 9204 §4.4.3 — Insert Count Increment of 0 is `QPACK_DECODER_STREAM_ERROR`.
- RFC 9204 §6 — QPACK errors are connection-level, not stream-level.
- RFC 9114 §8.1 / RFC 9204 §6 — correct close error code on the wire.