### PR TITLE
feat(quinn): add QuicConfig::from_cert_resolver

### DIFF
--- a/quinn/CHANGELOG.md
+++ b/quinn/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2026-05-11
+
+### Added
+- `QuicConfig::from_cert_resolver` — build a `QuicConfig` from an `Arc<dyn rustls::server::ResolvesServerCert>`. Lets callers supply a dynamic certificate source (e.g. an ACME integration) without rebuilding the QUIC server config on rotation; if the resolver returns `None`, the TLS handshake fails and the connection is rejected, so binding before the first cert is available is safe.
+
 ## [0.1.2] - 2026-05-05
 
 ### Fixed

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-quinn"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "quinn QUIC adapter for trillium.rs HTTP/3 support"
 license = "MIT OR Apache-2.0"

--- a/quinn/src/config.rs
+++ b/quinn/src/config.rs
@@ -2,6 +2,7 @@ use crate::{
     connection::QuinnConnection,
     runtime::{SocketTransport, TrilliumRuntime},
 };
+use rustls::server::ResolvesServerCert;
 use std::{io, net::SocketAddr, sync::Arc};
 use trillium_server_common::{Info, QuicConfig as QuicConfigTrait, QuicEndpoint, Server};
 
@@ -69,6 +70,27 @@ impl QuicConfig {
     /// For custom TLS only, prefer [`from_rustls_server_config`](Self::from_rustls_server_config).
     pub fn from_quinn_server_config(config: quinn::ServerConfig) -> Self {
         Self(config)
+    }
+
+    /// Build a `QuicConfig` from a [`rustls::server::ResolvesServerCert`] cert resolver.
+    ///
+    /// Use this to bring your own dynamic certificate source — for example, an ACME integration
+    /// that rotates certificates over time. The resolver is consulted on every new connection,
+    /// so renewals take effect immediately without rebuilding the QUIC server config.
+    ///
+    /// If the resolver returns `None` for a given `ClientHello` (e.g. before the first
+    /// certificate has been obtained), the TLS handshake fails and the connection is rejected.
+    /// This makes it safe to bind the endpoint before any certificate is available.
+    ///
+    /// Automatically configures ALPN for HTTP/3 (`h3`).
+    pub fn from_cert_resolver(resolver: Arc<dyn ResolvesServerCert>) -> Self {
+        let tls_config =
+            rustls::ServerConfig::builder_with_provider(crate::crypto_provider::crypto_provider())
+                .with_safe_default_protocol_versions()
+                .expect("building TLS config with protocol versions")
+                .with_no_client_auth()
+                .with_cert_resolver(resolver);
+        Self::from_rustls_server_config(tls_config)
     }
 }
 

--- a/quinn/tests/h3_integration.rs
+++ b/quinn/tests/h3_integration.rs
@@ -1,7 +1,7 @@
 #![cfg(quinn_testing)]
 
 use rcgen::generate_simple_self_signed;
-use std::net::SocketAddr;
+use std::{io, net::SocketAddr, sync::Arc};
 use trillium::{Conn, KnownHeaderName};
 use trillium_client::{Client, Version};
 use trillium_quinn::{ClientQuicConfig, QuicConfig};
@@ -55,6 +55,23 @@ async fn start_server(handler: impl trillium::Handler, tc: &TestCert) -> SocketA
         .with_quic(QuicConfig::from_single_cert(&tc.cert_pem, &tc.key_pem))
         .spawn(handler);
     *handle.info().await.tcp_socket_addr().unwrap()
+}
+
+/// Build an `Arc<dyn ResolvesServerCert>` that always returns the test cert.
+fn static_cert_resolver(tc: &TestCert) -> Arc<dyn rustls::server::ResolvesServerCert> {
+    let certs: Vec<_> = rustls_pemfile::certs(&mut io::BufReader::new(&tc.cert_pem[..]))
+        .collect::<Result<_, _>>()
+        .unwrap();
+    let key = rustls_pemfile::private_key(&mut io::BufReader::new(&tc.key_pem[..]))
+        .unwrap()
+        .unwrap();
+    let certified_key = rustls::sign::CertifiedKey::from_der(
+        certs,
+        key,
+        &rustls::crypto::aws_lc_rs::default_provider(),
+    )
+    .unwrap();
+    Arc::new(rustls::sign::SingleCertAndKey::from(certified_key))
 }
 
 /// Build a trillium client configured for both H1 (TLS) and H3 with the test cert trusted.
@@ -176,6 +193,37 @@ async fn trillium_client_alt_svc_upgrade() -> TestResult {
     assert!(
         version_str.contains("Http3"),
         "expected H3 for second request after alt-svc, got: {version_str}"
+    );
+    Ok(())
+}
+
+#[test(harness)]
+async fn trillium_client_h3_via_cert_resolver() -> TestResult {
+    // Verifies QuicConfig::from_cert_resolver wires a rustls cert resolver through to a
+    // live H3 handshake. The static resolver here stands in for a dynamic source like ACME.
+    let tc = test_cert();
+    let handle = config()
+        .with_port(0)
+        .with_host("localhost")
+        .without_signals()
+        .with_acceptor(trillium_rustls::RustlsAcceptor::from_single_cert(
+            &tc.cert_pem,
+            &tc.key_pem,
+        ))
+        .with_quic(QuicConfig::from_cert_resolver(static_cert_resolver(&tc)))
+        .spawn(|conn: Conn| async move { conn.ok("hello via resolver") });
+    let addr = *handle.info().await.tcp_socket_addr().unwrap();
+
+    let client = trillium_client(&tc);
+    let mut conn = client
+        .get(format!("https://localhost:{}/", addr.port()))
+        .with_http_version(Version::Http3)
+        .await?;
+
+    assert_eq!(conn.status().unwrap(), 200u16);
+    assert_eq!(
+        conn.response_body().read_string().await?,
+        "hello via resolver"
     );
     Ok(())
 }


### PR DESCRIPTION
Build a `QuicConfig` from an `Arc<dyn rustls::server::ResolvesServerCert>`, so callers can supply a dynamic certificate source (e.g. an ACME integration) without rebuilding the QUIC server config on rotation. If the resolver returns `None`, the TLS handshake fails and the connection is rejected, so binding before the first cert is available is safe.