### PR TITLE
fix(client): propagate InvalidStatus instead of panicking on unknown response codes

### DIFF
--- a/client/src/conn/h1.rs
+++ b/client/src/conn/h1.rs
@@ -223,7 +223,10 @@ impl Conn {
             _ => return Err(Error::InvalidHead),
         }
 
-        self.status = httparse_res.code.map(|code| code.try_into().unwrap());
+        self.status = httparse_res
+            .code
+            .map(|code| code.try_into().map_err(|_| Error::InvalidStatus))
+            .transpose()?;
 
         for header in httparse_res.headers {
             let header_name = HeaderName::from_str(header.name)?;


### PR DESCRIPTION
## Summary

- The h1 client previously did `code.try_into().unwrap()` on the status code from `httparse_res`, panicking on any value outside the `Status` enum (e.g. a server responding with a status code that isn't recognized).
- Replace with `.transpose()?` returning `Error::InvalidStatus` so the client surfaces a recoverable error instead of crashing the task.
