### PR TITLE
Rustls additions

### DIFF
--- a/rustls/CHANGELOG.md
+++ b/rustls/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.11.2] - 2026-05-26
+
+### Added
+- `RustlsClientConfig::from_root_cert_pem(pem)` — build a client config that trusts exactly the certificate(s) in the provided PEM (ignoring platform/webpki defaults) while keeping certificate verification intact. Useful for connecting to a service with a private or self-signed certificate without reconstructing the crate's provider/ALPN defaults by hand.
+- `RustlsClientConfig` is now re-exported from the crate root.
+- `dangerous` cargo feature, gating `RustlsClientConfig::dangerously_accept_any_cert()` — a client config that disables server authentication entirely.
 
 ### Fixed
 - Connecting over TLS to a host given as an IP address (e.g. `https://127.0.0.1`) failed with a `missing domain` transport error; only DNS hostnames worked. IP-address hosts now connect, validated against the certificate's IP SAN (no SNI is sent for them, per the TLS spec).

--- a/rustls/CHANGELOG.md
+++ b/rustls/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Connecting over TLS to a host given as an IP address (e.g. `https://127.0.0.1`) failed with a `missing domain` transport error; only DNS hostnames worked. IP-address hosts now connect, validated against the certificate's IP SAN (no SNI is sent for them, per the TLS spec).
+
 ## [0.11.1] - 2026-05-05
 
 ### Fixed

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-rustls"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 description = "rustls adapter for trillium.rs"
 license = "MIT OR Apache-2.0"

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "trillium-rustls"
 version = "0.11.1"
-authors = ["Jacob Rothstein <hi@jbr.me>"]
 edition = "2024"
 description = "rustls adapter for trillium.rs"
 license = "MIT OR Apache-2.0"
@@ -10,6 +9,14 @@ readme = "README.md"
 keywords = ["trillium", "framework", "async"]
 categories = ["web-programming::http-server", "web-programming"]
 
+[package.metadata.docs.rs]
+features = ["dangerous", "client", "server", "platform-verifier", "custom-crypto-provider"]
+rustdoc-args = ["--cfg", "docsrs"]
+
+[package.metadata.cargo-udeps.ignore]
+# because there is no way to say [dependencies.'cfg(not(feature = "platform-verifier"))']
+normal = ["webpki-roots"]
+
 [features]
 default = ["platform-verifier", "aws-lc-rs", "client", "server", "tls12"]
 aws-lc-rs = ["futures-rustls/aws-lc-rs"]
@@ -17,9 +24,10 @@ custom-crypto-provider = []
 fips = ["futures-rustls/fips"]
 ring = ["futures-rustls/ring"]
 tls12 = ["futures-rustls/tls12"]
-client = ["dep:webpki-roots"]
+client = ["dep:webpki-roots", "dep:rustls-pemfile"]
 server = ["dep:rustls-pemfile"]
 platform-verifier = ["dep:rustls-platform-verifier"]
+dangerous = []
 
 [dependencies.futures-rustls]
 version = "0.26"
@@ -36,13 +44,10 @@ webpki-roots = { version = "1.0", optional = true }
 [dev-dependencies]
 env_logger = "0.11.10"
 portpicker = "0.1.1"
+rcgen = "0.14"
 test-harness = "0.3.1"
 trillium = { path = "../trillium" }
 trillium-client = { path = "../client" }
 trillium-native-tls = { path = "../native-tls" }
 trillium-smol = { path = "../smol" }
 trillium-testing = { path = "../testing" }
-
-[package.metadata.cargo-udeps.ignore]
-# because there is no way to say [dependencies.'cfg(not(feature = "platform-verifier"))']
-normal = ["webpki-roots"]

--- a/rustls/src/client.rs
+++ b/rustls/src/client.rs
@@ -16,7 +16,7 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
-use trillium_server_common::{AsyncRead, AsyncWrite, Connector, Transport, Url};
+use trillium_server_common::{AsyncRead, AsyncWrite, Connector, Transport, Url, url::Host};
 
 #[derive(Clone, Debug)]
 pub struct RustlsClientConfig(Arc<ClientConfig>);
@@ -132,10 +132,18 @@ impl<C: Connector> Connector for RustlsConfig<C> {
                 http.set_port(url.port_or_known_default()).ok();
 
                 let connector: TlsConnector = Arc::clone(&self.rustls_config.0).into();
-                let domain = url
-                    .domain()
-                    .and_then(|dns_name| ServerName::try_from(dns_name.to_string()).ok())
-                    .ok_or_else(|| Error::other("missing domain"))?;
+                // Derive the TLS server name from the URL host. A domain becomes a DNS
+                // `ServerName` (sent via SNI); an IP literal becomes an `IpAddress` server
+                // name (no SNI, validated against the certificate's IP SAN) — `url.domain()`
+                // returns `None` for IPs, so matching on `host()` is what lets us connect to
+                // an IP address over TLS at all.
+                let domain = match url.host() {
+                    Some(Host::Domain(domain)) => ServerName::try_from(domain.to_owned())
+                        .map_err(|e| Error::other(format!("invalid server name {domain:?}: {e}")))?,
+                    Some(Host::Ipv4(ip)) => ServerName::IpAddress(std::net::IpAddr::V4(ip).into()),
+                    Some(Host::Ipv6(ip)) => ServerName::IpAddress(std::net::IpAddr::V6(ip).into()),
+                    None => return Err(Error::other("url has no host")),
+                };
 
                 connector
                     .connect(domain, self.tcp_config.connect(&http).await?)

--- a/rustls/src/client.rs
+++ b/rustls/src/client.rs
@@ -1,10 +1,19 @@
 use crate::crypto_provider;
 use RustlsClientTransportInner::{Tcp, Tls};
+#[cfg(feature = "dangerous")]
+use futures_rustls::rustls::{
+    DigitallySignedStruct, SignatureScheme,
+    client::danger::{HandshakeSignatureValid, ServerCertVerified},
+    crypto::{verify_tls12_signature, verify_tls13_signature},
+    pki_types::{CertificateDer, UnixTime},
+};
 use futures_rustls::{
     TlsConnector,
     client::TlsStream,
     rustls::{
-        ClientConfig, ClientConnection, client::danger::ServerCertVerifier, crypto::CryptoProvider,
+        ClientConfig, ClientConnection, RootCertStore,
+        client::{WebPkiServerVerifier, danger::ServerCertVerifier},
+        crypto::CryptoProvider,
         pki_types::ServerName,
     },
 };
@@ -18,6 +27,12 @@ use std::{
 };
 use trillium_server_common::{AsyncRead, AsyncWrite, Connector, Transport, Url, url::Host};
 
+/// Rustls [`ClientConfig`] wrapper used by [`RustlsConfig`].
+///
+/// [`RustlsClientConfig::default`] trusts the platform or webpki roots (depending on the
+/// `platform-verifier` feature). Use [`RustlsClientConfig::from_root_cert_pem`] to trust a specific
+/// private or self-signed certificate instead, or convert an existing [`ClientConfig`] via
+/// [`From`].
 #[derive(Clone, Debug)]
 pub struct RustlsClientConfig(Arc<ClientConfig>);
 
@@ -54,19 +69,16 @@ fn verifier(provider: Arc<CryptoProvider>) -> Arc<dyn ServerCertVerifier> {
 
 #[cfg(not(feature = "platform-verifier"))]
 fn verifier(provider: Arc<CryptoProvider>) -> Arc<dyn ServerCertVerifier> {
-    let roots = Arc::new(futures_rustls::rustls::RootCertStore::from_iter(
+    let roots = Arc::new(RootCertStore::from_iter(
         webpki_roots::TLS_SERVER_ROOTS.iter().cloned(),
     ));
-    futures_rustls::rustls::client::WebPkiServerVerifier::builder_with_provider(roots, provider)
+    WebPkiServerVerifier::builder_with_provider(roots, provider)
         .build()
         .unwrap()
 }
 
-fn default_client_config() -> ClientConfig {
-    let provider = crypto_provider();
-    let verifier = verifier(Arc::clone(&provider));
-
-    let mut config = ClientConfig::builder_with_provider(provider)
+fn client_config_with_verifier(verifier: Arc<dyn ServerCertVerifier>) -> ClientConfig {
+    let mut config = ClientConfig::builder_with_provider(crypto_provider())
         .with_safe_default_protocol_versions()
         .expect("crypto provider did not support safe default protocol versions")
         .dangerous()
@@ -78,6 +90,49 @@ fn default_client_config() -> ClientConfig {
     config
 }
 
+fn default_client_config() -> ClientConfig {
+    client_config_with_verifier(verifier(crypto_provider()))
+}
+
+impl RustlsClientConfig {
+    /// Build a client configuration that trusts exactly the certificate(s) in `pem`.
+    ///
+    /// Unlike [`RustlsClientConfig::default`], this consults neither the platform trust store nor
+    /// the webpki root bundle — the provided roots are the only trust anchors. Server
+    /// authentication is otherwise unchanged: certificate chains, signatures, expiry, and server
+    /// name are all still verified against these roots. This is the right tool for talking to a
+    /// service that presents a private or self-signed certificate.
+    ///
+    /// The crate's configured crypto provider and default ALPN protocol list (`h2`, `http/1.1`)
+    /// are reused.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `pem` contains no certificates or cannot be parsed, or if the resulting
+    /// trust anchors are rejected by the verifier builder.
+    pub fn from_root_cert_pem(pem: &[u8]) -> Result<Self> {
+        let mut roots = RootCertStore::empty();
+        let mut reader = pem;
+        for cert in rustls_pemfile::certs(&mut reader) {
+            roots.add(cert?).map_err(Error::other)?;
+        }
+
+        if roots.is_empty() {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                "no certificates found in pem",
+            ));
+        }
+
+        let verifier =
+            WebPkiServerVerifier::builder_with_provider(Arc::new(roots), crypto_provider())
+                .build()
+                .map_err(Error::other)?;
+
+        Ok(Self(Arc::new(client_config_with_verifier(verifier))))
+    }
+}
+
 impl From<ClientConfig> for RustlsClientConfig {
     fn from(rustls_config: ClientConfig) -> Self {
         Self(Arc::new(rustls_config))
@@ -87,6 +142,80 @@ impl From<ClientConfig> for RustlsClientConfig {
 impl From<Arc<ClientConfig>> for RustlsClientConfig {
     fn from(rustls_config: Arc<ClientConfig>) -> Self {
         Self(rustls_config)
+    }
+}
+
+#[cfg(feature = "dangerous")]
+#[derive(Debug)]
+struct AcceptAnyServerCert(Arc<CryptoProvider>);
+
+#[cfg(feature = "dangerous")]
+impl ServerCertVerifier for AcceptAnyServerCert {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> std::result::Result<ServerCertVerified, futures_rustls::rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> std::result::Result<HandshakeSignatureValid, futures_rustls::rustls::Error> {
+        verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> std::result::Result<HandshakeSignatureValid, futures_rustls::rustls::Error> {
+        verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.0.signature_verification_algorithms.supported_schemes()
+    }
+}
+
+#[cfg(feature = "dangerous")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dangerous")))]
+impl RustlsClientConfig {
+    /// Build a client configuration that accepts **any** server certificate without verification.
+    ///
+    /// ⚠️ This disables server authentication entirely: handshake signatures are still checked,
+    /// but the certificate is never validated against any trust anchor, so the connection is
+    /// vulnerable to man-in-the-middle attacks. It exists for development against throwaway
+    /// self-signed certificates and for `--insecure`-style CLI flags. For talking to a service
+    /// with a known private certificate, prefer [`RustlsClientConfig::from_root_cert_pem`], which
+    /// keeps authentication intact.
+    ///
+    /// This constructor is only available with the `dangerous` crate feature enabled, and logs a
+    /// warning when called.
+    pub fn dangerously_accept_any_cert() -> Self {
+        log::warn!(
+            "constructing a rustls client config that accepts any server certificate; server \
+             authentication is disabled and connections are vulnerable to interception"
+        );
+        let verifier = Arc::new(AcceptAnyServerCert(crypto_provider()));
+        Self(Arc::new(client_config_with_verifier(verifier)))
     }
 }
 
@@ -138,8 +267,11 @@ impl<C: Connector> Connector for RustlsConfig<C> {
                 // returns `None` for IPs, so matching on `host()` is what lets us connect to
                 // an IP address over TLS at all.
                 let domain = match url.host() {
-                    Some(Host::Domain(domain)) => ServerName::try_from(domain.to_owned())
-                        .map_err(|e| Error::other(format!("invalid server name {domain:?}: {e}")))?,
+                    Some(Host::Domain(domain)) => {
+                        ServerName::try_from(domain.to_owned()).map_err(|e| {
+                            Error::other(format!("invalid server name {domain:?}: {e}"))
+                        })?
+                    }
                     Some(Host::Ipv4(ip)) => ServerName::IpAddress(std::net::IpAddr::V4(ip).into()),
                     Some(Host::Ipv6(ip)) => ServerName::IpAddress(std::net::IpAddr::V6(ip).into()),
                     None => return Err(Error::other("url has no host")),

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -8,6 +8,7 @@
     nonstandard_style,
     unused_qualifications
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //!  This crate provides rustls trait implementations for trillium client ([`RustlsConfig`]) and
 //! server ([`RustlsAcceptor`]).
@@ -65,6 +66,17 @@
 //! the selected cryptographic backend and uses
 //! [`rustls-platform-verifier`](https://docs.rs/rustls-platform-verifier/). This feature is enabled by
 //! default. If you disable the feature, [`webpki_roots`] will be used.
+//!
+//! To trust a specific private or self-signed certificate without dropping into raw rustls, use
+//! [`RustlsClientConfig::from_root_cert_pem`], which trusts exactly the provided roots while
+//! keeping certificate verification intact.
+//!
+//! ## `dangerous` feature
+//!
+//! ⚠️ This feature enables [`RustlsClientConfig::dangerously_accept_any_cert`], which builds a
+//! client configuration that disables server authentication entirely. It is not enabled by
+//! default and should only be used for development or explicit `--insecure`-style opt-ins. Prefer
+//! [`RustlsClientConfig::from_root_cert_pem`] whenever the certificate is known in advance.
 
 #[cfg(test)]
 #[doc = include_str!("../README.md")]
@@ -73,7 +85,7 @@ mod readme {}
 #[cfg(feature = "client")]
 mod client;
 #[cfg(feature = "client")]
-pub use client::{RustlsClientTransport, RustlsConfig};
+pub use client::{RustlsClientConfig, RustlsClientTransport, RustlsConfig};
 
 #[cfg(feature = "server")]
 mod server;

--- a/rustls/tests/custom_roots.rs
+++ b/rustls/tests/custom_roots.rs
@@ -1,0 +1,98 @@
+use rcgen::generate_simple_self_signed;
+use std::{error::Error, future::Future};
+use test_harness::test;
+use trillium_client::Client;
+use trillium_rustls::{RustlsAcceptor, RustlsClientConfig, RustlsConfig};
+use trillium_server_common::Url;
+use trillium_testing::{block_on, client_config, config, harness};
+
+fn handler() -> impl trillium::Handler {
+    "ok"
+}
+
+struct SelfSigned {
+    cert_pem: Vec<u8>,
+    key_pem: Vec<u8>,
+}
+
+fn self_signed() -> SelfSigned {
+    let cert = generate_simple_self_signed(["localhost".to_string()]).unwrap();
+    SelfSigned {
+        cert_pem: cert.cert.pem().into_bytes(),
+        key_pem: cert.signing_key.serialize_pem().into_bytes(),
+    }
+}
+
+fn client_with(rustls_config: RustlsClientConfig) -> Client {
+    Client::new(RustlsConfig {
+        rustls_config,
+        tcp_config: client_config(),
+    })
+}
+
+/// Spawns a server presenting a freshly generated self-signed `localhost` certificate and hands
+/// the test both the URL and the certificate PEM.
+fn with_self_signed_server<Fun, Fut>(tests: Fun)
+where
+    Fun: FnOnce(Url, Vec<u8>) -> Fut,
+    Fut: Future<Output = Result<(), Box<dyn Error>>>,
+{
+    block_on(async move {
+        let SelfSigned { cert_pem, key_pem } = self_signed();
+        let port = portpicker::pick_unused_port().expect("could not pick a port");
+        let url = format!("https://localhost:{port}").parse().unwrap();
+
+        let handle = config()
+            .with_host("localhost")
+            .with_port(port)
+            .with_acceptor(RustlsAcceptor::from_single_cert(&cert_pem, &key_pem))
+            .spawn(handler());
+        handle.info().await;
+        tests(url, cert_pem).await.unwrap();
+        handle.shut_down().await;
+    });
+}
+
+#[test(harness = with_self_signed_server)]
+async fn from_root_cert_pem_trusts_the_cert(
+    url: Url,
+    cert_pem: Vec<u8>,
+) -> Result<(), Box<dyn Error>> {
+    let config = RustlsClientConfig::from_root_cert_pem(&cert_pem)?;
+    let _ = client_with(config).get(url).await?.success()?;
+    Ok(())
+}
+
+#[test(harness = with_self_signed_server)]
+async fn default_client_rejects_self_signed(
+    url: Url,
+    _cert_pem: Vec<u8>,
+) -> Result<(), Box<dyn Error>> {
+    assert!(
+        client_with(RustlsClientConfig::default())
+            .get(url)
+            .await
+            .is_err(),
+        "default client must not trust an untrusted self-signed certificate"
+    );
+    Ok(())
+}
+
+#[cfg(feature = "dangerous")]
+#[test(harness = with_self_signed_server)]
+async fn dangerously_accept_any_cert_connects(
+    url: Url,
+    _cert_pem: Vec<u8>,
+) -> Result<(), Box<dyn Error>> {
+    let _ = client_with(RustlsClientConfig::dangerously_accept_any_cert())
+        .get(url)
+        .await?
+        .success()?;
+    Ok(())
+}
+
+#[test(harness)]
+async fn from_root_cert_pem_rejects_invalid_input() {
+    assert!(RustlsClientConfig::from_root_cert_pem(b"").is_err());
+    assert!(RustlsClientConfig::from_root_cert_pem(b"not a certificate").is_err());
+}


### PR DESCRIPTION
### Added
- `RustlsClientConfig::from_root_cert_pem(pem)` — build a client config that trusts exactly the certificate(s) in the provided PEM (ignoring platform/webpki defaults) while keeping certificate verification intact. Useful for connecting to a service with a private or self-signed certificate without reconstructing the crate's provider/ALPN defaults by hand.
- `RustlsClientConfig` is now re-exported from the crate root.
- `dangerous` cargo feature, gating `RustlsClientConfig::dangerously_accept_any_cert()` — a client config that disables server authentication entirely.

### Fixed
- Connecting over TLS to a host given as an IP address (e.g. `https://127.0.0.1`) failed with a `missing domain` transport error; only DNS hostnames worked. IP-address hosts now connect, validated against the certificate's IP SAN (no SNI is sent for them, per the TLS spec).
