### PR TITLE
Http and client h2 fixes

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -14,17 +14,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- HTTP/2: a received body that carried a `content-length` header could report end-of-input before
+  the stream's trailing headers arrived, so `request_trailers()` (server) / `response_trailers()`
+  (client) came back empty even though the peer had sent trailers. The effect was a timing-dependent
+  race condition. Bodies now wait for the end of the stream before reporting end-of-input, so the
+  trailers are always delivered.
 - HTTP/2 and HTTP/3 response trailers are now surfaced on the owned response body taken via
   `Conn::take_response_body` (and the `From<Conn> for Body` proxy path). Previously the protocol
   session wasn't carried onto the detached body, so driver-decoded trailers were never harvested,
   and even when present they were discarded by the body's EOF recycle before a caller could read
   them. The borrowed `Conn::response_body` path was unaffected.
-
 - HTTP/2: response trailers could go missing when talking to a server that responds and resets the
-  stream before reading the full request body (common for unary gRPC and early error responses) —
-  the body ended cleanly but the trailers the server had already sent were dropped. Trailers are now
-  delivered in this case.
-
+  stream before reading the full request body — the body ended cleanly but the trailers the server
+  had already sent were dropped. Trailers are now delivered in this case.
 - HTTP/2: issuing several requests concurrently through one `Client` to the same origin could abort
   the connection with a protocol error, failing those requests and any others in flight on the same
   connection with a connection-aborted error. Concurrent requests over a shared connection now

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.3] - 2026-05-26
 
 ### Added
 
@@ -15,10 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - HTTP/2 and HTTP/3 response trailers are now surfaced on the owned response body taken via
-  `Conn::take_response_body` (and the `From<Conn> for Body` proxy path). Previously the
-  protocol session wasn't carried onto the detached body, so driver-decoded trailers were
-  never harvested, and even when present they were discarded by the body's EOF recycle
-  before a caller could read them. The borrowed `Conn::response_body` path was unaffected.
+  `Conn::take_response_body` (and the `From<Conn> for Body` proxy path). Previously the protocol
+  session wasn't carried onto the detached body, so driver-decoded trailers were never harvested,
+  and even when present they were discarded by the body's EOF recycle before a caller could read
+  them. The borrowed `Conn::response_body` path was unaffected.
+
+- HTTP/2: response trailers could go missing when talking to a server that responds and resets the
+  stream before reading the full request body (common for unary gRPC and early error responses) —
+  the body ended cleanly but the trailers the server had already sent were dropped. Trailers are now
+  delivered in this case.
+
 
 ## [0.9.2] - 2026-05-25
 

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the body ended cleanly but the trailers the server had already sent were dropped. Trailers are now
   delivered in this case.
 
+- HTTP/2: issuing several requests concurrently through one `Client` to the same origin could abort
+  the connection with a protocol error, failing those requests and any others in flight on the same
+  connection with a connection-aborted error. Concurrent requests over a shared connection now
+  proceed normally.
+
 
 ## [0.9.2] - 2026-05-25
 

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `ResponseBody::trailers(&self) -> Option<&Headers>` borrows the trailers received after the
+  response body, on both borrowed and owned response bodies. Populated after the body has been
+  read to end-of-stream.
+
+### Fixed
+
+- HTTP/2 and HTTP/3 response trailers are now surfaced on the owned response body taken via
+  `Conn::take_response_body` (and the `From<Conn> for Body` proxy path). Previously the
+  protocol session wasn't carried onto the detached body, so driver-decoded trailers were
+  never harvested, and even when present they were discarded by the body's EOF recycle
+  before a caller could read them. The borrowed `Conn::response_body` path was unaffected.
+
 ## [0.9.2] - 2026-05-25
 
 ### Changed

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-client"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 description = "http client for trillium.rs"
 license = "MIT OR Apache-2.0"
@@ -40,7 +40,7 @@ sonic-rs = { version = "0.5.8", optional = true }
 fieldwork = "0.5.0"
 trillium-macros.workspace = true
 trillium-webtransport = { workspace = true, optional = true }
-trillium-http = { version = "1.3.2", path = "../http", features = ["unstable"] }
+trillium-http = { version = "1.3.3", path = "../http", features = ["unstable"] }
 
 [dev-dependencies]
 async-channel = "2.5.0"

--- a/client/src/conn.rs
+++ b/client/src/conn.rs
@@ -513,14 +513,17 @@ impl Conn {
                 as Box<dyn FnOnce(Box<dyn Transport>) + Send + Sync + 'static>
         });
 
-        Some(ReceivedBody::new(
-            self.response_content_length(),
-            mem::take(&mut self.buffer),
-            transport,
-            self.response_body_state,
-            on_completion,
-            encoding(&self.response_headers),
-        ))
+        Some(
+            ReceivedBody::new(
+                self.response_content_length(),
+                mem::take(&mut self.buffer),
+                transport,
+                self.response_body_state,
+                on_completion,
+                encoding(&self.response_headers),
+            )
+            .with_protocol_session(self.protocol_session.clone()),
+        )
     }
 
     /// Returns this conn to the connection pool if it is keepalive, and

--- a/client/src/response_body.rs
+++ b/client/src/response_body.rs
@@ -51,6 +51,11 @@ pub struct ResponseBody<'a> {
     /// transport is attached at this layer — `take_response_body` already evicted any leftover
     /// transport before returning).
     cleanup: Option<CleanupContext>,
+    /// Trailers harvested off the inner [`ReceivedBody`] when it reaches `End`. The
+    /// EOF-driven recycle in `poll_read` moves the `ReceivedBody` out before the caller can
+    /// observe its trailers, so they're captured here to outlive it and surfaced through
+    /// [`BodySource::trailers`].
+    trailers: Option<Headers>,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -180,6 +185,7 @@ impl AsyncRead for ResponseBody<'_> {
                 && rb.state() == ReceivedBodyState::End
                 && let Some(mut transport) = rb.take_transport()
             {
+                self.trailers = Pin::new(&mut rb).trailers();
                 if let Some((pool, origin)) = cleanup.h1_pool_origin {
                     pool.insert(origin, PoolEntry::new(transport, None));
                 } else {
@@ -333,6 +339,21 @@ impl ResponseBody<'_> {
         self
     }
 
+    /// The trailers received after the response body, if any.
+    ///
+    /// Returns `None` until the body has been read to end-of-stream, and only on protocols
+    /// that delivered a trailer section (HTTP/1.1 chunked with trailers, HTTP/2, HTTP/3).
+    /// Reading the body via [`read_string`](Self::read_string)/[`read_bytes`](Self::read_bytes)
+    /// consumes it, so to observe trailers drive the body to completion through its
+    /// [`AsyncRead`](futures_lite::AsyncRead) interface and then call this.
+    pub fn trailers(&self) -> Option<&Headers> {
+        match &self.inner {
+            ResponseBodyInner::Received(rb) => rb.trailers_ref(),
+            // Captured off the inner ReceivedBody when it was recycled at end-of-stream.
+            _ => self.trailers.as_ref(),
+        }
+    }
+
     /// The content-length of this body, if available.
     ///
     /// Usually derived from the content-length header. If the response uses
@@ -417,10 +438,13 @@ impl Drop for ResponseBody<'_> {
 
 impl BodySource for ResponseBody<'static> {
     fn trailers(self: Pin<&mut Self>) -> Option<Headers> {
-        match &mut self.get_mut().inner {
+        let this = self.get_mut();
+        match &mut this.inner {
             ResponseBodyInner::Received(rb) => Pin::new(rb).trailers(),
             ResponseBodyInner::Override(o) => o.body.trailers(),
-            _ => None,
+            // Recycled at EOF — trailers were captured off the ReceivedBody before it was
+            // moved out. See `ResponseBody::trailers`.
+            _ => this.trailers.take(),
         }
     }
 }
@@ -430,6 +454,7 @@ impl<'a> From<ReceivedBody<'a, Box<dyn Transport>>> for ResponseBody<'a> {
         Self {
             inner: ResponseBodyInner::Received(received_body),
             cleanup: None,
+            trailers: None,
         }
     }
 }
@@ -439,6 +464,7 @@ impl<'a> From<OverrideBody<'a>> for ResponseBody<'a> {
         Self {
             inner: ResponseBodyInner::Override(o),
             cleanup: None,
+            trailers: None,
         }
     }
 }
@@ -451,6 +477,7 @@ impl ResponseBody<'static> {
         Self {
             inner: ResponseBodyInner::Received(body),
             cleanup: Some(cleanup),
+            trailers: None,
         }
     }
 

--- a/client/tests/h2_alpn.rs
+++ b/client/tests/h2_alpn.rs
@@ -4,7 +4,7 @@
 //! ALPN) and a trillium client whose rustls config trusts the test cert and advertises the
 //! same ALPN list. The client request should be transparently dispatched over HTTP/2.
 
-use futures_lite::{AsyncRead, io::Cursor};
+use futures_lite::{AsyncRead, AsyncReadExt, io::Cursor};
 use std::{
     io,
     pin::Pin,
@@ -217,6 +217,56 @@ async fn h2_bidirectional_trailers() -> TestResult {
             .as_ref()
             .and_then(|t| t.get_str("x-pong")),
         Some("pong"),
+    );
+
+    server.shut_down().await;
+    Ok(())
+}
+
+/// The owned-body path (`take_response_body`) must carry the h2 protocol session through
+/// to the detached `ResponseBody`, or trailers decoded by the driver at end-of-stream are
+/// never harvested. Reads them back via `ResponseBody::trailers`.
+#[test(harness)]
+async fn h2_owned_body_trailers() -> TestResult {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let cert = test_cert();
+
+    let server = trillium_smol::config()
+        .with_host("localhost")
+        .with_port(0)
+        .with_acceptor(RustlsAcceptor::from_single_cert(
+            &cert.cert_pem,
+            &cert.key_pem,
+        ))
+        .spawn(trailer_handler);
+    let info = server.info().await;
+    let port = info.tcp_socket_addr().unwrap().port();
+
+    let client = Client::new(RustlsConfig::new(
+        Arc::new(rustls_client_config(&cert)),
+        trillium_smol::ClientConfig::default(),
+    ))
+    .with_base(format!("https://localhost:{port}"));
+
+    let req_trailers = one_trailer("x-ping", "ping");
+    let mut conn = client
+        .post("/")
+        .with_body(Body::new_with_trailers(
+            BodyWithTrailers::new("data", req_trailers),
+            None,
+        ))
+        .await?;
+
+    assert_eq!(conn.status().unwrap(), 200);
+    assert_eq!(conn.http_version(), Version::Http2);
+
+    let mut body = conn.take_response_body().expect("response body");
+    let mut read = String::new();
+    body.read_to_string(&mut read).await?;
+    assert_eq!(read, "ping:data");
+    assert_eq!(
+        body.trailers().and_then(|t| t.get_str("x-pong")),
+        Some("pong")
     );
 
     server.shut_down().await;

--- a/client/tests/h3_trailers.rs
+++ b/client/tests/h3_trailers.rs
@@ -1,0 +1,154 @@
+//! End-to-end test that the trillium-client owned-body path (`take_response_body`) surfaces
+//! HTTP/3 response trailers. The owned `ResponseBody` must carry the h3 protocol session, or
+//! the trailing HEADERS frame is decoded into nothing and the trailers are silently dropped.
+//! Reads them back via `ResponseBody::trailers`.
+
+use futures_lite::{AsyncRead, AsyncReadExt, io::Cursor};
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use trillium::Conn;
+use trillium_client::{Body, BodySource, Client, Headers, Version};
+use trillium_quinn::{ClientQuicConfig, QuicConfig};
+use trillium_rustls::{
+    RustlsAcceptor, RustlsConfig,
+    rustls::{self, RootCertStore},
+};
+use trillium_testing::{TestResult, harness, test};
+
+struct TestCert {
+    cert_pem: Vec<u8>,
+    key_pem: Vec<u8>,
+    cert_der: rustls::pki_types::CertificateDer<'static>,
+}
+
+fn test_cert() -> TestCert {
+    let rcgen::CertifiedKey {
+        cert, signing_key, ..
+    } = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+    TestCert {
+        cert_pem: cert.pem().into_bytes(),
+        key_pem: signing_key.serialize_pem().into_bytes(),
+        cert_der: cert.der().clone(),
+    }
+}
+
+fn rustls_client_config(cert: &TestCert) -> rustls::ClientConfig {
+    let mut roots = RootCertStore::empty();
+    roots.add(cert.cert_der.clone()).unwrap();
+    rustls::ClientConfig::builder_with_provider(
+        rustls::crypto::aws_lc_rs::default_provider().into(),
+    )
+    .with_safe_default_protocol_versions()
+    .unwrap()
+    .with_root_certificates(roots)
+    .with_no_client_auth()
+}
+
+fn quic_client(cert: &TestCert) -> Client {
+    Client::new_with_quic(
+        RustlsConfig::new(
+            rustls_client_config(cert),
+            trillium_smol::ClientConfig::default(),
+        ),
+        ClientQuicConfig::from_rustls_client_config(rustls_client_config(cert)),
+    )
+}
+
+struct BodyWithTrailers {
+    cursor: Cursor<Vec<u8>>,
+    trailers: Option<Headers>,
+}
+
+impl BodyWithTrailers {
+    fn new(body: impl Into<Vec<u8>>, trailers: Headers) -> Self {
+        Self {
+            cursor: Cursor::new(body.into()),
+            trailers: Some(trailers),
+        }
+    }
+}
+
+impl AsyncRead for BodyWithTrailers {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.get_mut().cursor).poll_read(cx, buf)
+    }
+}
+
+impl BodySource for BodyWithTrailers {
+    fn trailers(self: Pin<&mut Self>) -> Option<Headers> {
+        self.get_mut().trailers.take()
+    }
+}
+
+fn one_trailer(name: &'static str, value: &'static str) -> Headers {
+    let mut h = Headers::new();
+    h.insert(name, value);
+    h
+}
+
+async fn trailer_handler(mut conn: Conn) -> Conn {
+    let body = conn.request_body_string().await.unwrap_or_default();
+    let ping = conn
+        .request_trailers()
+        .and_then(|t| t.get_str("x-ping"))
+        .unwrap_or("")
+        .to_string();
+    let resp_trailers = one_trailer("x-pong", "pong");
+    conn.with_status(200)
+        .with_body(Body::new_with_trailers(
+            BodyWithTrailers::new(format!("{ping}:{body}"), resp_trailers),
+            None,
+        ))
+        .halt()
+}
+
+#[test(harness)]
+async fn h3_owned_body_trailers() -> TestResult {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let cert = test_cert();
+
+    let server = trillium_smol::config()
+        .with_host("localhost")
+        .with_port(0)
+        .with_acceptor(RustlsAcceptor::from_single_cert(
+            &cert.cert_pem,
+            &cert.key_pem,
+        ))
+        .with_quic(QuicConfig::from_single_cert(&cert.cert_pem, &cert.key_pem))
+        .spawn(trailer_handler);
+    let port = server.info().await.tcp_socket_addr().unwrap().port();
+
+    let client = quic_client(&cert).with_base(format!("https://localhost:{port}"));
+
+    let req_trailers = one_trailer("x-ping", "ping");
+    let mut conn = client
+        .post("/")
+        .with_http_version(Version::Http3)
+        .with_body(Body::new_with_trailers(
+            BodyWithTrailers::new("data", req_trailers),
+            None,
+        ))
+        .await?;
+
+    assert_eq!(conn.status().unwrap(), 200);
+    assert_eq!(conn.http_version(), Version::Http3);
+
+    let mut body = conn.take_response_body().expect("response body");
+    let mut read = String::new();
+    body.read_to_string(&mut read).await?;
+    assert_eq!(read, "ping:data");
+    assert_eq!(
+        body.trailers().and_then(|t| t.get_str("x-pong")),
+        Some("pong")
+    );
+
+    server.shut_down().await;
+    Ok(())
+}

--- a/http/CHANGELOG.md
+++ b/http/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- HTTP/2 client: response trailers could go missing when talking to a server that responds and resets the stream before reading the full request body (common for unary gRPC and early error responses) — the body ended cleanly but the trailers the server had already sent were dropped. Trailers are now delivered in this case.
+
 ## [1.3.2] - 2026-05-24
 
 ### Changed

--- a/http/CHANGELOG.md
+++ b/http/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- HTTP/2 client: response trailers could go missing when talking to a server that responds and resets the stream before reading the full request body (common for unary gRPC and early error responses) — the body ended cleanly but the trailers the server had already sent were dropped. Trailers are now delivered in this case.
+- HTTP/2: a received body that carried a `content-length` header could report end-of-input before
+  the stream's trailing headers arrived, so `request_trailers()` (server) / `response_trailers()`
+  (client) came back empty even though the peer had sent trailers. The effect was a timing-dependent
+  race condition. Bodies now wait for the end of the stream before reporting end-of-input, so the
+  trailers are always delivered.
 
 ## [1.3.2] - 2026-05-24
 

--- a/http/CHANGELOG.md
+++ b/http/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.3] - 2026-05-26
 
 ### Fixed
 

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-http"
-version = "1.3.2"
+version = "1.3.3"
 edition = "2024"
 description = "the http implementation for the trillium toolkit"
 license = "MIT OR Apache-2.0"

--- a/http/src/h2/acceptor.rs
+++ b/http/src/h2/acceptor.rs
@@ -56,9 +56,9 @@ use constants::{
     INITIAL_CONNECTION_RECV_WINDOW, MAX_BUFFER_SIZE, MAX_DATA_CHUNK_SIZE, MAX_FLOW_CONTROL_WINDOW,
 };
 use futures_lite::io::{AsyncRead, AsyncWrite};
-use hashbrown::HashMap;
 use recv::PendingHeaders;
 use std::{
+    collections::BTreeMap,
     future::Future,
     io,
     pin::Pin,
@@ -119,7 +119,14 @@ pub struct H2Driver<T> {
     /// `Arc<StreamState>` via [`H2Transport`] and don't consult this table. The entry
     /// bundles the shared state with driver-private bookkeeping (e.g. "have we already
     /// advertised the recv window after seeing `is_reading`?").
-    streams: HashMap<u32, StreamEntry>,
+    ///
+    /// A `BTreeMap` (not a hash map) so the send pump iterates streams in ascending
+    /// stream-id order. For the client role this is load-bearing: a client MUST send
+    /// opening HEADERS in monotonically increasing stream-id order (RFC 9113 §5.1.1),
+    /// and concurrent `open_stream` calls would otherwise let the pump frame a higher
+    /// id before a lower one, drawing a `GOAWAY(PROTOCOL_ERROR)` from the peer. (See
+    /// also the allocate-under-`streams_lock` ordering in `open_stream`.)
+    streams: BTreeMap<u32, StreamEntry>,
 
     /// Highest peer-initiated stream id seen so far. Peer-initiated (client) stream ids
     /// must be odd and strictly increasing.
@@ -206,7 +213,7 @@ where
             write_flush_pending: false,
             hpack: HpackDecoder::new(config.hpack_table_capacity()),
             hpack_encoder,
-            streams: HashMap::new(),
+            streams: BTreeMap::new(),
             last_peer_stream_id: 0,
             pending_headers: None,
             close_outcome: None,

--- a/http/src/h2/acceptor/recv.rs
+++ b/http/src/h2/acceptor/recv.rs
@@ -18,6 +18,7 @@ use super::{
 use crate::h2::{
     H2ErrorCode, H2Settings,
     frame::{FRAME_HEADER_LEN, Frame, FrameDecodeError, FrameHeader},
+    role::Role,
     stream_state::StreamEvent,
 };
 use futures_lite::io::{AsyncRead, AsyncWrite};
@@ -194,17 +195,27 @@ where
                     return Err(CloseOutcome::Protocol(H2ErrorCode::ProtocolError));
                 }
                 if let Some(entry) = self.streams.get(&stream_id) {
-                    // Move the stream to the terminal `Closed{Reset}` state before removing it, so
+                    // Move the stream to the terminal `Closed{Reset}` state before tearing down, so
                     // a handler parked on it re-polls to EOF / `BrokenPipe` rather than accepting
                     // writes into a ring the driver has stopped draining (silent data loss on an
-                    // upgraded stream). `complete_and_remove_stream` → `signal_close` then fires
-                    // the conn-task wakers so the parked handler actually
-                    // observes the close.
+                    // upgraded stream). `signal_close` then fires the conn-task wakers so the
+                    // parked handler actually observes the close.
+                    let recv_closed = entry.shared.lifecycle_lock().recv_closed();
                     let _ = entry.shared.apply_event(StreamEvent::RecvReset(error_code));
-                    self.complete_and_remove_stream(
-                        stream_id,
-                        Err(std::io::Error::other("peer RST_STREAM")),
-                    );
+                    if self.role == Role::Client && recv_closed {
+                        // The full response — including any trailers the driver already stashed —
+                        // arrived before this RST, which only aborts our still-open send half (a
+                        // server that responds without consuming the request body resets it with
+                        // NoError). Keep the stream in the map exactly as a clean close does, so
+                        // the application can still read the body to EOF and collect its trailers;
+                        // it's GC'd on transport drop.
+                        self.signal_close(stream_id, Err(std::io::Error::other("peer RST_STREAM")));
+                    } else {
+                        self.complete_and_remove_stream(
+                            stream_id,
+                            Err(std::io::Error::other("peer RST_STREAM")),
+                        );
+                    }
                 } else {
                     // Already closed from our side; still record (idempotent) so later
                     // stray peer frames on this id map to the right error category.

--- a/http/src/h2/acceptor/tests/client.rs
+++ b/http/src/h2/acceptor/tests/client.rs
@@ -9,10 +9,12 @@
 
 use super::fixture::*;
 use crate::{
-    Body, Headers, KnownHeaderName, Method, Status,
+    Body, Buffer, Headers, KnownHeaderName, Method, ProtocolSession, ReceivedBody,
+    ReceivedBodyState, Status,
     h2::{H2ErrorCode, H2Transport, SubmitSend, acceptor::types::DriverState, frame::Frame},
     headers::hpack::PseudoHeaders,
 };
+use futures_lite::io::AsyncRead;
 use std::{
     future::Future,
     net::Shutdown,
@@ -466,4 +468,76 @@ fn client_interim_response_with_end_stream_aborts_waiter() {
              surface a response; got {other:?}",
         ),
     }
+}
+
+/// Regression: a response carrying `content-length` must not let the body declare EOF (and
+/// harvest trailers) until the stream's `END_STREAM` arrives. In HTTP/2 the trailing HEADERS
+/// follow the DATA, so a body that ends the instant `content-length` is satisfied races the
+/// driver's trailer stash and loses — surfacing an empty trailer set. gRPC unary/client-stream
+/// responses set `content-length` (connect-go buffers them), which made the rotating conformance
+/// "empty trailers → Unknown" flake. `content-length: 0` (an empty/no-message response) is the
+/// deterministic case: the body would otherwise complete on the very first poll, before any
+/// trailer could possibly have arrived.
+#[test]
+fn content_length_response_defers_eof_until_end_stream_so_trailers_survive() {
+    let mut fx = DriverFixture::new_client();
+    fx.complete_handshake_client();
+    let (id, _submit, mut transport) = open_get(&mut fx);
+
+    // Response head: 200 with `content-length: 0`, NO END_STREAM — trailers still to come.
+    let pseudos = PseudoHeaders::default().with_status(Status::Ok);
+    let mut fields = Headers::new();
+    fields.insert(KnownHeaderName::ContentLength, "0");
+    fx.peer_headers(id, pseudos, &fields, false);
+    let _ = fx.tick();
+
+    // Read the response body exactly as trillium-client does: `content_length` from the head,
+    // an h2 protocol session so the End transition harvests trailers via `take_trailers`.
+    let mut buffer = Buffer::with_capacity(64);
+    let mut state = ReceivedBodyState::new_h2();
+    let mut received_trailers: Option<Headers> = None;
+    let mut body: ReceivedBody<'_, H2Transport> = ReceivedBody::new(
+        Some(0),
+        &mut buffer,
+        &mut transport,
+        &mut state,
+        None,
+        encoding_rs::UTF_8,
+    )
+    .with_protocol_session(ProtocolSession::Http2 {
+        connection: fx.connection.clone(),
+        stream_id: id,
+    })
+    .with_trailers(&mut received_trailers);
+
+    let waker = Waker::from(Arc::new(CountingWaker(AtomicUsize::new(0))));
+    let mut cx = Context::from_waker(&waker);
+    let mut buf = [0u8; 16];
+
+    // Before END_STREAM the body must park, not report EOF. With the content-length-terminal
+    // bug this returns `Ready(Ok(0))` on the first poll and harvests no trailers.
+    assert!(
+        Pin::new(&mut body).poll_read(&mut cx, &mut buf).is_pending(),
+        "body must not declare EOF on content-length alone before END_STREAM (would lose trailers)",
+    );
+
+    // Trailing HEADERS (END_STREAM) arrive carrying grpc-status.
+    let mut trailers = Headers::new();
+    trailers.insert("grpc-status", "0");
+    fx.peer_trailers(id, &trailers);
+    let _ = fx.tick();
+
+    // Now the body reaches EOF and surfaces the trailers it had to wait for.
+    assert!(
+        matches!(
+            Pin::new(&mut body).poll_read(&mut cx, &mut buf),
+            Poll::Ready(Ok(0))
+        ),
+        "body should reach clean EOF once END_STREAM has arrived",
+    );
+    assert_eq!(
+        received_trailers.as_ref().and_then(|t| t.get_str("grpc-status")),
+        Some("0"),
+        "trailers delivered with END_STREAM must be surfaced through the body, not dropped",
+    );
 }

--- a/http/src/h2/acceptor/tests/client.rs
+++ b/http/src/h2/acceptor/tests/client.rs
@@ -9,7 +9,7 @@
 
 use super::fixture::*;
 use crate::{
-    Headers, KnownHeaderName, Method, Status,
+    Body, Headers, KnownHeaderName, Method, Status,
     h2::{H2ErrorCode, H2Transport, SubmitSend, acceptor::types::DriverState, frame::Frame},
     headers::hpack::PseudoHeaders,
 };
@@ -258,6 +258,62 @@ fn client_parked_in_closing_is_rewoken_by_late_rst() {
         wakes_after > wakes_before,
         "an RST arriving after the driver parked in Closing must re-wake the driver task (was \
          {wakes_before}, now {wakes_after}); no wake means the lost-wake deadlock",
+    );
+}
+
+/// Regression: when the client has already received the full response — including trailers —
+/// and the server then sends `RST_STREAM(NoError)` (because the client's request/send half was
+/// still open), the already-received trailers must still be surfaced. The RST path used to
+/// remove the stream from the map outright, so the body's EOF `take_trailers` found nothing and
+/// the application saw a clean EOF with no trailers.
+#[test]
+fn server_rst_after_trailers_preserves_trailers_while_send_half_open() {
+    let mut fx = DriverFixture::new_client();
+    fx.complete_handshake_client();
+
+    // A request whose body is larger than the peer's default 65535-byte initial window: after
+    // HEADERS + one full window of DATA the send half is still Open (the body can't finish
+    // until the peer grants more window, which it never does).
+    let pseudos = PseudoHeaders::default()
+        .with_method(Method::Post)
+        .with_path("/")
+        .with_scheme("http")
+        .with_authority("test");
+    let (id, _submit, _transport) = fx
+        .connection
+        .open_stream(
+            pseudos,
+            Headers::new(),
+            Some(Body::new_static(vec![0u8; 70_000])),
+        )
+        .expect("open_stream on a running client connection");
+    let _ = fx.tick();
+    let _ = fx.next_outbound_frames();
+
+    // Full response: HEADERS (no END_STREAM) then a trailing HEADERS (END_STREAM).
+    fx.peer_response_headers(id, Status::Ok, false);
+    let _ = fx.tick();
+    let mut trailers = Headers::new();
+    trailers.insert("grpc-status", "0");
+    fx.peer_trailers(id, &trailers);
+    let _ = fx.tick();
+
+    assert!(
+        fx.connection.streams_lock().contains_key(&id),
+        "stream should still be tracked after receiving trailers (send half still open)",
+    );
+
+    // The server resets our still-open send half with NoError — it has what it needs and
+    // doesn't want the rest of the request body.
+    fx.peer_rst_stream(id, H2ErrorCode::NoError);
+    let _ = fx.tick();
+
+    // The trailers received before the RST must still be retrievable — this is exactly what
+    // `ReceivedBody` calls at EOF to populate `conn.response_trailers`.
+    let recovered = fx.connection.take_trailers(id);
+    assert!(
+        recovered.is_some_and(|t| t.get_str("grpc-status") == Some("0")),
+        "trailers received before RST_STREAM(NoError) must be preserved, not discarded",
     );
 }
 

--- a/http/src/h2/acceptor/tests/client.rs
+++ b/http/src/h2/acceptor/tests/client.rs
@@ -517,7 +517,9 @@ fn content_length_response_defers_eof_until_end_stream_so_trailers_survive() {
     // Before END_STREAM the body must park, not report EOF. With the content-length-terminal
     // bug this returns `Ready(Ok(0))` on the first poll and harvests no trailers.
     assert!(
-        Pin::new(&mut body).poll_read(&mut cx, &mut buf).is_pending(),
+        Pin::new(&mut body)
+            .poll_read(&mut cx, &mut buf)
+            .is_pending(),
         "body must not declare EOF on content-length alone before END_STREAM (would lose trailers)",
     );
 
@@ -536,7 +538,9 @@ fn content_length_response_defers_eof_until_end_stream_so_trailers_survive() {
         "body should reach clean EOF once END_STREAM has arrived",
     );
     assert_eq!(
-        received_trailers.as_ref().and_then(|t| t.get_str("grpc-status")),
+        received_trailers
+            .as_ref()
+            .and_then(|t| t.get_str("grpc-status")),
         Some("0"),
         "trailers delivered with END_STREAM must be surfaced through the body, not dropped",
     );

--- a/http/src/h2/acceptor/tests/recv_headers.rs
+++ b/http/src/h2/acceptor/tests/recv_headers.rs
@@ -549,9 +549,11 @@ fn request_content_length_defers_eof_until_end_stream_so_trailers_survive() {
     {
         let mut body = conn.request_body();
         assert!(
-            Pin::new(&mut body).poll_read(&mut cx, &mut buf).is_pending(),
-            "request body must not declare EOF on content-length alone before END_STREAM \
-             (would lose trailers)",
+            Pin::new(&mut body)
+                .poll_read(&mut cx, &mut buf)
+                .is_pending(),
+            "request body must not declare EOF on content-length alone before END_STREAM (would \
+             lose trailers)",
         );
     }
 
@@ -573,7 +575,9 @@ fn request_content_length_defers_eof_until_end_stream_so_trailers_survive() {
         );
     }
     assert_eq!(
-        conn.request_trailers.as_ref().and_then(|t| t.get_str("x-trailer")),
+        conn.request_trailers
+            .as_ref()
+            .and_then(|t| t.get_str("x-trailer")),
         Some("present"),
         "request trailers delivered with END_STREAM must be surfaced, not dropped",
     );

--- a/http/src/h2/acceptor/tests/recv_headers.rs
+++ b/http/src/h2/acceptor/tests/recv_headers.rs
@@ -11,7 +11,11 @@ use crate::{
     h2::{H2ErrorCode, frame::Frame},
     headers::hpack::PseudoHeaders,
 };
-use std::task::Poll;
+use futures_lite::io::AsyncRead;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 /// True if any frame in the batch is a `GOAWAY` carrying `code`.
 fn goaway_with(frames: &[Frame], code: H2ErrorCode) -> bool {
@@ -513,5 +517,64 @@ fn data_matching_content_length_is_accepted() {
     assert!(
         fx.connection.streams_lock().contains_key(&1),
         "a well-formed request stream should remain open for its response",
+    );
+}
+
+/// Server-role dual of trillium-http's client-side
+/// `content_length_response_defers_eof_until_end_stream_so_trailers_survive`: a *request* body
+/// that advertises `content-length` must not let `request_body()` report end-of-input (and
+/// harvest request trailers) until the peer's `END_STREAM`. In HTTP/2 a request may carry
+/// trailing HEADERS after its DATA, so a body that ends the instant `content-length` is
+/// satisfied would complete before the trailers arrive and drop them. `content-length: 0` is the
+/// deterministic case — the body would otherwise complete on its very first poll.
+#[test]
+fn request_content_length_defers_eof_until_end_stream_so_trailers_survive() {
+    let mut fx = DriverFixture::new_server();
+    fx.complete_handshake();
+
+    // Peer opens a POST declaring `content-length: 0` with NO END_STREAM — trailers still to come.
+    let (pseudos, fields) = post_with_content_length(0);
+    fx.peer_headers(1, pseudos, &fields, false);
+    let mut conn = match fx.tick() {
+        Poll::Ready(Some(Ok(conn))) => conn,
+        other => panic!("expected Conn for stream 1, got {other:?}"),
+    };
+
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    let mut buf = [0u8; 16];
+
+    // Before END_STREAM the request body must park, not report EOF. With the content-length-
+    // terminal bug this returns `Ready(Ok(0))` on the first poll and harvests no trailers.
+    {
+        let mut body = conn.request_body();
+        assert!(
+            Pin::new(&mut body).poll_read(&mut cx, &mut buf).is_pending(),
+            "request body must not declare EOF on content-length alone before END_STREAM \
+             (would lose trailers)",
+        );
+    }
+
+    // Trailing HEADERS (END_STREAM) arrive carrying a request trailer.
+    let mut trailers = Headers::new();
+    trailers.insert("x-trailer", "present");
+    fx.peer_trailers(1, &trailers);
+    let _ = fx.tick();
+
+    // Now the body reaches clean EOF and the trailers it had to wait for are on the Conn.
+    {
+        let mut body = conn.request_body();
+        assert!(
+            matches!(
+                Pin::new(&mut body).poll_read(&mut cx, &mut buf),
+                Poll::Ready(Ok(0))
+            ),
+            "request body should reach clean EOF once END_STREAM has arrived",
+        );
+    }
+    assert_eq!(
+        conn.request_trailers.as_ref().and_then(|t| t.get_str("x-trailer")),
+        Some("present"),
+        "request trailers delivered with END_STREAM must be surfaced, not dropped",
     );
 }

--- a/http/src/h2/acceptor/tests/two_driver.rs
+++ b/http/src/h2/acceptor/tests/two_driver.rs
@@ -87,6 +87,55 @@ fn client_get_pseudos() -> PseudoHeaders<'static> {
         .with_authority("test")
 }
 
+/// Several client requests opened back-to-back before the driver runs must reach the wire with
+/// their opening HEADERS in ascending stream-id order — RFC 9113 §5.1.1 requires a client to
+/// open streams in monotonically increasing order, and a peer rejects an out-of-order open with
+/// `GOAWAY(PROTOCOL_ERROR)`, tearing down the whole connection. Regression for concurrent
+/// `open_stream` calls being framed in (nondeterministic) hash order rather than id order.
+#[test]
+fn concurrent_client_streams_open_in_id_order() {
+    let mut d = TwoDrivers::new();
+    d.pump();
+    assert_eq!(d.client.state, DriverState::Running, "client handshake");
+    assert_eq!(d.server.state, DriverState::Running, "server handshake");
+
+    // Stage a batch of requests with no driver step in between, so they're all queued before the
+    // send pump frames any of them — the case where pickup/framing order decides wire order.
+    const N: usize = 8;
+    let handles: Vec<_> = (0..N)
+        .map(|_| {
+            d.client_conn
+                .open_stream(client_get_pseudos(), Headers::new(), None)
+                .expect("open_stream on a running client connection")
+        })
+        .collect();
+    let ids: Vec<u32> = handles.iter().map(|(id, _, _)| *id).collect();
+    assert_eq!(
+        ids,
+        vec![1, 3, 5, 7, 9, 11, 13, 15],
+        "client ids are sequential odd"
+    );
+
+    let conns = d.pump();
+
+    // The server accepts every stream and never errors: out-of-order opening HEADERS would have
+    // drawn a connection-level PROTOCOL_ERROR before all N streams were yielded.
+    assert_eq!(
+        conns.len(),
+        N,
+        "server should yield a Conn for every opened stream"
+    );
+    assert!(
+        d.server.close_outcome.is_none() && d.server.state == DriverState::Running,
+        "server must not protocol-error on the stream opens (state={:?}, outcome={:?})",
+        d.server.state,
+        d.server.close_outcome,
+    );
+
+    // Held so the streams aren't reset by a local drop before the assertions above.
+    drop(handles);
+}
+
 /// Trace-faithful reproduction: client opens a request, server yields the `Conn`, then both
 /// peers abandon the stream at once (each drops its transport → `RST_STREAM(Cancel)`) while
 /// the server begins a graceful shutdown. Both drivers must finish their close-out; a driver

--- a/http/src/h2/connection.rs
+++ b/http/src/h2/connection.rs
@@ -96,6 +96,14 @@ pub struct H2Connection {
     /// `+= 2` per allocation. Capped at `2^31` — once exhausted, `fetch_update`'s closure
     /// refuses to advance, and `open_stream` returns `None` (the caller is expected to
     /// fail over to a fresh connection).
+    ///
+    /// Allocation happens **while holding `streams_lock`** (see `open_stream`), so id order
+    /// matches shared-map insertion order — the invariant the BTreeMap-ordered send pump
+    /// relies on to frame opening HEADERS in monotonic order (RFC 9113 §5.1.1). The lock,
+    /// not the atomic, is what orders allocations; the `AtomicU32` is just the interior
+    /// mutability this `Arc`-shared field needs, so `Relaxed` suffices. The one out-of-band
+    /// reader (`can_open_stream`'s exhaustion check) takes `streams_lock` immediately after,
+    /// so its `load` is an advisory fast-path, not a separately-synchronized access.
     #[cfg(feature = "unstable")]
     pub(super) next_client_stream_id: std::sync::atomic::AtomicU32,
     /// Outstanding active PINGs awaiting ACKs, keyed by opaque payload. Completed by the

--- a/http/src/h2/connection/submit.rs
+++ b/http/src/h2/connection/submit.rs
@@ -273,13 +273,6 @@ impl H2Connection {
             return None;
         }
 
-        let stream_id = self
-            .next_client_stream_id
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
-                (n < (1u32 << 31)).then_some(n + 2)
-            })
-            .ok()?;
-
         let state = Arc::new(StreamState::default());
 
         // Stage the request parts *before* publishing the stream id to the shared map so they're
@@ -287,7 +280,25 @@ impl H2Connection {
         // needed to start framing. A non-upgrade request closes after its body; an extended-CONNECT
         // bootstrap stays open.
         state.stage(submission_parts(pseudos, headers, body, !is_upgrade));
-        self.streams_lock().insert(stream_id, state.clone());
+
+        // Allocate the id and publish the stream *atomically under the shared map lock*. The id and
+        // its wire HEADERS must go out in monotonically increasing order (RFC 9113 §5.1.1); holding
+        // the lock across allocation + insertion means a concurrent opener can't allocate a higher
+        // id and make it visible to the driver while this lower id is still mid-publish — which
+        // would let the driver frame the higher id's HEADERS first and trip GOAWAY(PROTOCOL_ERROR).
+        // (The driver completes the guarantee by framing streams in id order — see the `BTreeMap`
+        // streams table in the acceptor.)
+        let stream_id = {
+            let mut streams = self.streams_lock();
+            let stream_id = self
+                .next_client_stream_id
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+                    (n < (1u32 << 31)).then_some(n + 2)
+                })
+                .ok()?;
+            streams.insert(stream_id, state.clone());
+            stream_id
+        };
         log::trace!("h2 client: open_stream allocated stream {stream_id} (upgrade={is_upgrade})");
         self.outbound_waker.wake();
         let transport = H2Transport::new(Arc::clone(self), stream_id, state.clone());

--- a/http/src/received_body.rs
+++ b/http/src/received_body.rs
@@ -355,6 +355,17 @@ impl<T> ReceivedBody<'static, T> {
 }
 
 impl<T> ReceivedBody<'_, T> {
+    /// Borrow the trailers decoded from this body, if any. Unlike [`BodySource::trailers`],
+    /// this does not take them. Only `Some` after the body has been read to end-of-stream on
+    /// a protocol that carried a trailer section.
+    ///
+    /// [`BodySource::trailers`]: crate::BodySource::trailers
+    #[doc(hidden)]
+    #[cfg(feature = "unstable")]
+    pub fn trailers_ref(&self) -> Option<&Headers> {
+        self.trailers.as_ref()
+    }
+
     /// Retype as `ReceivedBody<'static, T>` if every internal `MutCow` field is `Owned`.
     ///
     /// Returns `None` if any field is `Borrowed`, in which case `self` is dropped — the

--- a/http/src/received_body/raw.rs
+++ b/http/src/received_body/raw.rs
@@ -2,7 +2,7 @@ use super::{
     AsyncRead, AsyncWrite, Context, End, ErrorKind, Ready, ReceivedBody, ReceivedBodyState,
     StateOutput, io, ready,
 };
-use crate::h2::H2ErrorCode;
+use crate::{ProtocolSession, h2::H2ErrorCode};
 
 impl<Transport> ReceivedBody<'_, Transport>
 where
@@ -21,7 +21,17 @@ where
         buf: &mut [u8],
         total: u64,
     ) -> StateOutput {
-        let buf = if let Some(expected) = self.content_length {
+        // Whether `content-length` *frames* the body (so it's terminal) or is merely advisory.
+        // In h1, content-length defines the body length and the next request's bytes follow on
+        // the same transport, so we clamp reads to the declared length and end on it. In h2/h3
+        // the driver demuxes DATA per stream and the authoritative end-of-body is the stream's
+        // `END_STREAM` — after which a trailing HEADERS frame may still deliver trailers. Ending
+        // on content-length there would complete the body *before* the trailers arrive and drop
+        // them (the gRPC unary/client-stream "empty trailers → Unknown" race). content-length
+        // stays a cross-check, validated against the byte total at EOF below.
+        let length_is_terminal = matches!(self.protocol_session, ProtocolSession::Http1);
+
+        let buf = if let Some(expected) = self.content_length.filter(|_| length_is_terminal) {
             let remaining = usize::try_from(expected - total).unwrap_or(usize::MAX);
             let len = buf.len().min(remaining);
             &mut buf[..len]
@@ -47,7 +57,8 @@ where
         if total > self.max_len {
             return self.protocol_error(ErrorKind::Unsupported, "content too long".into());
         }
-        if let Some(expected) = self.content_length
+        if length_is_terminal
+            && let Some(expected) = self.content_length
             && total == expected
         {
             return Ready(Ok((End, bytes)));


### PR DESCRIPTION
## trillium-client

### Added

- `ResponseBody::trailers(&self) -> Option<&Headers>` borrows the trailers received after the
  response body, on both borrowed and owned response bodies. Populated after the body has been
  read to end-of-stream.

### Fixed

- HTTP/2: a received body that carried a `content-length` header could report end-of-input before
  the stream's trailing headers arrived, so `request_trailers()` (server) / `response_trailers()`
  (client) came back empty even though the peer had sent trailers. The effect was a timing-dependent
  race condition. Bodies now wait for the end of the stream before reporting end-of-input, so the
  trailers are always delivered.
- HTTP/2 and HTTP/3 response trailers are now surfaced on the owned response body taken via
  `Conn::take_response_body` (and the `From<Conn> for Body` proxy path). Previously the protocol
  session wasn't carried onto the detached body, so driver-decoded trailers were never harvested,
  and even when present they were discarded by the body's EOF recycle before a caller could read
  them. The borrowed `Conn::response_body` path was unaffected.
- HTTP/2: response trailers could go missing when talking to a server that responds and resets the
  stream before reading the full request body — the body ended cleanly but the trailers the server
  had already sent were dropped. Trailers are now delivered in this case.
- HTTP/2: issuing several requests concurrently through one `Client` to the same origin could abort
  the connection with a protocol error, failing those requests and any others in flight on the same
  connection with a connection-aborted error. Concurrent requests over a shared connection now
  proceed normally.


## trillium-http

### Fixed

- HTTP/2: a received body that carried a `content-length` header could report end-of-input before
  the stream's trailing headers arrived, so `request_trailers()` (server) / `response_trailers()`
  (client) came back empty even though the peer had sent trailers. The effect was a timing-dependent
  race condition. Bodies now wait for the end of the stream before reporting end-of-input, so the
  trailers are always delivered.
