### PR TITLE
Fix WebSocketConn missing querystring

### DIFF
--- a/websockets/src/websocket_connection.rs
+++ b/websockets/src/websocket_connection.rs
@@ -28,6 +28,7 @@ use trillium_http::{HttpContext, type_set::entry::Entry};
 pub struct WebSocketConn {
     request_headers: Headers,
     path: Cow<'static, str>,
+    querystring: Cow<'static, str>,
     method: Method,
     state: TypeSet,
     peer_ip: Option<IpAddr>,
@@ -109,6 +110,7 @@ impl WebSocketConn {
         let mut upgrade = upgrade.into();
         let request_headers = upgrade.take_request_headers();
         let path = upgrade.path().to_string().into();
+        let path = upgrade.querystring().to_string().into();
         let method = upgrade.method();
         let state = upgrade.take_state();
         let context = upgrade.context().clone();
@@ -129,6 +131,7 @@ impl WebSocketConn {
         Self {
             request_headers,
             path,
+            querystring,
             method,
             state,
             peer_ip,
@@ -167,16 +170,13 @@ impl WebSocketConn {
     /// retrieves the path part of the request url, up to and excluding
     /// any query component
     pub fn path(&self) -> &str {
-        self.path.split('?').next().unwrap_or_default()
+        &self.path
     }
 
     /// Retrieves the query component of the path, excluding `?`. Returns
     /// an empty string if there is no query component.
     pub fn querystring(&self) -> &str {
-        self.path
-            .split_once('?')
-            .map(|(_, query)| query)
-            .unwrap_or_default()
+        &self.querystring
     }
 
     /// retrieve the request method for this conn


### PR DESCRIPTION
Previously, Upgrade did not split off the query string from the path.

This was changed, and the result was that the query string for WebSocketConn was lost since the implementation made the assumption that the path obtained from Upgrade would include the query string.

This is fixed by adding a `querystring` field to WebSocketConn which is obtained from the Upgrade's query string. With this change, the query string is now preserved and no longer erroneously empty.