### PR TITLE
Some more conformance work

### DIFF
--- a/http/CHANGELOG.md
+++ b/http/CHANGELOG.md
@@ -4,7 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.4.1] - 2026-06-06
+## [1.3.7] - 2026-06-10
+
+The theme of this release is HTTP/1.x SHOULD-level conformance.
+
+### Changed
+
+- An HTTP/1.x request-line that can't be parsed returns a `400 Bad Request` instead of closing the
+  connection.
+- An HTTP/1.x request-target containing `#` or `\` is now rejected with `400 Bad Request`.
+- Leading empty lines before a HTTP/1.x request-line are now ignored.
+- An HTTP/1.x request carrying an `Expect` field-value other than `100-continue` is now answered
+  with `417 Expectation Failed` rather than silently ignored.
+
+## [1.3.6] - 2026-06-06
 
 The theme of this release is improved HTTP/2 flow control, informed by in-the-wild peer behavior.
 
@@ -20,7 +33,7 @@ The theme of this release is improved HTTP/2 flow control, informed by in-the-wi
   overruns were tolerated). If `h2_max_stream_recv_window_size` is configured below
   `h2_initial_stream_window_size` it is raised to match it, with a warning logged.
 
-## [1.4.0] - 2026-06-05
+## [1.3.5] - 2026-06-05
 
 The theme of this release is protocol correctness / conformance, with a focus on http/1.x.
 

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-http"
-version = "1.3.6"
+version = "1.3.7"
 edition = "2024"
 description = "the http implementation for the trillium toolkit"
 license = "MIT OR Apache-2.0"

--- a/http/src/conn/h1.rs
+++ b/http/src/conn/h1.rs
@@ -2,9 +2,9 @@ use crate::{
     BufWriter, Buffer, Conn, ConnectionStatus, Error, Headers, HttpContext, KnownHeaderName,
     Method, ProtocolSession, ReceivedBody, Result, Status, TypeSet, Version,
     after_send::AfterSend,
-    conn::ReceivedBodyState,
+    conn::{ReceivedBodyState, shared::authority_matches_host},
     headers::date::current_date_header,
-    util::{encoding, is_tchar},
+    util::encoding,
 };
 use futures_lite::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use memchr::memmem::Finder;
@@ -187,9 +187,19 @@ where
 
         crate::util::validate_content_length(content_length)?;
 
-        // An HTTP/1.1 request must carry exactly one Host (CONNECT carries its authority in the
-        // request target instead), and a present Host must be a bare host[:port] — no userinfo
-        // (`@`), path (`/`), comma-list, empty value, or whitespace.
+        if let Some(expect) = request_headers.get_values(KnownHeaderName::Expect) {
+            let all_continue = expect.iter().all(|value| {
+                value.as_str().is_some_and(|value| {
+                    value
+                        .split(',')
+                        .all(|token| token.trim().eq_ignore_ascii_case("100-continue"))
+                })
+            });
+            if !all_continue {
+                return Err(Error::ExpectationFailed);
+            }
+        }
+
         match request_headers.get_values(KnownHeaderName::Host) {
             None => {
                 if version == Version::Http1_1 && method != Method::Connect {
@@ -215,17 +225,17 @@ where
     /// Validate the request target. The asterisk-form (`*`) is only valid for `OPTIONS`. When
     /// absolute-form supplied an authority, it must agree with the `Host` header.
     fn validate_request_target(&self) -> Result<()> {
-        use super::shared::authority_matches_host;
-
-        // By this point the only well-formed targets are origin-form (path starts with `/`;
-        // absolute-form was reconstructed to it in `parse_head`), asterisk-form (`*`, OPTIONS
-        // only), and authority-form (CONNECT, whose path was set to `/`). Anything else — a
-        // rootless relative target like `foo` — is malformed.
         if &*self.path == "*" {
             if self.method != Method::Options {
                 return Err(Error::InvalidHead);
             }
-        } else if self.method != Method::Connect && !self.path.starts_with('/') {
+        } else if self.method == Method::Connect {
+            // authority-form; path was normalized to `/` in parse_head — nothing to validate here.
+        } else if self.path.starts_with('/') {
+            if self.path.contains(['#', '\\']) {
+                return Err(Error::InvalidHead);
+            }
+        } else {
             return Err(Error::InvalidHead);
         }
 
@@ -253,11 +263,6 @@ where
             .find(&buffer)
             .ok_or(HeadError::Fatal(Error::InvalidHead))?;
 
-        // `head()` has already required a CRLF-terminated head, so binary garbage (TLS, etc.) never
-        // reaches here. A line we still can't tokenize into `method SP target SP version` isn't
-        // recognizably a request-line and is closed (Fatal); a tokenizable line always yields a
-        // `RequestLine`, with any component-level violation carried in `error` to answer with an
-        // error-appropriate status rather than closing.
         let RequestLine {
             method,
             path,
@@ -265,7 +270,7 @@ where
             scheme,
             version,
             error: mut first_error,
-        } = RequestLine::parse(&buffer[..first_line_index]).map_err(HeadError::Fatal)?;
+        } = RequestLine::parse(&buffer[..first_line_index]);
 
         let mut request_headers = Headers::new();
         if let Err(e) = request_headers.extend_parse(&buffer[first_line_index + 2..head_size]) {
@@ -341,25 +346,31 @@ where
         buf: &mut Buffer,
         context: &HttpContext,
     ) -> Result<(usize, Instant)> {
-        let mut len = 0;
+        // `total` is the active byte count; `scanned` is how much of it the finder has already
+        // covered, so each read only rescans the 3-byte tail overlap plus the new bytes.
+        let mut total = 0;
+        let mut scanned = 0;
         let mut start_with_read = buf.is_empty();
         let mut instant = None;
+        // Leading empty lines discarded before the request-line (RFC 9112 §2.2). Counted against
+        // head_max_len so a peer streaming bare CRLFs hits the limit rather than looping forever.
+        let mut leading_skipped = 0;
         let finder = Finder::new(b"\r\n\r\n");
         loop {
-            if len >= context.config.head_max_len {
+            if total + leading_skipped >= context.config.head_max_len {
                 return Err(Error::HeadersTooLong);
             }
 
             let bytes = if start_with_read {
                 buf.expand();
-                if len == 0 {
+                if total == 0 {
                     context
                         .swansong
                         .interrupt(transport.read(buf))
                         .await
                         .ok_or(Error::Closed)??
                 } else {
-                    transport.read(&mut buf[len..]).await?
+                    transport.read(&mut buf[total..]).await?
                 }
             } else {
                 start_with_read = true;
@@ -370,23 +381,29 @@ where
                 instant = Some(Instant::now());
             }
 
-            let search_start = len.max(3) - 3;
-            let search = finder.find(&buf[search_start..]);
-
-            if let Some(index) = search {
-                buf.truncate(len + bytes);
-                return Ok((search_start + index + 4, instant.unwrap()));
-            }
-
-            len += bytes;
-
             if bytes == 0 {
-                return if len == 0 {
+                return if total == 0 {
                     Err(Error::Closed)
                 } else {
                     Err(Error::InvalidHead)
                 };
             }
+
+            total += bytes;
+
+            while buf[..total].starts_with(b"\r\n") {
+                buf.ignore_front(2);
+                total -= 2;
+                scanned = 0;
+                leading_skipped += 2;
+            }
+
+            let search_start = scanned.max(3) - 3;
+            if let Some(index) = finder.find(&buf[search_start..total]) {
+                buf.truncate(total);
+                return Ok((search_start + index + 4, instant.unwrap()));
+            }
+            scanned = total;
         }
     }
 
@@ -544,35 +561,22 @@ struct RequestLine {
 }
 
 impl RequestLine {
-    /// Parse the request-line bytes (everything before the first CRLF). Returns `Err` only when the
-    /// line can't be tokenized into `method SP target SP version` — an unrecognizable line the
-    /// caller closes. A tokenizable line always returns `Ok`, with any malformed component
-    /// defaulted and recorded in `error`.
-    fn parse(first_line: &[u8]) -> Result<Self> {
+    fn parse(first_line: &[u8]) -> Self {
         let mut spaces = memchr::memchr_iter(b' ', first_line);
-        let first_space = spaces.next().ok_or(Error::MissingMethod)?;
-        let second_space = spaces.next().ok_or(Error::RequestPathMissing)?;
+        let Some(first_space) = spaces.next() else {
+            return Self::malformed(Error::MissingMethod);
+        };
+        let Some(second_space) = spaces.next() else {
+            return Self::malformed(Error::RequestPathMissing);
+        };
 
         let mut error: Option<Error> = None;
 
-        // The method token is case-sensitive. `Method::parse` is lenient (it also
-        // backs the h2/h3 `:method` pseudo), so a well-formed but unknown or non-canonically-cased
-        // method is unimplemented (→ 501). A method that isn't a valid `token` at all — empty, or
-        // carrying a non-tchar octet — is a malformed request-line (→ 400), not an unimplemented
-        // method.
         let method_bytes = &first_line[..first_space];
         let method = match Method::parse(method_bytes) {
-            Ok(method) if method.as_str().as_bytes() == method_bytes => method,
-            _ => {
-                error = Some(
-                    if !method_bytes.is_empty() && method_bytes.iter().all(|&b| is_tchar(b)) {
-                        Error::UnrecognizedMethod(
-                            String::from_utf8_lossy(method_bytes).into_owned(),
-                        )
-                    } else {
-                        Error::InvalidHead
-                    },
-                );
+            Ok(method) => method,
+            Err(e) => {
+                error = Some(e);
                 Method::Get
             }
         };
@@ -588,14 +592,11 @@ impl RequestLine {
         let target = &first_line[first_space + 1..second_space];
         let mut authority = None;
         let mut scheme = None;
-        // A request target is a URI, defined over a limited ASCII set: only printable
-        // ASCII (0x21..=0x7e). This rejects controls, space, DEL, and raw non-ASCII (which must be
-        // percent-encoded); we don't do full URI-grammar validation beyond that.
+
         let path = if target.is_empty() || target.iter().any(|&b| !(0x21..=0x7e).contains(&b)) {
             error.get_or_insert(Error::InvalidHead);
             Cow::Borrowed("/")
         } else {
-            // every byte is printable ASCII, so this conversion cannot fail
             let target = std::str::from_utf8(target).unwrap_or("/");
             if method == Method::Connect {
                 authority = Some(Cow::Owned(target.to_string()));
@@ -607,27 +608,33 @@ impl RequestLine {
             } else if let Some((parsed_scheme, parsed_authority, parsed_path)) =
                 split_absolute_form(target)
             {
-                // Absolute-form: split scheme/authority off and reconstruct
-                // origin-form so routing sees the same path it would for origin-form, mirroring how
-                // h2/h3 carry `:scheme`/`:authority`/`:path`.
                 scheme = Some(Cow::Owned(parsed_scheme));
                 authority = Some(Cow::Owned(parsed_authority));
                 Cow::Owned(parsed_path)
             } else {
-                // A non-origin, non-asterisk, non-absolute target — rootless and malformed. Carried
-                // as-is and rejected by `validate_request_target`.
                 Cow::Owned(target.to_string())
             }
         };
 
-        Ok(Self {
+        Self {
             method,
             path,
             authority,
             scheme,
             version,
             error,
-        })
+        }
+    }
+
+    fn malformed(error: Error) -> Self {
+        Self {
+            method: Method::Get,
+            path: Cow::Borrowed("/"),
+            authority: None,
+            scheme: None,
+            version: Version::Http1_1,
+            error: Some(error),
+        }
     }
 }
 
@@ -635,6 +642,7 @@ impl RequestLine {
 fn status_for_error(error: &Error) -> Status {
     match error {
         Error::UnrecognizedMethod(_) => Status::NotImplemented,
+        Error::ExpectationFailed => Status::ExpectationFailed,
         _ => Status::BadRequest,
     }
 }

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -60,6 +60,10 @@ pub enum Error {
     #[error("Missing method")]
     MissingMethod,
 
+    /// the request carried an `Expect` value that we do not handle
+    #[error("Unsupported expectation")]
+    ExpectationFailed,
+
     /// this request did not have a status code
     #[error("Missing status code")]
     MissingStatus,
@@ -92,8 +96,8 @@ pub enum Error {
     TimedOut(&'static str, Duration),
 
     /// HTTP/2 peer has not advertised `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1`, so an
-    /// extended-CONNECT (e.g. WebSocket-over-h2) request cannot be sent on this connection.
-    #[error("HTTP/2 peer does not support extended CONNECT (RFC 8441)")]
+    /// extended-CONNECT request cannot be sent on this connection.
+    #[error("HTTP/2 peer does not support extended CONNECT")]
     ExtendedConnectUnsupported,
 
     /// An error from middleware or other application-level code, type-erased into a boxed

--- a/http/src/method.rs
+++ b/http/src/method.rs
@@ -1,4 +1,5 @@
 // originally from https://github.com/http-rs/http-types/blob/main/src/method.rs
+use crate::{Error, util::is_tchar};
 use std::{
     fmt::{self, Display},
     str::{self, FromStr},
@@ -434,9 +435,57 @@ impl Method {
     }
 
     pub(crate) fn parse(bytes: &[u8]) -> crate::Result<Self> {
-        str::from_utf8(bytes)
-            .map_err(|_| crate::Error::UnrecognizedMethod(String::from_utf8_lossy(bytes).into()))?
-            .parse()
+        match bytes {
+            b"GET" => Ok(Self::Get),
+            b"OPTIONS" => Ok(Self::Options),
+            b"POST" => Ok(Self::Post),
+            b"PUT" => Ok(Self::Put),
+            b"PATCH" => Ok(Self::Patch),
+            b"DELETE" => Ok(Self::Delete),
+            b"HEAD" => Ok(Self::Head),
+            b"ACL" => Ok(Self::Acl),
+            b"BASELINE-CONTROL" => Ok(Self::BaselineControl),
+            b"BIND" => Ok(Self::Bind),
+            b"CHECKIN" => Ok(Self::Checkin),
+            b"CHECKOUT" => Ok(Self::Checkout),
+            b"CONNECT" => Ok(Self::Connect),
+            b"COPY" => Ok(Self::Copy),
+            b"LABEL" => Ok(Self::Label),
+            b"LINK" => Ok(Self::Link),
+            b"LOCK" => Ok(Self::Lock),
+            b"MERGE" => Ok(Self::Merge),
+            b"MKACTIVITY" => Ok(Self::MkActivity),
+            b"MKCALENDAR" => Ok(Self::MkCalendar),
+            b"MKCOL" => Ok(Self::MkCol),
+            b"MKREDIRECTREF" => Ok(Self::MkRedirectRef),
+            b"MKWORKSPACE" => Ok(Self::MkWorkspace),
+            b"MOVE" => Ok(Self::Move),
+            b"ORDERPATCH" => Ok(Self::OrderPatch),
+            b"PRI" => Ok(Self::Pri),
+            b"PROPFIND" => Ok(Self::PropFind),
+            b"PROPPATCH" => Ok(Self::PropPatch),
+            b"QUERY" => Ok(Self::Query),
+            b"REBIND" => Ok(Self::Rebind),
+            b"REPORT" => Ok(Self::Report),
+            b"SEARCH" => Ok(Self::Search),
+            b"TRACE" => Ok(Self::Trace),
+            b"UNBIND" => Ok(Self::Unbind),
+            b"UNCHECKOUT" => Ok(Self::Uncheckout),
+            b"UNLINK" => Ok(Self::Unlink),
+            b"UNLOCK" => Ok(Self::Unlock),
+            b"UPDATE" => Ok(Self::Update),
+            b"UPDATEREDIRECTREF" => Ok(Self::UpdateRedirectRef),
+            b"VERSION-CONTROL" => Ok(Self::VersionControl),
+            _ => {
+                if !bytes.is_empty() && bytes.iter().all(|&b| is_tchar(b)) {
+                    Err(Error::UnrecognizedMethod(
+                        String::from_utf8_lossy(bytes).into_owned(),
+                    ))
+                } else {
+                    Err(Error::InvalidHead)
+                }
+            }
+        }
     }
 }
 
@@ -447,57 +496,15 @@ impl Display for Method {
 }
 
 impl FromStr for Method {
-    type Err = crate::Error;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match &*s.to_ascii_uppercase() {
-            "GET" => Ok(Self::Get),
-            "OPTIONS" => Ok(Self::Options),
-            "POST" => Ok(Self::Post),
-            "PUT" => Ok(Self::Put),
-            "PATCH" => Ok(Self::Patch),
-            "DELETE" => Ok(Self::Delete),
-            "HEAD" => Ok(Self::Head),
-            "ACL" => Ok(Self::Acl),
-            "BASELINE-CONTROL" => Ok(Self::BaselineControl),
-            "BIND" => Ok(Self::Bind),
-            "CHECKIN" => Ok(Self::Checkin),
-            "CHECKOUT" => Ok(Self::Checkout),
-            "CONNECT" => Ok(Self::Connect),
-            "COPY" => Ok(Self::Copy),
-            "LABEL" => Ok(Self::Label),
-            "LINK" => Ok(Self::Link),
-            "LOCK" => Ok(Self::Lock),
-            "MERGE" => Ok(Self::Merge),
-            "MKACTIVITY" => Ok(Self::MkActivity),
-            "MKCALENDAR" => Ok(Self::MkCalendar),
-            "MKCOL" => Ok(Self::MkCol),
-            "MKREDIRECTREF" => Ok(Self::MkRedirectRef),
-            "MKWORKSPACE" => Ok(Self::MkWorkspace),
-            "MOVE" => Ok(Self::Move),
-            "ORDERPATCH" => Ok(Self::OrderPatch),
-            "PRI" => Ok(Self::Pri),
-            "PROPFIND" => Ok(Self::PropFind),
-            "PROPPATCH" => Ok(Self::PropPatch),
-            "QUERY" => Ok(Self::Query),
-            "REBIND" => Ok(Self::Rebind),
-            "REPORT" => Ok(Self::Report),
-            "SEARCH" => Ok(Self::Search),
-            "TRACE" => Ok(Self::Trace),
-            "UNBIND" => Ok(Self::Unbind),
-            "UNCHECKOUT" => Ok(Self::Uncheckout),
-            "UNLINK" => Ok(Self::Unlink),
-            "UNLOCK" => Ok(Self::Unlock),
-            "UPDATE" => Ok(Self::Update),
-            "UPDATEREDIRECTREF" => Ok(Self::UpdateRedirectRef),
-            "VERSION-CONTROL" => Ok(Self::VersionControl),
-            _ => Err(crate::Error::UnrecognizedMethod(s.to_string())),
-        }
+        Self::parse(s.to_ascii_uppercase().as_bytes())
     }
 }
 
 impl<'a> TryFrom<&'a str> for Method {
-    type Error = crate::Error;
+    type Error = Error;
 
     fn try_from(value: &'a str) -> Result<Self, Self::Error> {
         Self::from_str(value)

--- a/http/tests/corpus/leading-crlf.request
+++ b/http/tests/corpus/leading-crlf.request
@@ -1,0 +1,5 @@
+\r\n
+\r\n
+GET / HTTP/1.1\r\n
+Host: example.com\r\n
+\r\n

--- a/http/tests/corpus/leading-crlf.response
+++ b/http/tests/corpus/leading-crlf.response
@@ -1,0 +1,14 @@
+HTTP/1.1 200 OK\r\n
+Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
+Content-Length: 98\r\n
+Server: corpus-test\r\n
+\r\n
+===request===\n
+method: GET\n
+path: /\n
+version: HTTP/1.1\n
+\n
+===headers===\n
+Host: example.com\r\n
+\n
+===body===\n

--- a/http/tests/corpus/reject-backslash-path.request
+++ b/http/tests/corpus/reject-backslash-path.request
@@ -1,0 +1,3 @@
+GET /foo\bar HTTP/1.1\r\n
+Host: example.com\r\n
+\r\n

--- a/http/tests/corpus/reject-backslash-path.response
+++ b/http/tests/corpus/reject-backslash-path.response
@@ -1,0 +1,5 @@
+HTTP/1.1 400 Bad Request\r\n
+Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
+Connection: close\r\n
+Content-Length: 0\r\n
+\r\n

--- a/http/tests/corpus/reject-expect-unknown.request
+++ b/http/tests/corpus/reject-expect-unknown.request
@@ -1,0 +1,4 @@
+GET / HTTP/1.1\r\n
+Host: example.com\r\n
+Expect: 200-ok\r\n
+\r\n

--- a/http/tests/corpus/reject-expect-unknown.response
+++ b/http/tests/corpus/reject-expect-unknown.response
@@ -1,0 +1,5 @@
+HTTP/1.1 417 Expectation Failed\r\n
+Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
+Connection: close\r\n
+Content-Length: 0\r\n
+\r\n

--- a/http/tests/corpus/reject-fragment-target.request
+++ b/http/tests/corpus/reject-fragment-target.request
@@ -1,0 +1,3 @@
+GET /foo#bar HTTP/1.1\r\n
+Host: example.com\r\n
+\r\n

--- a/http/tests/corpus/reject-fragment-target.response
+++ b/http/tests/corpus/reject-fragment-target.response
@@ -1,0 +1,5 @@
+HTTP/1.1 400 Bad Request\r\n
+Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
+Connection: close\r\n
+Content-Length: 0\r\n
+\r\n

--- a/http/tests/corpus/reject-garbage-request-line.error
+++ b/http/tests/corpus/reject-garbage-request-line.error
@@ -1,1 +1,0 @@
-Missing method

--- a/http/tests/corpus/reject-garbage-request-line.response
+++ b/http/tests/corpus/reject-garbage-request-line.response
@@ -1,0 +1,5 @@
+HTTP/1.1 400 Bad Request\r\n
+Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
+Connection: close\r\n
+Content-Length: 0\r\n
+\r\n

--- a/http/tests/corpus/reject-missing-target.request
+++ b/http/tests/corpus/reject-missing-target.request
@@ -1,0 +1,3 @@
+GET HTTP/1.1\r\n
+Host: example.com\r\n
+\r\n

--- a/http/tests/corpus/reject-missing-target.response
+++ b/http/tests/corpus/reject-missing-target.response
@@ -1,0 +1,5 @@
+HTTP/1.1 400 Bad Request\r\n
+Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
+Connection: close\r\n
+Content-Length: 0\r\n
+\r\n

--- a/http/tests/corpus/reject-request-line-tab.request
+++ b/http/tests/corpus/reject-request-line-tab.request
@@ -1,0 +1,3 @@
+GET	/ HTTP/1.1\r\n
+Host: example.com\r\n
+\r\n

--- a/http/tests/corpus/reject-request-line-tab.response
+++ b/http/tests/corpus/reject-request-line-tab.response
@@ -1,0 +1,5 @@
+HTTP/1.1 400 Bad Request\r\n
+Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
+Connection: close\r\n
+Content-Length: 0\r\n
+\r\n

--- a/http/tests/corpus/trailer-prohibited-auth.request
+++ b/http/tests/corpus/trailer-prohibited-auth.request
@@ -1,0 +1,9 @@
+POST / HTTP/1.1\r\n
+Host: example.com\r\n
+Transfer-Encoding: chunked\r\n
+\r\n
+5\r\n
+hello\r\n
+0\r\n
+Authorization: Bearer evil\r\n
+\r\n

--- a/http/tests/corpus/trailer-prohibited-auth.response
+++ b/http/tests/corpus/trailer-prohibited-auth.response
@@ -1,0 +1,19 @@
+HTTP/1.1 200 OK\r\n
+Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
+Content-Length: 177\r\n
+Server: corpus-test\r\n
+\r\n
+===request===\n
+method: POST\n
+path: /\n
+version: HTTP/1.1\n
+\n
+===headers===\n
+Host: example.com\r\n
+Transfer-Encoding: chunked\r\n
+\n
+===body===\n
+hello\n
+===trailers===\n
+Authorization: Bearer evil\r\n
+\n

--- a/http/tests/corpus/trailer-prohibited-cl.request
+++ b/http/tests/corpus/trailer-prohibited-cl.request
@@ -1,0 +1,9 @@
+POST / HTTP/1.1\r\n
+Host: example.com\r\n
+Transfer-Encoding: chunked\r\n
+\r\n
+5\r\n
+hello\r\n
+0\r\n
+Content-Length: 50\r\n
+\r\n

--- a/http/tests/corpus/trailer-prohibited-cl.response
+++ b/http/tests/corpus/trailer-prohibited-cl.response
@@ -1,0 +1,19 @@
+HTTP/1.1 200 OK\r\n
+Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
+Content-Length: 169\r\n
+Server: corpus-test\r\n
+\r\n
+===request===\n
+method: POST\n
+path: /\n
+version: HTTP/1.1\n
+\n
+===headers===\n
+Host: example.com\r\n
+Transfer-Encoding: chunked\r\n
+\n
+===body===\n
+hello\n
+===trailers===\n
+Content-Length: 50\r\n
+\n

--- a/http/tests/corpus/trailer-prohibited-host.request
+++ b/http/tests/corpus/trailer-prohibited-host.request
@@ -1,0 +1,9 @@
+POST / HTTP/1.1\r\n
+Host: example.com\r\n
+Transfer-Encoding: chunked\r\n
+\r\n
+5\r\n
+hello\r\n
+0\r\n
+Host: evil.example.com\r\n
+\r\n

--- a/http/tests/corpus/trailer-prohibited-host.response
+++ b/http/tests/corpus/trailer-prohibited-host.response
@@ -1,0 +1,19 @@
+HTTP/1.1 200 OK\r\n
+Date: Tue, 21 Nov 2023 21:27:21 GMT\r\n
+Content-Length: 173\r\n
+Server: corpus-test\r\n
+\r\n
+===request===\n
+method: POST\n
+path: /\n
+version: HTTP/1.1\n
+\n
+===headers===\n
+Host: example.com\r\n
+Transfer-Encoding: chunked\r\n
+\n
+===body===\n
+hello\n
+===trailers===\n
+Host: evil.example.com\r\n
+\n

--- a/router/CHANGELOG.md
+++ b/router/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2026-06-10
+
+### Changed
+
+- The default OPTIONS response now uses `204 No Content` instead of `200 Ok`.
+
 ## [0.5.1] - 2026-06-01
 
 ### Added

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-router"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 description = "router for trillium.rs"
 license = "MIT OR Apache-2.0"

--- a/router/src/router.rs
+++ b/router/src/router.rs
@@ -539,7 +539,7 @@ impl Handler for Router {
                 .join(", ");
 
             conn.with_response_header(KnownHeaderName::Allow, allow)
-                .with_status(200)
+                .with_status(204)
                 .halt()
         } else if let Some(allow) = self
             .handle_method_not_allowed

--- a/router/tests/options.rs
+++ b/router/tests/options.rs
@@ -13,7 +13,7 @@ async fn options_star_with_a_star_handler() {
 
     app.build(Method::Options, "*")
         .await
-        .assert_status(200)
+        .assert_status(204)
         .assert_header("allow", "GET, POST");
 }
 
@@ -29,17 +29,17 @@ async fn options_specific_route_with_several_matching_methods() {
 
     app.build(Method::Options, "/some/specific/route")
         .await
-        .assert_status(200)
+        .assert_status(204)
         .assert_header("allow", "DELETE, GET, POST");
 
     app.build(Method::Options, "/some/specific/other")
         .await
-        .assert_status(200)
+        .assert_status(204)
         .assert_header("allow", "DELETE, GET");
 
     app.build(Method::Options, "/only-get")
         .await
-        .assert_status(200)
+        .assert_status(204)
         .assert_header("allow", "GET");
 }
 
@@ -54,7 +54,7 @@ async fn options_specific_route_with_no_matching_routes() {
 
     app.build(Method::Options, "/other")
         .await
-        .assert_status(200)
+        .assert_status(204)
         .assert_header("allow", "");
 }
 
@@ -65,7 +65,7 @@ async fn options_any() {
 
     app.build(Method::Options, "*")
         .await
-        .assert_status(200)
+        .assert_status(204)
         .assert_header("allow", "DELETE, GET, PATCH");
 }
 
@@ -86,11 +86,11 @@ async fn nested_router() {
 
     app.build(Method::Options, "/nested/here")
         .await
-        .assert_status(200)
+        .assert_status(204)
         .assert_header("allow", "GET, POST");
 
     app.build(Method::Options, "*")
         .await
-        .assert_status(200)
+        .assert_status(204)
         .assert_header("allow", "DELETE, GET, PATCH, POST, PUT");
 }

--- a/websockets/CHANGELOG.md
+++ b/websockets/CHANGELOG.md
@@ -4,10 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-06-10
+
+### Fixed
+- A WebSocket handshake carrying a `Sec-WebSocket-Version` other than `13` is now rejected with `426
+  Upgrade Required`
+- A WebSocket handshake is now only recognized for `GET` requests over HTTP/1.1.
+- A WebSocket handshake over HTTP/1.0 is not accepted.
+
 ## [0.8.0] - 2026-05-05
 
 ### Added
-- WebSockets over HTTP/2 (RFC 8441) — handled transparently when the request arrives via h2 with extended CONNECT. `WebSocketHandler::init` checks that the peer advertised `SETTINGS_ENABLE_CONNECT_PROTOCOL` and turns the handler into a no-op for that connection if not.
+- WebSockets over HTTP/2 (RFC 8441) — handled transparently when the request arrives via h2 with
+  extended CONNECT. `WebSocketHandler::init` checks that the peer advertised
+  `SETTINGS_ENABLE_CONNECT_PROTOCOL` and turns the handler into a no-op for that connection if not.
 
 ## [0.7.0] - 2026-05-02
 

--- a/websockets/Cargo.toml
+++ b/websockets/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "trillium-websockets"
-version = "0.8.0"
-authors = ["Jacob Rothstein <hi@jbr.me>"]
+version = "0.8.1"
 edition = "2024"
 description = "websocket support for trillium.rs"
 license = "MIT OR Apache-2.0"
@@ -12,6 +11,9 @@ categories = ["web-programming::http-server", "web-programming"]
 
 [package.metadata.docs.rs]
 features = ["json"]
+
+[package.metadata.cargo-udeps.ignore]
+development = ["trillium-testing"]
 
 [features]
 default = []
@@ -44,5 +46,3 @@ trillium-websockets = { features = ["json"], path = "." }
 trillium-logger = { path = "../logger" }
 env_logger = "0.11.10"
 
-[package.metadata.cargo-udeps.ignore]
-development = ["trillium-testing"]

--- a/websockets/src/lib.rs
+++ b/websockets/src/lib.rs
@@ -157,6 +157,10 @@ where
             }
         }
 
+        if !supported_websocket_version(&conn) {
+            return reject_unsupported_version(conn);
+        }
+
         let websocket_peer_ip = WebsocketPeerIp(conn.peer_ip());
 
         let Some(sec_websocket_key) = conn.request_headers().get_str(SecWebsocketKey) else {
@@ -246,6 +250,10 @@ where
             // bidirectional byte channel carrying WebSocket frames.
             Version::Http2 | Version::Http3 => {
                 if extended_connect_websocket_request(&conn) {
+                    if !supported_websocket_version(&conn) {
+                        return reject_unsupported_version(conn);
+                    }
+
                     let websocket_peer_ip = WebsocketPeerIp(conn.peer_ip());
                     let protocol = websocket_protocol(&conn, &self.protocols);
 
@@ -358,8 +366,21 @@ fn upgrade_to_websocket(conn: &Conn) -> bool {
         .eq_ignore_ascii_case(UpgradeHeader, "websocket")
 }
 
+fn supported_websocket_version(conn: &Conn) -> bool {
+    conn.request_headers().get_str(SecWebsocketVersion) == Some("13")
+}
+
+fn reject_unsupported_version(conn: Conn) -> Conn {
+    conn.with_status(Status::UpgradeRequired)
+        .with_response_header(SecWebsocketVersion, "13")
+        .halt()
+}
+
 fn upgrade_requested(conn: &Conn) -> bool {
-    connection_is_upgrade(conn) && upgrade_to_websocket(conn)
+    conn.method() == Method::Get
+        && conn.http_version() == Version::Http1_1
+        && connection_is_upgrade(conn)
+        && upgrade_to_websocket(conn)
 }
 
 /// Detect a WebSocket bootstrap over extended CONNECT (RFC 8441 for h2, RFC 9220 for h3).

--- a/websockets/src/tests.rs
+++ b/websockets/src/tests.rs
@@ -1,6 +1,54 @@
-use super::connection_is_upgrade;
-use trillium::Conn;
+use super::{connection_is_upgrade, websocket};
+use crate::WebSocketConn;
+use trillium::{Conn, Status};
 use trillium_testing::{TestServer, harness, test};
+
+const SAMPLE_KEY: &str = "dGhlIHNhbXBsZSBub25jZQ==";
+
+#[test(harness)]
+async fn rejects_unsupported_version() {
+    let app = TestServer::new(websocket(|_: WebSocketConn| async {})).await;
+
+    // RFC 6455 §4.4: an unsupported version aborts the handshake with 426 and advertises 13,
+    // rather than switching protocols.
+    app.get("/")
+        .with_request_header("connection", "Upgrade")
+        .with_request_header("upgrade", "websocket")
+        .with_request_header("sec-websocket-key", SAMPLE_KEY)
+        .with_request_header("sec-websocket-version", "99")
+        .await
+        .assert_status(Status::UpgradeRequired)
+        .assert_header("sec-websocket-version", "13");
+
+    // A missing version is likewise not version 13.
+    app.get("/")
+        .with_request_header("connection", "Upgrade")
+        .with_request_header("upgrade", "websocket")
+        .with_request_header("sec-websocket-key", SAMPLE_KEY)
+        .await
+        .assert_status(Status::UpgradeRequired);
+
+    // Version 13 negotiates normally.
+    app.get("/")
+        .with_request_header("connection", "Upgrade")
+        .with_request_header("upgrade", "websocket")
+        .with_request_header("sec-websocket-key", SAMPLE_KEY)
+        .with_request_header("sec-websocket-version", "13")
+        .await
+        .assert_status(Status::SwitchingProtocols);
+}
+
+#[test(harness)]
+async fn ignores_non_get_handshake() {
+    let app = TestServer::new(websocket(|_: WebSocketConn| async {})).await;
+    app.post("/")
+        .with_request_header("connection", "Upgrade")
+        .with_request_header("upgrade", "websocket")
+        .with_request_header("sec-websocket-key", SAMPLE_KEY)
+        .with_request_header("sec-websocket-version", "13")
+        .await
+        .assert_status(Status::NotFound);
+}
 
 #[test(harness)]
 async fn test_connection_is_upgrade() {


### PR DESCRIPTION
# trillium-http
- An HTTP/1.x request-line that can't be parsed returns a `400 Bad Request` instead of closing the
  connection.
- An HTTP/1.x request-target containing `#` or `\` is now rejected with `400 Bad Request`.
- Leading empty lines before a HTTP/1.x request-line are now ignored.
- An HTTP/1.x request carrying an `Expect` field-value other than `100-continue` is now answered
  with `417 Expectation Failed` rather than silently ignored.

# trillium-router
- The default OPTIONS response now uses `204 No Content` instead of `200 Ok`.

# trillium-websockets
- A WebSocket handshake carrying a `Sec-WebSocket-Version` other than `13` is now rejected with `426
  Upgrade Required`
- A WebSocket handshake is now only recognized for `GET` requests over HTTP/1.1.
- A WebSocket handshake over HTTP/1.0 is not accepted.