### PR TITLE
fix(http): allow close-terminated 1.1 responses without TE:C or CL

### DIFF
--- a/client/src/conn/h1.rs
+++ b/client/src/conn/h1.rs
@@ -355,21 +355,14 @@ impl Conn {
         // another/unknown coding, or an empty value — is rejected rather than decoded-once
         // or read-to-close: those framing fallbacks are response-smuggling vectors. Matches
         // the server's request-side rule so both halves of a proxy frame identically.
-        let transfer_encoding = self.response_headers.get_values(TransferEncoding);
-        let chunked = match transfer_encoding {
-            None => false,
-            Some(values) => {
-                let mut codings = values
-                    .iter()
-                    .filter_map(|v| v.as_str())
-                    .flat_map(|s| s.split(','))
-                    .map(str::trim)
-                    .filter(|s| !s.is_empty());
-                match (codings.next(), codings.next()) {
-                    (Some(only), None) if only.eq_ignore_ascii_case("chunked") => true,
-                    _ => return Err(Error::UnexpectedHeader(TransferEncoding.into())),
-                }
+        let chunked = if self.response_headers.has_header(TransferEncoding) {
+            let mut codings = self.response_headers.token_iter(TransferEncoding);
+            match (codings.next(), codings.next()) {
+                (Some(only), None) if only.eq_ignore_ascii_case("chunked") => true,
+                _ => return Err(Error::UnexpectedHeader(TransferEncoding.into())),
             }
+        } else {
+            false
         };
 
         let content_length = self.response_headers.get_values(ContentLength);
@@ -402,17 +395,10 @@ impl Conn {
             return false;
         }
 
-        // Scan every Connection field line and every comma-token within it. `get_str` would miss a
-        // `Connection: close` split across multiple header lines (it returns `None` for more than
-        // one value), which would pool a connection the peer asked to close.
         let has_token = |headers: &Headers, token: &str| {
-            headers.get_values(Connection).is_some_and(|values| {
-                values
-                    .iter()
-                    .filter_map(|v| v.as_str())
-                    .flat_map(|v| v.split(','))
-                    .any(|t| t.trim().eq_ignore_ascii_case(token))
-            })
+            headers
+                .token_iter(Connection)
+                .any(|t| t.eq_ignore_ascii_case(token))
         };
 
         if has_token(&self.request_headers, "close") || has_token(&self.response_headers, "close") {

--- a/http/CHANGELOG.md
+++ b/http/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `Headers::token_iter(name)` iterates the comma-separated tokens of a list-typed header
+  (`Connection`, `Transfer-Encoding`, `Accept-Encoding`, and the like), flattened across every
+  field line, trimmed, with empty elements skipped.
+
+### Changed
+
+- An HTTP/1.1 response that sets `Connection: close` on a streaming body of unknown length is now
+  sent close-delimited — carrying neither `Content-Length` nor `Transfer-Encoding`, with the body
+  running until the connection closes — rather than with chunked transfer-encoding. Responses that
+  don't set `Connection: close` are unaffected and still use chunked encoding.
+
 ## [1.3.8]
 
 The theme of this release is [RFC 9218 priority](https://datatracker.ietf.org/doc/rfc9218/) support.

--- a/http/src/body.rs
+++ b/http/src/body.rs
@@ -143,16 +143,19 @@ impl Body {
         }
     }
 
-    pub(crate) fn ensure_chunked_framing(&mut self) -> &mut Self {
+    /// Set whether this body's [`AsyncRead`] impl emits chunked framing for the
+    /// `len: None` case. The h1 send path drives this from the finalized response
+    /// headers: `chunked` when `Transfer-Encoding: chunked` is present, raw passthrough
+    /// (close-delimited) when neither it nor `Content-Length` is. Has no effect on
+    /// fixed-length or static bodies, which never chunk.
+    pub(crate) fn set_chunked_framing(&mut self, on: bool) {
         if let Streaming {
             ref mut chunked_framing,
             ..
         } = self.0
         {
-            *chunked_framing = true;
+            *chunked_framing = on;
         }
-
-        self
     }
 
     /// Returns trailers from the body source, if any.

--- a/http/src/conn/h1.rs
+++ b/http/src/conn/h1.rs
@@ -62,8 +62,18 @@ where
             };
 
             if self.version == Version::Http1_1 && !has_content_length {
-                self.response_headers
-                    .insert(KnownHeaderName::TransferEncoding, "chunked");
+                // Close-delimited framing (RFC 9112 §6.3): `Connection: close` on an
+                // unknown-length response opts out of chunked transfer-encoding — the body
+                // runs until the connection closes, carrying neither `Content-Length` nor
+                // `Transfer-Encoding`. Upgrades own their framing separately (chunked
+                // keep-open prelude).
+                if !self.upgrade && self.response_requests_close() {
+                    self.response_headers
+                        .remove(KnownHeaderName::TransferEncoding);
+                } else {
+                    self.response_headers
+                        .insert(KnownHeaderName::TransferEncoding, "chunked");
+                }
             } else {
                 self.response_headers
                     .remove(KnownHeaderName::TransferEncoding);
@@ -90,9 +100,14 @@ where
             && !matches!(self.status, Some(Status::NotModified | Status::NoContent))
             && let Some(mut body) = self.response_body.take()
         {
-            let chunked = body.len().is_none();
+            // Framing follows the finalized response headers: chunked when
+            // `Transfer-Encoding: chunked` is present, raw passthrough (close-delimited,
+            // run to connection close) when neither it nor `Content-Length` is.
+            let chunked = self
+                .response_headers
+                .has_header(KnownHeaderName::TransferEncoding);
 
-            body.ensure_chunked_framing();
+            body.set_chunked_framing(chunked);
             if upgrading {
                 // Leave the chunked stream unterminated for the following upgrade to close.
                 body.set_keep_open();
@@ -102,10 +117,11 @@ where
 
             bufwriter.copy_from(&mut body, loops_per_yield).await?;
 
-            // When an upgrade follows, the upgrade owns the terminator; the body's trailers
-            // (if any) ride onto the `Upgrade` and merge with whatever the upgrade handler
-            // emits. Skip the terminator stitch here.
-            if !upgrading {
+            // The trailer-section and its terminator only exist in chunked framing. When an
+            // upgrade follows, the upgrade owns the terminator and the body's trailers (if
+            // any) ride onto the `Upgrade`. A close-delimited body has no trailer-section —
+            // the connection close is the terminator — so trailers are dropped.
+            if !upgrading && chunked {
                 // Chunked-trailer-section stitch. `Body::poll_read` emitted the last-chunk
                 // marker `0\r\n` at EOF and stopped there; we own the rest of the framing
                 // because trailers are structured `Headers` (not bytes) and the terminating
@@ -117,9 +133,7 @@ where
                     // we don't store the trailers anywhere because the conn is about to be dropped
                 }
 
-                if chunked {
-                    write!(bufwriter.buffer_mut(), "\r\n")?;
-                }
+                write!(bufwriter.buffer_mut(), "\r\n")?;
             }
         }
 
@@ -428,21 +442,19 @@ where
         }
     }
 
+    /// True if the outbound headers carry a `Connection: close` token.
+    fn response_requests_close(&self) -> bool {
+        self.response_headers
+            .token_iter(KnownHeaderName::Connection)
+            .any(|t| t.eq_ignore_ascii_case("close"))
+    }
+
     fn should_close(&self) -> bool {
-        // Scan every Connection field line and every comma-token within it. `get_str` would miss a
-        // `Connection: close` split across multiple header lines (it returns `None` for more than
-        // one value), keeping alive a connection the peer asked to close. Mirrors the client's
-        // `is_keep_alive`.
+        // Mirrors the client's `is_keep_alive`.
         let has_token = |headers: &Headers, token: &str| {
             headers
-                .get_values(KnownHeaderName::Connection)
-                .is_some_and(|values| {
-                    values
-                        .iter()
-                        .filter_map(|v| v.as_str())
-                        .flat_map(|v| v.split(','))
-                        .any(|t| t.trim().eq_ignore_ascii_case(token))
-                })
+                .token_iter(KnownHeaderName::Connection)
+                .any(|t| t.eq_ignore_ascii_case(token))
         };
 
         if has_token(&self.request_headers, "close") || has_token(&self.response_headers, "close") {

--- a/http/src/headers.rs
+++ b/http/src/headers.rs
@@ -349,6 +349,30 @@ impl Headers {
             .is_some_and(|v| v.eq_ignore_ascii_case(needle))
     }
 
+    /// Iterate the comma-separated tokens of a header — the [HTTP list
+    /// syntax](https://www.rfc-editor.org/rfc/rfc9110#section-5.6.1) used by `Connection`,
+    /// `Transfer-Encoding`, `Accept-Encoding`, and similar fields.
+    ///
+    /// Tokens are flattened across every field line for `name` (a list value may be split
+    /// across multiple header lines or combined on one), trimmed of surrounding whitespace,
+    /// with empty elements skipped. Returns an empty iterator when the header is absent.
+    ///
+    /// Comparison is left to the caller. Most list fields are case-insensitive —
+    /// `headers.token_iter(KnownHeaderName::Connection).any(|t| t.eq_ignore_ascii_case("close"))`
+    /// — but a few, like `Sec-WebSocket-Protocol`, are case-sensitive.
+    pub fn token_iter<'a>(
+        &'a self,
+        name: impl Into<HeaderName<'a>>,
+    ) -> impl Iterator<Item = &'a str> {
+        self.get_values(name)
+            .into_iter()
+            .flatten()
+            .filter_map(|value| value.as_str())
+            .flat_map(|value| value.split(','))
+            .map(str::trim)
+            .filter(|token| !token.is_empty())
+    }
+
     /// Chainable method to insert a header
     pub fn with_inserted_header(
         mut self,

--- a/http/src/upgrade.rs
+++ b/http/src/upgrade.rs
@@ -67,11 +67,8 @@ fn compute_write_state(version: Version, outbound_headers: &Headers) -> WriteSta
 /// `gzip, chunked`; no ordering enforcement.
 fn has_chunked_encoding(headers: &Headers) -> bool {
     headers
-        .get_str(KnownHeaderName::TransferEncoding)
-        .is_some_and(|v| {
-            v.split(',')
-                .any(|coding| coding.trim().eq_ignore_ascii_case("chunked"))
-        })
+        .token_iter(KnownHeaderName::TransferEncoding)
+        .any(|coding| coding.eq_ignore_ascii_case("chunked"))
 }
 
 /// Parse the inbound `Content-Length`. `None` for chunked, missing, or malformed.

--- a/http/tests/close_delimited.rs
+++ b/http/tests/close_delimited.rs
@@ -1,0 +1,80 @@
+//! Close-delimited response framing (RFC 9112 §6.3): a `Connection: close` response with
+//! an unknown-length streaming body carries neither `Content-Length` nor
+//! `Transfer-Encoding`, and its body bytes go out raw rather than chunk-framed.
+use futures_lite::io::Cursor;
+use std::{net::Shutdown, sync::Arc};
+use test_harness::test;
+use trillium_http::{Body, Conn, HttpContext, KnownHeaderName};
+use trillium_testing::{RuntimeTrait, TestTransport, harness};
+
+fn streaming(content: &'static str) -> Body {
+    Body::new_streaming(Cursor::new(content.as_bytes().to_vec()), None)
+}
+
+async fn drive(
+    handler: impl Fn(Conn<TestTransport>) -> Conn<TestTransport> + Send + Sync + 'static,
+) -> String {
+    let runtime = trillium_testing::runtime();
+    let (client, server) = TestTransport::new();
+    let context = Arc::new(HttpContext::new());
+    let res = runtime.spawn(async move {
+        context
+            .run(server, |conn| {
+                let conn = handler(conn);
+                async move { conn }
+            })
+            .await
+    });
+
+    client.write_all("GET / HTTP/1.1\r\nHost: _\r\n\r\n");
+    client.shutdown(Shutdown::Write);
+    res.await.unwrap().unwrap();
+    client.read_available_string().await
+}
+
+#[test(harness)]
+async fn connection_close_streaming_body_is_close_delimited() {
+    let response = drive(|mut conn| {
+        conn.set_status(200);
+        conn.response_headers_mut()
+            .insert(KnownHeaderName::Connection, "close");
+        conn.set_response_body(streaming("hello"));
+        conn
+    })
+    .await;
+
+    let lower = response.to_ascii_lowercase();
+    assert!(
+        !lower.contains("transfer-encoding"),
+        "close-delimited response must not chunk:\n{response:?}"
+    );
+    assert!(
+        !lower.contains("content-length"),
+        "close-delimited response must not have a content-length:\n{response:?}"
+    );
+    // Body bytes appear verbatim, with no hex chunk prefix or trailer terminator.
+    assert!(
+        response.ends_with("\r\n\r\nhello"),
+        "body should be raw, not chunk-framed:\n{response:?}"
+    );
+}
+
+#[test(harness)]
+async fn streaming_body_without_close_still_chunks() {
+    let response = drive(|mut conn| {
+        conn.set_status(200);
+        conn.set_response_body(streaming("hello"));
+        conn
+    })
+    .await;
+
+    let lower = response.to_ascii_lowercase();
+    assert!(
+        lower.contains("transfer-encoding: chunked"),
+        "unknown-length keep-alive response should chunk:\n{response:?}"
+    );
+    assert!(
+        response.ends_with("\r\n\r\n5\r\nhello\r\n0\r\n\r\n"),
+        "body should be chunk-framed:\n{response:?}"
+    );
+}

--- a/http/tests/headers.rs
+++ b/http/tests/headers.rs
@@ -435,3 +435,33 @@ fn content_length_accepts_only_a_single_run_of_digits() {
     multi.append(ContentLength, "5");
     assert_eq!(multi.content_length(), None);
 }
+
+#[test]
+fn token_iter() {
+    use KnownHeaderName::Connection;
+
+    let collect = |headers: &Headers| -> Vec<String> {
+        headers.token_iter(Connection).map(str::to_owned).collect()
+    };
+
+    // Absent header yields nothing.
+    assert_eq!(collect(&Headers::new()), Vec::<String>::new());
+
+    // Comma-separated tokens on a single line are split and trimmed.
+    let mut single = Headers::new();
+    single.insert(Connection, "keep-alive,  Upgrade ");
+    assert_eq!(collect(&single), ["keep-alive", "Upgrade"]);
+
+    // Tokens are flattened across multiple field lines for the same name — the case `get_str`
+    // (which returns `None` for more than one value) misses.
+    let mut multi = Headers::new();
+    multi.append(Connection, "keep-alive");
+    multi.append(Connection, "Upgrade, close");
+    assert_eq!(multi.get_str(Connection), None);
+    assert_eq!(collect(&multi), ["keep-alive", "Upgrade", "close"]);
+
+    // Empty elements are skipped (RFC 9110 §5.6.1).
+    let mut empties = Headers::new();
+    empties.insert(Connection, " , close , ,");
+    assert_eq!(collect(&empties), ["close"]);
+}

--- a/proxy/CHANGELOG.md
+++ b/proxy/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Hop-by-hop headers named in a `Connection` header that is split across multiple request header
+  lines are now stripped before forwarding upstream; previously a multi-line `Connection` header was
+  ignored and the headers it named leaked through.
+
 ## [0.8.0] - 2026-05-15
 
 ### Changed

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -226,10 +226,8 @@ impl<U: UpstreamSelector> Handler for Proxy<U> {
         let mut connection_is_upgrade = false;
         for header in conn
             .request_headers()
-            .get_str(KnownHeaderName::Connection)
-            .unwrap_or_default()
-            .split(',')
-            .map(|h| HeaderName::from(h.trim()))
+            .token_iter(KnownHeaderName::Connection)
+            .map(HeaderName::from)
         {
             if header == KnownHeaderName::Upgrade {
                 connection_is_upgrade = true;

--- a/sse/CHANGELOG.md
+++ b/sse/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Event streams are sent with close-delimited framing (`Connection: close`) rather than chunked
+  transfer-encoding. The server-sent-events specification cautions that chunking can interfere with
+  event delivery timing.
+
 ## [0.2.0] - 2026-05-02
 
 ### Changed

--- a/sse/Cargo.toml
+++ b/sse/Cargo.toml
@@ -19,5 +19,6 @@ broadcaster = "1.0.0"
 trillium-logger = { path = "../logger" }
 trillium-smol = { path = "../smol" }
 trillium-static-compiled = { path = "../static-compiled" }
+trillium-testing = { path = "../testing" }
 
 [features]

--- a/sse/src/lib.rs
+++ b/sse/src/lib.rs
@@ -185,6 +185,10 @@ impl SseConnExt for Conn {
         let body = SseBody::new(self.swansong().interrupt(sse_stream));
         self.with_response_header(KnownHeaderName::ContentType, "text/event-stream")
             .with_response_header(KnownHeaderName::CacheControl, "no-cache")
+            // Close-delimited framing: the event stream carries neither `Content-Length`
+            // nor `Transfer-Encoding`, running until the connection closes. Chunked
+            // transfer-encoding can disrupt event delivery timing for this protocol.
+            .with_response_header(KnownHeaderName::Connection, "close")
             .with_body(body)
             .with_status(Status::Ok)
             .halt()

--- a/sse/tests/sse.rs
+++ b/sse/tests/sse.rs
@@ -1,0 +1,25 @@
+use futures_lite::stream;
+use trillium::Conn;
+use trillium_sse::{Event, SseConnExt};
+use trillium_testing::{TestServer, harness, test};
+
+#[test(harness)]
+async fn sse_stream_is_close_delimited_and_well_formed() {
+    let app = TestServer::new(|conn: Conn| async move {
+        conn.with_sse_stream(stream::iter([
+            Event::new("hello"),
+            Event::new("world").with_type("greeting"),
+        ]))
+    })
+    .await;
+
+    app.get("/")
+        .await
+        .assert_ok()
+        .assert_header("content-type", "text/event-stream")
+        .assert_header("cache-control", "no-cache")
+        .assert_header("connection", "close")
+        // No chunked transfer-encoding leaks into the event stream.
+        .assert_no_header("transfer-encoding")
+        .assert_body("data: hello\n\nevent: greeting\ndata: world\n\n");
+}

--- a/websockets/CHANGELOG.md
+++ b/websockets/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- A WebSocket handshake whose `Connection` header is split across multiple header lines (for example
+  `Connection: keep-alive` and `Connection: Upgrade` on separate lines) is now recognized;
+  previously the `Upgrade` token was missed and the handshake was not performed.
+
 ## [0.8.1] - 2026-06-10
 
 ### Fixed

--- a/websockets/src/lib.rs
+++ b/websockets/src/lib.rs
@@ -340,25 +340,15 @@ where
 
 fn websocket_protocol(conn: &Conn, protocols: &[String]) -> Option<String> {
     conn.request_headers()
-        .get_str(SecWebsocketProtocol)
-        .and_then(|value| {
-            value
-                .split(',')
-                .map(str::trim)
-                .find(|req_p| protocols.iter().any(|x| x == req_p))
-                .map(|s| s.to_owned())
-        })
+        .token_iter(SecWebsocketProtocol)
+        .find(|req_p| protocols.iter().any(|x| x == req_p))
+        .map(str::to_owned)
 }
 
 fn connection_is_upgrade(conn: &Conn) -> bool {
     conn.request_headers()
-        .get_str(Connection)
-        .map(|connection| {
-            connection
-                .split(',')
-                .any(|c| c.trim().eq_ignore_ascii_case("upgrade"))
-        })
-        .unwrap_or(false)
+        .token_iter(Connection)
+        .any(|c| c.eq_ignore_ascii_case("upgrade"))
 }
 
 fn upgrade_to_websocket(conn: &Conn) -> bool {

--- a/websockets/src/tests.rs
+++ b/websockets/src/tests.rs
@@ -93,4 +93,12 @@ async fn test_connection_is_upgrade() {
         .await
         .assert_ok()
         .assert_body("no-upgrade");
+
+    // A `Connection` value split across multiple header lines coalesces into one token list
+    // (RFC 9110 §5.6.1), so the `Upgrade` token is found even on a separate line from `keep-alive`.
+    app.get("/")
+        .with_request_header("connection", ["keep-alive", "Upgrade"])
+        .await
+        .assert_ok()
+        .assert_body("upgrade");
 }


### PR DESCRIPTION
closes #583